### PR TITLE
Enhance configuration and versioning support with new init command

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: check-case-conflict
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.8
+    rev: v0.15.9
     hooks:
       - id: ruff
         args: [--fix]

--- a/.serena/.gitignore
+++ b/.serena/.gitignore
@@ -1,0 +1,2 @@
+/cache
+/project.local.yml

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -67,7 +67,7 @@ read_only: false
 # This extends the existing exclusions (e.g. from the global configuration)
 #
 # Below is the complete list of tools for convenience.
-# To make sure you have the latest list of tools, and to view their descriptions, 
+# To make sure you have the latest list of tools, and to view their descriptions,
 # execute `uv run scripts/print_tool_overview.py`.
 #
 #  * `activate_project`: Activates a project by name.

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,0 +1,152 @@
+# the name by which the project can be referenced within Serena
+project_name: "repo-release-tools"
+
+
+# list of languages for which language servers are started; choose from:
+#   al                  bash                clojure             cpp                 csharp
+#   csharp_omnisharp    dart                elixir              elm                 erlang
+#   fortran             fsharp              go                  groovy              haskell
+#   java                julia               kotlin              lua                 markdown
+#   matlab              nix                 pascal              perl                php
+#   php_phpactor        powershell          python              python_jedi         r
+#   rego                ruby                ruby_solargraph     rust                scala
+#   swift               terraform           toml                typescript          typescript_vts
+#   vue                 yaml                zig
+#   (This list may be outdated. For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
+#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+# Note:
+#   - For C, use cpp
+#   - For JavaScript, use typescript
+#   - For Free Pascal/Lazarus, use pascal
+# Special requirements:
+#   Some languages require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
+# When using multiple languages, the first language server that supports a given file will be used for that file.
+# The first language is the default language and the respective language server will be used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
+languages:
+- python
+
+# the encoding used by text files in the project
+# For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
+encoding: "utf-8"
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# whether to use project's .gitignore files to ignore files
+ignore_all_files_in_gitignore: true
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}
+
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Note: global ignored_paths from serena_config.yml are also applied additively.
+ignored_paths: []
+
+# whether the project is in read-only mode
+# If set to true, all editing tools will be disabled and attempts to use them will result in an error
+# Added on 2025-04-18
+read_only: false
+
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+#
+# Below is the complete list of tools for convenience.
+# To make sure you have the latest list of tools, and to view their descriptions, 
+# execute `uv run scripts/print_tool_overview.py`.
+#
+#  * `activate_project`: Activates a project by name.
+#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
+#  * `create_text_file`: Creates/overwrites a file in the project directory.
+#  * `delete_lines`: Deletes a range of lines within a file.
+#  * `delete_memory`: Deletes a memory from Serena's project-specific memory store.
+#  * `execute_shell_command`: Executes a shell command.
+#  * `find_referencing_code_snippets`: Finds code snippets in which the symbol at the given location is referenced.
+#  * `find_referencing_symbols`: Finds symbols that reference the symbol at the given location (optionally filtered by type).
+#  * `find_symbol`: Performs a global (or local) search for symbols with/containing a given name/substring (optionally filtered by type).
+#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
+#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
+#  * `initial_instructions`: Gets the initial instructions for the current project.
+#     Should only be used in settings where the system prompt cannot be set,
+#     e.g. in clients you have no control over, like Claude Desktop.
+#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
+#  * `insert_at_line`: Inserts content at a given line in a file.
+#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
+#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
+#  * `list_memories`: Lists memories in Serena's project-specific memory store.
+#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
+#  * `prepare_for_new_conversation`: Provides instructions for preparing for a new conversation (in order to continue with the necessary context).
+#  * `read_file`: Reads a file within the project directory.
+#  * `read_memory`: Reads the memory with the given name from Serena's project-specific memory store.
+#  * `remove_project`: Removes a project from the Serena configuration.
+#  * `replace_lines`: Replaces a range of lines within a file with new content.
+#  * `replace_symbol_body`: Replaces the full definition of a symbol.
+#  * `restart_language_server`: Restarts the language server, may be necessary when edits not through Serena happen.
+#  * `search_for_pattern`: Performs a search for a pattern in the project.
+#  * `summarize_changes`: Provides instructions for summarizing the changes made to the codebase.
+#  * `switch_modes`: Activates modes by providing a list of their names
+#  * `think_about_collected_information`: Thinking tool for pondering the completeness of collected information.
+#  * `think_about_task_adherence`: Thinking tool for determining whether the agent is still on track with the current task.
+#  * `think_about_whether_you_are_done`: Thinking tool for determining whether the task is truly completed.
+#  * `write_memory`: Writes a named memory (for future reference) to Serena's project-specific memory store.
+excluded_tools: []
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+included_optional_tools: []
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+fixed_tools: []
+
+# list of mode names to that are always to be included in the set of active modes
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the base_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this setting overrides the global configuration.
+# Set this to [] to disable base modes for this project.
+# Set this to a list of mode names to always include the respective modes for this project.
+base_modes:
+
+# list of mode names that are to be activated by default.
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+default_modes:
+
+# initial prompt for the project. It will always be given to the LLM upon activating the project
+# (contrary to the memories, which are loaded on demand).
+initial_prompt: ""
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []

--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ Or:
 uvx repo-release-tools branch new feat "add parser"
 ```
 
+For basic versioning, `bump` and `ci-version` can run without `[tool.rrt]` by
+auto-detecting root-level `pyproject.toml`, `package.json`, and `Cargo.toml`.
+If multiple version files are found they are updated together, and explicit
+config becomes optional fine-tuning for groups, release branches, changelog
+paths, lock commands, generated files, or custom patterns. Go repos still need
+explicit config for file updates because Go has no standard in-file project
+version.
+
 Minimal config:
 
 ```toml

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ policy, and version bumps across local development, CI, and Copilot workflows.
 
 ```bash
 pip install repo-release-tools
+rrt init
 rrt branch new feat "add parser"
 rrt bump patch
 ```
@@ -30,7 +31,7 @@ If multiple version files are found they are updated together, and explicit
 config becomes optional fine-tuning for groups, release branches, changelog
 paths, lock commands, generated files, or custom patterns. Go repos still need
 explicit config for file updates because Go has no standard in-file project
-version.
+version. Run `rrt init` to capture the current recommendation in `.rrt.toml`.
 
 Minimal config:
 

--- a/docs/rrt-cli.md
+++ b/docs/rrt-cli.md
@@ -17,6 +17,7 @@ uvx repo-release-tools branch new feat "add parser"
 ## Core commands
 
 ```bash
+rrt init
 rrt branch new feat "add parser"
 rrt branch rescue fix "recover release work"
 rrt bump patch
@@ -37,7 +38,21 @@ For basic versioning, `rrt` can work without `[tool.rrt]`.
 
 Add `[tool.rrt]` later only when you want fine-tuning such as grouped releases,
 custom release branches, changelog paths, lock commands, generated files, or
-pattern-based targets.
+pattern-based targets. Run `rrt init` when you want `rrt` to write a
+recommended `.rrt.toml` for the current repo shape.
+
+## Init
+
+```bash
+rrt init
+rrt init --dry-run
+rrt init --force
+```
+
+`rrt init` writes a recommended `.rrt.toml` in the repo root. It keeps branch
+creation config-free, preserves zero-config bumping, and gives you an explicit
+file when you want to tune release branches, changelog paths, generated files,
+or custom version targets.
 
 ## Configuration files
 

--- a/docs/rrt-cli.md
+++ b/docs/rrt-cli.md
@@ -24,6 +24,21 @@ rrt bump minor --dry-run
 rrt bump 1.2.3 --no-changelog
 ```
 
+## Zero-config mode
+
+For basic versioning, `rrt` can work without `[tool.rrt]`.
+
+- `bump` and `ci-version` auto-detect root-level `pyproject.toml`, `package.json`,
+  and `Cargo.toml`
+- If multiple version files are found, they are updated together
+- Auto-detected files must already agree on the current version before `bump`
+- Go does not have a standard in-file project version, so Go repos still need
+  explicit config for file updates
+
+Add `[tool.rrt]` later only when you want fine-tuning such as grouped releases,
+custom release branches, changelog paths, lock commands, generated files, or
+pattern-based targets.
+
 ## Configuration files
 
 `rrt` discovers configuration in this order:
@@ -34,7 +49,9 @@ rrt bump 1.2.3 --no-changelog
 4. `.rrt.toml`
 5. `.config/rrt.toml`
 
-Native config locations:
+All use the same `[tool.rrt]` table.
+Use `.rrt.toml` or `.config/rrt.toml` for local repo config if you do not want
+to keep release-tool settings in `pyproject.toml`.
 
 - `pyproject.toml`, `.rrt.toml`, `.config/rrt.toml`: `[tool.rrt]`
 - `package.json`: top-level `"rrt": { ... }`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "repo-release-tools"
-version = "0.1.4"
+version = "0.1.5"
 description = "Config-driven branch and release helpers for Git repositories"
 readme = "README.md"
 license = "MIT"

--- a/src/repo_release_tools/__init__.py
+++ b/src/repo_release_tools/__init__.py
@@ -1,3 +1,3 @@
 """repo-release-tools package."""
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"

--- a/src/repo_release_tools/cli.py
+++ b/src/repo_release_tools/cli.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import argparse
 import sys
 
-from repo_release_tools.commands import branch, bump, ci_version
+from repo_release_tools.commands import branch, bump, ci_version, init
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -18,6 +18,7 @@ def build_parser() -> argparse.ArgumentParser:
     branch.register(subparsers)
     bump.register(subparsers)
     ci_version.register(subparsers)
+    init.register(subparsers)
     return parser
 
 

--- a/src/repo_release_tools/commands/bump.py
+++ b/src/repo_release_tools/commands/bump.py
@@ -9,11 +9,40 @@ from pathlib import Path
 
 from repo_release_tools import git, output
 from repo_release_tools.changelog import build_changelog_section
-from repo_release_tools.config import RrtConfig, load_config
-from repo_release_tools.version_targets import read_group_current_version, replace_version_in_file
+from repo_release_tools.config import (
+    RrtConfig,
+    format_autodetected_config_notice,
+    format_missing_tool_rrt_guidance,
+    is_missing_tool_rrt_error,
+    iter_config_files,
+    load_or_autodetect_config,
+)
+from repo_release_tools.version_targets import (
+    read_group_current_version,
+    read_group_version_strings,
+    replace_version_in_file,
+)
 from repo_release_tools.versioning import Version
 
 PREVIEW_LINES = 8
+
+
+def _ensure_autodetected_versions_match(config: RrtConfig) -> str | None:
+    """Return an error message when auto-detected targets disagree on the version."""
+    if not config.autodetected:
+        return None
+
+    group = config.resolve_group()
+    versions = read_group_version_strings(group)
+    distinct_versions = {version for _, version in versions}
+    if len(distinct_versions) <= 1:
+        return None
+
+    details = ", ".join(f"{target.path.name}={version}" for target, version in versions)
+    return (
+        "Auto-detected version files do not agree: "
+        f"{details}. Make them consistent, or add [tool.rrt] to choose explicit targets/groups."
+    )
 
 
 def git_log_since_latest_tag(root: Path) -> list[str]:
@@ -61,10 +90,27 @@ def cmd_bump(args: argparse.Namespace) -> int:
     """Bump project version using [tool.rrt]."""
     root = Path.cwd()
     try:
-        config = load_config(root)
-    except (FileNotFoundError, ValueError, RuntimeError) as exc:
+        config = load_or_autodetect_config(root)
+    except FileNotFoundError:
+        print(output.warning("No supported rrt config file found."), file=sys.stderr)
+        print(format_missing_tool_rrt_guidance(root, []), file=sys.stderr)
+        return 1
+    except ValueError as exc:
+        if is_missing_tool_rrt_error(exc):
+            print(output.warning("No [tool.rrt] configuration found."), file=sys.stderr)
+            print(format_missing_tool_rrt_guidance(root, iter_config_files(root)), file=sys.stderr)
+            return 1
         print(str(exc), file=sys.stderr)
         return 1
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    if config.autodetected:
+        print(output.warning(format_autodetected_config_notice(config)), file=sys.stderr)
+        if mismatch := _ensure_autodetected_versions_match(config):
+            print(mismatch, file=sys.stderr)
+            return 1
 
     try:
         group = config.resolve_group(args.group)

--- a/src/repo_release_tools/commands/bump.py
+++ b/src/repo_release_tools/commands/bump.py
@@ -18,31 +18,13 @@ from repo_release_tools.config import (
     load_or_autodetect_config,
 )
 from repo_release_tools.version_targets import (
+    check_autodetected_version_consistency,
     read_group_current_version,
-    read_group_version_strings,
     replace_version_in_file,
 )
 from repo_release_tools.versioning import Version
 
 PREVIEW_LINES = 8
-
-
-def _ensure_autodetected_versions_match(config: RrtConfig) -> str | None:
-    """Return an error message when auto-detected targets disagree on the version."""
-    if not config.autodetected:
-        return None
-
-    group = config.resolve_group()
-    versions = read_group_version_strings(group)
-    distinct_versions = {version for _, version in versions}
-    if len(distinct_versions) <= 1:
-        return None
-
-    details = ", ".join(f"{target.path.name}={version}" for target, version in versions)
-    return (
-        "Auto-detected version files do not agree: "
-        f"{details}. Make them consistent, or add [tool.rrt] to choose explicit targets/groups."
-    )
 
 
 def git_log_since_latest_tag(root: Path) -> list[str]:
@@ -108,7 +90,7 @@ def cmd_bump(args: argparse.Namespace) -> int:
 
     if config.autodetected:
         print(output.warning(format_autodetected_config_notice(config)), file=sys.stderr)
-        if mismatch := _ensure_autodetected_versions_match(config):
+        if mismatch := check_autodetected_version_consistency(config):
             print(mismatch, file=sys.stderr)
             return 1
 

--- a/src/repo_release_tools/commands/ci_version.py
+++ b/src/repo_release_tools/commands/ci_version.py
@@ -31,8 +31,19 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from repo_release_tools import output
-from repo_release_tools.config import VALID_CI_FORMATS, load_config
-from repo_release_tools.version_targets import read_group_current_version, replace_version_in_file
+from repo_release_tools.config import (
+    VALID_CI_FORMATS,
+    format_autodetected_config_notice,
+    format_missing_tool_rrt_guidance,
+    is_missing_tool_rrt_error,
+    iter_config_files,
+    load_or_autodetect_config,
+)
+from repo_release_tools.version_targets import (
+    read_group_current_version,
+    read_group_version_strings,
+    replace_version_in_file,
+)
 
 
 # Regex that matches the PEP 440 dev-release suffix so it can be converted
@@ -129,12 +140,46 @@ def _resolve_base(args: argparse.Namespace, root: Path) -> str | None:
     if args.base:
         return args.base
     try:
-        config = load_config(root)
+        config = load_or_autodetect_config(root)
+        if config.autodetected:
+            print(output.warning(format_autodetected_config_notice(config)), file=sys.stderr)
+            if mismatch := _autodetected_version_mismatch(config):
+                print(mismatch, file=sys.stderr)
+                return None
         group = config.resolve_group(getattr(args, "group", None))
         return str(read_group_current_version(group))
-    except (FileNotFoundError, ValueError, RuntimeError) as exc:
+    except FileNotFoundError:
+        print(output.warning("No supported rrt config file found."), file=sys.stderr)
+        print(format_missing_tool_rrt_guidance(root, []), file=sys.stderr)
+        return None
+    except ValueError as exc:
+        if is_missing_tool_rrt_error(exc):
+            print(output.warning("No [tool.rrt] configuration found."), file=sys.stderr)
+            print(format_missing_tool_rrt_guidance(root, iter_config_files(root)), file=sys.stderr)
+            return None
         print(str(exc), file=sys.stderr)
         return None
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
+        return None
+
+
+def _autodetected_version_mismatch(config) -> str | None:
+    """Return an error message when auto-detected targets disagree."""
+    if not config.autodetected:
+        return None
+
+    group = config.resolve_group()
+    versions = read_group_version_strings(group)
+    distinct_versions = {version for _, version in versions}
+    if len(distinct_versions) <= 1:
+        return None
+
+    details = ", ".join(f"{target.path.name}={version}" for target, version in versions)
+    return (
+        "Auto-detected version files do not agree: "
+        f"{details}. Make them consistent, or add [tool.rrt] to choose explicit targets/groups."
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -175,9 +220,22 @@ def cmd_ci_version_apply(args: argparse.Namespace) -> int:
     root = Path.cwd()
 
     try:
-        config = load_config(root)
+        config = load_or_autodetect_config(root)
+        if config.autodetected:
+            print(output.warning(format_autodetected_config_notice(config)), file=sys.stderr)
         group = config.resolve_group(getattr(args, "group", None))
-    except (FileNotFoundError, ValueError, RuntimeError) as exc:
+    except FileNotFoundError:
+        print(output.warning("No supported rrt config file found."), file=sys.stderr)
+        print(format_missing_tool_rrt_guidance(root, []), file=sys.stderr)
+        return 1
+    except ValueError as exc:
+        if is_missing_tool_rrt_error(exc):
+            print(output.warning("No [tool.rrt] configuration found."), file=sys.stderr)
+            print(format_missing_tool_rrt_guidance(root, iter_config_files(root)), file=sys.stderr)
+            return 1
+        print(str(exc), file=sys.stderr)
+        return 1
+    except RuntimeError as exc:
         print(str(exc), file=sys.stderr)
         return 1
 

--- a/src/repo_release_tools/commands/ci_version.py
+++ b/src/repo_release_tools/commands/ci_version.py
@@ -40,8 +40,8 @@ from repo_release_tools.config import (
     load_or_autodetect_config,
 )
 from repo_release_tools.version_targets import (
+    check_autodetected_version_consistency,
     read_group_current_version,
-    read_group_version_strings,
     replace_version_in_file,
 )
 
@@ -143,7 +143,7 @@ def _resolve_base(args: argparse.Namespace, root: Path) -> str | None:
         config = load_or_autodetect_config(root)
         if config.autodetected:
             print(output.warning(format_autodetected_config_notice(config)), file=sys.stderr)
-            if mismatch := _autodetected_version_mismatch(config):
+            if mismatch := check_autodetected_version_consistency(config):
                 print(mismatch, file=sys.stderr)
                 return None
         group = config.resolve_group(getattr(args, "group", None))
@@ -162,24 +162,6 @@ def _resolve_base(args: argparse.Namespace, root: Path) -> str | None:
     except RuntimeError as exc:
         print(str(exc), file=sys.stderr)
         return None
-
-
-def _autodetected_version_mismatch(config) -> str | None:
-    """Return an error message when auto-detected targets disagree."""
-    if not config.autodetected:
-        return None
-
-    group = config.resolve_group()
-    versions = read_group_version_strings(group)
-    distinct_versions = {version for _, version in versions}
-    if len(distinct_versions) <= 1:
-        return None
-
-    details = ", ".join(f"{target.path.name}={version}" for target, version in versions)
-    return (
-        "Auto-detected version files do not agree: "
-        f"{details}. Make them consistent, or add [tool.rrt] to choose explicit targets/groups."
-    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/repo_release_tools/commands/init.py
+++ b/src/repo_release_tools/commands/init.py
@@ -19,7 +19,12 @@ def cmd_init(args: argparse.Namespace) -> int:
     """Write a recommended local .rrt.toml file."""
     root = Path.cwd()
     target = root / DEFAULT_INIT_CONFIG
-    explicit_config = find_explicit_config_file(root)
+
+    try:
+        explicit_config = find_explicit_config_file(root)
+    except (ValueError, RuntimeError) as exc:
+        print(output.warning(f"Could not read existing configuration: {exc}"), file=sys.stderr)
+        return 1
 
     if explicit_config is not None and explicit_config != target and not args.force:
         relative = explicit_config.relative_to(root)
@@ -37,7 +42,11 @@ def cmd_init(args: argparse.Namespace) -> int:
         )
         return 1
 
-    config_text = recommend_init_config(root)
+    try:
+        config_text = recommend_init_config(root)
+    except (ValueError, RuntimeError) as exc:
+        print(output.warning(f"Could not generate init config: {exc}"), file=sys.stderr)
+        return 1
 
     print()
     print(

--- a/src/repo_release_tools/commands/init.py
+++ b/src/repo_release_tools/commands/init.py
@@ -1,0 +1,79 @@
+"""Repository init command."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from pathlib import Path
+
+from repo_release_tools import output
+from repo_release_tools.config import (
+    DEFAULT_INIT_CONFIG,
+    find_explicit_config_file,
+    recommend_init_config,
+)
+
+
+def cmd_init(args: argparse.Namespace) -> int:
+    """Write a recommended local .rrt.toml file."""
+    root = Path.cwd()
+    target = root / DEFAULT_INIT_CONFIG
+    explicit_config = find_explicit_config_file(root)
+
+    if explicit_config is not None and explicit_config != target and not args.force:
+        relative = explicit_config.relative_to(root)
+        print(
+            f"Explicit rrt configuration already exists in {relative}. "
+            f"Refusing to add {DEFAULT_INIT_CONFIG}; use --force to overwrite it anyway.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if target.exists() and not args.force:
+        print(
+            f"{DEFAULT_INIT_CONFIG} already exists. Use --force to overwrite it.",
+            file=sys.stderr,
+        )
+        return 1
+
+    config_text = recommend_init_config(root)
+
+    print()
+    print(
+        output.panel(
+            "[DRY RUN] Init config" if args.dry_run else "Init config",
+            [("File", DEFAULT_INIT_CONFIG)],
+        )
+    )
+    print()
+
+    if args.dry_run:
+        print(output.dry_run(f"Would write {DEFAULT_INIT_CONFIG}:"))
+        print()
+        print(config_text)
+        print()
+        print(output.dry_run_complete("no files were modified"))
+        return 0
+
+    target.write_text(config_text + "\n", encoding="utf-8")
+    print(output.ok(f"Wrote {DEFAULT_INIT_CONFIG}"))
+    if explicit_config is not None and explicit_config != target:
+        relative = explicit_config.relative_to(root)
+        print(
+            output.warning(
+                f"{relative} still takes precedence over {DEFAULT_INIT_CONFIG} during config discovery."
+            )
+        )
+    return 0
+
+
+def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    """Register the init command."""
+    parser = subparsers.add_parser(
+        "init",
+        help="Generate a recommended .rrt.toml for the current repository.",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Preview without writing files.")
+    parser.add_argument("--force", action="store_true", help="Overwrite an existing .rrt.toml.")
+    parser.set_defaults(handler=cmd_init)

--- a/src/repo_release_tools/config.py
+++ b/src/repo_release_tools/config.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import json
 import re
 import tomllib
+import json
 
 from dataclasses import dataclass
 from pathlib import Path
+from textwrap import dedent
 
 
 DEFAULT_RELEASE_BRANCH = "release/v{version}"
@@ -29,6 +31,55 @@ _AUTO: list[str] | None = None
 VALID_TARGET_KINDS = frozenset({"pep621", "package_json"})
 
 VALID_CI_FORMATS = frozenset({"pep440", "semver_pre"})
+
+AUTODETECTED_CONFIG_BASENAME = ".rrt.autodetected.toml"
+
+PYTHON_TOOL_RRT_EXAMPLE = dedent(
+    """\
+    [tool.rrt]
+    release_branch = "release/v{version}"
+
+    [[tool.rrt.version_targets]]
+    path = "pyproject.toml"
+    kind = "pep621"
+    """
+).strip()
+
+NODE_TOOL_RRT_EXAMPLE = dedent(
+    """\
+    [tool.rrt]
+    release_branch = "release/v{version}"
+
+    [[tool.rrt.version_targets]]
+    path = "package.json"
+    kind = "package_json"
+    ci_format = "semver_pre"
+    """
+).strip()
+
+RUST_TOOL_RRT_EXAMPLE = dedent(
+    """\
+    [tool.rrt]
+    release_branch = "release/v{version}"
+
+    [[tool.rrt.version_targets]]
+    path = "Cargo.toml"
+    section = "package"
+    field = "version"
+    ci_format = "semver_pre"
+    """
+).strip()
+
+GO_TOOL_RRT_EXAMPLE = dedent(
+    """\
+    [tool.rrt]
+    release_branch = "release/v{version}"
+
+    [[tool.rrt.version_targets]]
+    path = "internal/version/version.go"
+    pattern = '^(const Version = ")([^"]+)(")$'
+    """
+).strip()
 
 
 @dataclass(frozen=True)
@@ -121,6 +172,7 @@ class RrtConfig:
     config_file: Path
     version_groups: list[VersionGroup]
     default_group_name: str | None = None
+    autodetected: bool = False
 
     def resolve_group(self, name: str | None = None) -> VersionGroup:
         """Resolve a version group by name or default selection rules."""
@@ -210,6 +262,187 @@ def find_config_file(root: Path) -> Path:
 def iter_config_files(root: Path) -> list[Path]:
     """Return supported config files that exist in discovery order."""
     return [root / candidate for candidate in CONFIG_FILE_CANDIDATES if (root / candidate).exists()]
+
+
+def load_or_autodetect_config(root: Path) -> RrtConfig:
+    """Load explicit config, or fall back to safe auto-detection."""
+    try:
+        return load_config(root)
+    except FileNotFoundError:
+        autodetected = autodetect_config(root)
+        if autodetected is not None:
+            return autodetected
+        raise
+    except ValueError as exc:
+        if not is_missing_tool_rrt_error(exc):
+            raise
+        autodetected = autodetect_config(root)
+        if autodetected is not None:
+            return autodetected
+        raise
+
+
+def autodetect_config(root: Path) -> RrtConfig | None:
+    """Build an implicit config from common root-level version files."""
+    targets = _autodetect_version_targets(root)
+    if not targets:
+        return None
+
+    group = VersionGroup(
+        name="default",
+        release_branch=DEFAULT_RELEASE_BRANCH,
+        changelog_file=root / DEFAULT_CHANGELOG,
+        lock_command=[],
+        generated_files=[],
+        version_targets=targets,
+        version_source=targets[0].path,
+    )
+    return RrtConfig(
+        root=root,
+        config_file=root / AUTODETECTED_CONFIG_BASENAME,
+        version_groups=[group],
+        default_group_name="default",
+        autodetected=True,
+    )
+
+
+def format_autodetected_config_notice(config: RrtConfig) -> str:
+    """Describe the implicit version targets chosen for zero-config mode."""
+    group = config.resolve_group()
+    targets = ", ".join(_describe_version_target(target, root=config.root) for target in group.version_targets)
+    supported = ", ".join(CONFIG_FILE_CANDIDATES)
+    return (
+        "Using auto-detected version targets: "
+        f"{targets}. Add [tool.rrt] in {supported} for optional fine-tuning "
+        "(groups, release branches, changelog path, lock commands, generated files, or custom patterns)."
+    )
+
+
+def format_missing_tool_rrt_guidance(root: Path, checked_files: list[Path] | None = None) -> str:
+    """Render actionable setup guidance when [tool.rrt] is missing."""
+    checked_files = iter_config_files(root) if checked_files is None else checked_files
+
+    lines: list[str] = []
+    if checked_files:
+        checked = ", ".join(str(path.relative_to(root)) for path in checked_files)
+        lines.append(f"No [tool.rrt] configuration was found in supported config files: {checked}")
+    else:
+        supported = ", ".join(CONFIG_FILE_CANDIDATES)
+        lines.append(f"No supported config file was found. Supported locations: {supported}")
+
+    lines.extend(
+        [
+            "",
+            "Zero-config mode auto-detects these root-level version files:",
+            "  - pyproject.toml -> [project].version",
+            "  - package.json -> top-level version",
+            "  - Cargo.toml -> [package].version",
+            "",
+            "If none of those exist, add optional [tool.rrt] config in any supported file:",
+        ]
+    )
+    for candidate in CONFIG_FILE_CANDIDATES:
+        lines.append(f"  - {candidate}")
+
+    lines.extend(
+        [
+            "",
+            "Examples:",
+            "",
+            "Python / PEP 621:",
+            *[f"    {line}" for line in PYTHON_TOOL_RRT_EXAMPLE.splitlines()],
+            "",
+            "Node / package.json:",
+            *[f"    {line}" for line in NODE_TOOL_RRT_EXAMPLE.splitlines()],
+            "",
+            "Rust / Cargo.toml:",
+            *[f"    {line}" for line in RUST_TOOL_RRT_EXAMPLE.splitlines()],
+            "",
+            "Go example (Go has no standard in-file project version, so use an explicit pattern):",
+            *[f"    {line}" for line in GO_TOOL_RRT_EXAMPLE.splitlines()],
+            "",
+            "Local repo config works too: put that table in .rrt.toml or .config/rrt.toml",
+            "if you do not want to keep release-tool config in pyproject.toml.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _autodetect_version_targets(root: Path) -> list[VersionTarget]:
+    """Discover common version targets in the repository root."""
+    targets: list[VersionTarget] = []
+
+    pyproject = root / "pyproject.toml"
+    if _toml_string_field_exists(pyproject, section="project", field="version"):
+        targets.append(
+            VersionTarget(path=pyproject, kind="pep621", ci_format="pep440")
+        )
+
+    package_json = root / "package.json"
+    if _json_string_field_exists(package_json, field="version"):
+        targets.append(
+            VersionTarget(path=package_json, kind="package_json", ci_format="semver_pre")
+        )
+
+    cargo_toml = root / "Cargo.toml"
+    if _toml_string_field_exists(cargo_toml, section="package", field="version"):
+        targets.append(
+            VersionTarget(
+                path=cargo_toml,
+                section="package",
+                field="version",
+                ci_format="semver_pre",
+            )
+        )
+
+    return targets
+
+
+def _toml_string_field_exists(path: Path, *, section: str, field: str) -> bool:
+    """Return whether a TOML file contains a string field in a named section."""
+    if not path.exists():
+        return False
+
+    try:
+        with path.open("rb") as handle:
+            data = tomllib.load(handle)
+    except (tomllib.TOMLDecodeError, OSError):
+        return False
+
+    current: object = data
+    for part in section.split("."):
+        if not isinstance(current, dict) or part not in current:
+            return False
+        current = current[part]
+
+    return isinstance(current, dict) and isinstance(current.get(field), str)
+
+
+def _json_string_field_exists(path: Path, *, field: str) -> bool:
+    """Return whether a JSON file contains a string field at the top level."""
+    if not path.exists():
+        return False
+
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return False
+
+    return isinstance(data, dict) and isinstance(data.get(field), str)
+
+
+def _describe_version_target(target: VersionTarget, *, root: Path) -> str:
+    """Render a short human label for a version target."""
+    relative = str(target.path.relative_to(root))
+    if target.kind == "pep621":
+        return f"{relative} ([project].version)"
+    if target.kind == "package_json":
+        return f"{relative} (version)"
+    if target.section and target.field:
+        return f"{relative} ([{target.section}].{target.field})"
+    if target.pattern:
+        return f"{relative} (pattern)"
+    return relative
 
 
 def load_config_from_path(root: Path, config_file: Path) -> RrtConfig:

--- a/src/repo_release_tools/config.py
+++ b/src/repo_release_tools/config.py
@@ -335,7 +335,9 @@ def autodetect_config(root: Path) -> RrtConfig | None:
 def format_autodetected_config_notice(config: RrtConfig) -> str:
     """Describe the implicit version targets chosen for zero-config mode."""
     group = config.resolve_group()
-    targets = ", ".join(_describe_version_target(target, root=config.root) for target in group.version_targets)
+    targets = ", ".join(
+        _describe_version_target(target, root=config.root) for target in group.version_targets
+    )
     supported = ", ".join(CONFIG_FILE_CANDIDATES)
     return (
         "Using auto-detected version targets: "
@@ -522,8 +524,8 @@ def _render_recommended_rrt_toml(root: Path, group: VersionGroup) -> str:
     """Render an explicit .rrt.toml mirroring the current recommended defaults."""
     lines = [
         "[tool.rrt]",
-        f'release_branch = {_toml_basic_string(group.release_branch)}',
-        f'changelog_file = {_toml_basic_string(str(group.changelog_file.relative_to(root)))}',
+        f"release_branch = {_toml_basic_string(group.release_branch)}",
+        f"changelog_file = {_toml_basic_string(str(group.changelog_file.relative_to(root)))}",
     ]
 
     lock_command, generated_files = _recommended_lock_settings(root, group.version_targets)
@@ -533,22 +535,22 @@ def _render_recommended_rrt_toml(root: Path, group: VersionGroup) -> str:
         lines.append(f"generated_files = {_toml_string_list(generated_files)}")
     if len(group.version_targets) > 1:
         lines.append(
-            f'version_source = {_toml_basic_string(str(group.primary_target().path.relative_to(root)))}'
+            f"version_source = {_toml_basic_string(str(group.primary_target().path.relative_to(root)))}"
         )
 
     for target in group.version_targets:
         lines.extend(["", "[[tool.rrt.version_targets]]"])
-        lines.append(f'path = {_toml_basic_string(str(target.path.relative_to(root)))}')
+        lines.append(f"path = {_toml_basic_string(str(target.path.relative_to(root)))}")
         if target.kind is not None:
-            lines.append(f'kind = {_toml_basic_string(target.kind)}')
+            lines.append(f"kind = {_toml_basic_string(target.kind)}")
         if target.pattern is not None:
             lines.append(f"pattern = {_toml_literal_string(target.pattern)}")
         if target.section is not None:
-            lines.append(f'section = {_toml_basic_string(target.section)}')
+            lines.append(f"section = {_toml_basic_string(target.section)}")
         if target.field is not None:
-            lines.append(f'field = {_toml_basic_string(target.field)}')
+            lines.append(f"field = {_toml_basic_string(target.field)}")
         if target.ci_format is not None:
-            lines.append(f'ci_format = {_toml_basic_string(target.ci_format)}')
+            lines.append(f"ci_format = {_toml_basic_string(target.ci_format)}")
 
     return "\n".join(lines)
 

--- a/src/repo_release_tools/config.py
+++ b/src/repo_release_tools/config.py
@@ -24,6 +24,15 @@ CONFIG_FILE_CANDIDATES = (
     ".config/rrt.toml",
 )
 
+# Per-file rrt config section names used in user-facing guidance messages.
+CONFIG_SECTION_BY_FILE: dict[str, str] = {
+    "pyproject.toml": "[tool.rrt]",
+    "package.json": "rrt (top-level key)",
+    "Cargo.toml": "[package.metadata.rrt] / [workspace.metadata.rrt]",
+    ".rrt.toml": "[tool.rrt]",
+    ".config/rrt.toml": "[tool.rrt]",
+}
+
 # Sentinel: lock_command / generated_files not explicitly configured → auto-detect.
 _AUTO: list[str] | None = None
 
@@ -338,11 +347,14 @@ def format_autodetected_config_notice(config: RrtConfig) -> str:
     targets = ", ".join(
         _describe_version_target(target, root=config.root) for target in group.version_targets
     )
-    supported = ", ".join(CONFIG_FILE_CANDIDATES)
+    file_guidance = "; ".join(
+        f"{name} \u2192 {section}" for name, section in CONFIG_SECTION_BY_FILE.items()
+    )
     return (
         "Using auto-detected version targets: "
-        f"{targets}. Add [tool.rrt] in {supported} for optional fine-tuning "
-        "(groups, release branches, changelog path, lock commands, generated files, or custom patterns). "
+        f"{targets}. For optional fine-tuning (groups, release branches, changelog path, "
+        "lock commands, generated files, or custom patterns), add rrt config using the "
+        f"appropriate section for your project file: {file_guidance}. "
         f"Run `rrt init` to write the recommended {DEFAULT_INIT_CONFIG}."
     )
 
@@ -354,7 +366,7 @@ def format_missing_tool_rrt_guidance(root: Path, checked_files: list[Path] | Non
     lines: list[str] = []
     if checked_files:
         checked = ", ".join(str(path.relative_to(root)) for path in checked_files)
-        lines.append(f"No [tool.rrt] configuration was found in supported config files: {checked}")
+        lines.append(f"No rrt configuration was found in supported config files: {checked}")
     else:
         supported = ", ".join(CONFIG_FILE_CANDIDATES)
         lines.append(f"No supported config file was found. Supported locations: {supported}")
@@ -367,11 +379,11 @@ def format_missing_tool_rrt_guidance(root: Path, checked_files: list[Path] | Non
             "  - package.json -> top-level version",
             "  - Cargo.toml -> [package].version",
             "",
-            "If none of those exist, add optional [tool.rrt] config in any supported file:",
+            "If none of those exist, add rrt config using the appropriate section for your project file:",
         ]
     )
-    for candidate in CONFIG_FILE_CANDIDATES:
-        lines.append(f"  - {candidate}")
+    for name, section in CONFIG_SECTION_BY_FILE.items():
+        lines.append(f"  - {name} \u2192 {section}")
 
     lines.extend(
         [

--- a/src/repo_release_tools/config.py
+++ b/src/repo_release_tools/config.py
@@ -348,7 +348,7 @@ def format_autodetected_config_notice(config: RrtConfig) -> str:
         _describe_version_target(target, root=config.root) for target in group.version_targets
     )
     file_guidance = "; ".join(
-        f"{name} \u2192 {section}" for name, section in CONFIG_SECTION_BY_FILE.items()
+        f"{name} \u2192 {CONFIG_SECTION_BY_FILE[name]}" for name in CONFIG_FILE_CANDIDATES
     )
     return (
         "Using auto-detected version targets: "
@@ -382,8 +382,8 @@ def format_missing_tool_rrt_guidance(root: Path, checked_files: list[Path] | Non
             "If none of those exist, add rrt config using the appropriate section for your project file:",
         ]
     )
-    for name, section in CONFIG_SECTION_BY_FILE.items():
-        lines.append(f"  - {name} \u2192 {section}")
+    for name in CONFIG_FILE_CANDIDATES:
+        lines.append(f"  - {name} \u2192 {CONFIG_SECTION_BY_FILE[name]}")
 
     lines.extend(
         [

--- a/src/repo_release_tools/config.py
+++ b/src/repo_release_tools/config.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 import re
 import tomllib
-import json
 
 from dataclasses import dataclass
 from pathlib import Path
@@ -33,6 +32,7 @@ VALID_TARGET_KINDS = frozenset({"pep621", "package_json"})
 VALID_CI_FORMATS = frozenset({"pep440", "semver_pre"})
 
 AUTODETECTED_CONFIG_BASENAME = ".rrt.autodetected.toml"
+DEFAULT_INIT_CONFIG = ".rrt.toml"
 
 PYTHON_TOOL_RRT_EXAMPLE = dedent(
     """\
@@ -77,6 +77,19 @@ GO_TOOL_RRT_EXAMPLE = dedent(
 
     [[tool.rrt.version_targets]]
     path = "internal/version/version.go"
+    pattern = '^(const Version = ")([^"]+)(")$'
+    """
+).strip()
+
+GENERIC_TOOL_RRT_EXAMPLE = dedent(
+    """\
+    [tool.rrt]
+    release_branch = "release/v{version}"
+    changelog_file = "CHANGELOG.md"
+
+    # Replace this starter target with the file that owns your version string.
+    [[tool.rrt.version_targets]]
+    path = "path/to/version-file"
     pattern = '^(const Version = ")([^"]+)(")$'
     """
 ).strip()
@@ -225,13 +238,17 @@ class MissingRrtConfigError(ValueError):
     """Raised when a supported config file exists but does not contain rrt config."""
 
 
-def load_config(root: Path) -> RrtConfig:
-    """Load [tool.rrt] from the first supported config file in the repository root.
+def is_missing_tool_rrt_error(exc: Exception) -> bool:
+    """Return whether *exc* means supported config files exist without rrt config."""
+    if isinstance(exc, MissingRrtConfigError):
+        return True
 
-    Falls back to native project auto-detection when no [tool.rrt] section is
-    found anywhere, so that plain PEP 621, Poetry, and JS/TS projects work
-    without an explicit rrt config file.
-    """
+    message = str(exc)
+    return message.startswith("Missing rrt configuration in supported config files:")
+
+
+def load_config(root: Path) -> RrtConfig:
+    """Load explicit rrt config, or fall back to supported zero-config detection."""
     missing_tool_rrt: list[Path] = []
     for config_file in iter_config_files(root):
         try:
@@ -241,10 +258,9 @@ def load_config(root: Path) -> RrtConfig:
         except ValueError:
             raise
 
-    # Native auto-detection: works even when no config file exists at all.
-    auto = auto_detect_config(root)
-    if auto is not None:
-        return auto
+    autodetected = autodetect_config(root)
+    if autodetected is not None:
+        return autodetected
 
     if missing_tool_rrt:
         checked = ", ".join(str(path.relative_to(root)) for path in missing_tool_rrt)
@@ -285,25 +301,35 @@ def load_or_autodetect_config(root: Path) -> RrtConfig:
 def autodetect_config(root: Path) -> RrtConfig | None:
     """Build an implicit config from common root-level version files."""
     targets = _autodetect_version_targets(root)
-    if not targets:
-        return None
+    if len(targets) > 1:
+        group = VersionGroup(
+            name="default",
+            release_branch=DEFAULT_RELEASE_BRANCH,
+            changelog_file=root / DEFAULT_CHANGELOG,
+            lock_command=[],
+            generated_files=[],
+            version_targets=targets,
+            version_source=targets[0].path,
+        )
+        return RrtConfig(
+            root=root,
+            config_file=root / AUTODETECTED_CONFIG_BASENAME,
+            version_groups=[group],
+            default_group_name="default",
+            autodetected=True,
+        )
 
-    group = VersionGroup(
-        name="default",
-        release_branch=DEFAULT_RELEASE_BRANCH,
-        changelog_file=root / DEFAULT_CHANGELOG,
-        lock_command=[],
-        generated_files=[],
-        version_targets=targets,
-        version_source=targets[0].path,
-    )
-    return RrtConfig(
-        root=root,
-        config_file=root / AUTODETECTED_CONFIG_BASENAME,
-        version_groups=[group],
-        default_group_name="default",
-        autodetected=True,
-    )
+    single = auto_detect_config(root)
+    if single is not None:
+        return RrtConfig(
+            root=single.root,
+            config_file=single.config_file,
+            version_groups=single.version_groups,
+            default_group_name=single.default_group_name,
+            autodetected=True,
+        )
+
+    return None
 
 
 def format_autodetected_config_notice(config: RrtConfig) -> str:
@@ -314,7 +340,8 @@ def format_autodetected_config_notice(config: RrtConfig) -> str:
     return (
         "Using auto-detected version targets: "
         f"{targets}. Add [tool.rrt] in {supported} for optional fine-tuning "
-        "(groups, release branches, changelog path, lock commands, generated files, or custom patterns)."
+        "(groups, release branches, changelog path, lock commands, generated files, or custom patterns). "
+        f"Run `rrt init` to write the recommended {DEFAULT_INIT_CONFIG}."
     )
 
 
@@ -347,6 +374,8 @@ def format_missing_tool_rrt_guidance(root: Path, checked_files: list[Path] | Non
     lines.extend(
         [
             "",
+            f"Run `rrt init` to generate a recommended {DEFAULT_INIT_CONFIG} starter.",
+            "",
             "Examples:",
             "",
             "Python / PEP 621:",
@@ -374,8 +403,15 @@ def _autodetect_version_targets(root: Path) -> list[VersionTarget]:
 
     pyproject = root / "pyproject.toml"
     if _toml_string_field_exists(pyproject, section="project", field="version"):
+        targets.append(VersionTarget(path=pyproject, kind="pep621", ci_format="pep440"))
+    elif _toml_string_field_exists(pyproject, section="tool.poetry", field="version"):
         targets.append(
-            VersionTarget(path=pyproject, kind="pep621", ci_format="pep440")
+            VersionTarget(
+                path=pyproject,
+                section="tool.poetry",
+                field="version",
+                ci_format="pep440",
+            )
         )
 
     package_json = root / "package.json"
@@ -390,6 +426,15 @@ def _autodetect_version_targets(root: Path) -> list[VersionTarget]:
             VersionTarget(
                 path=cargo_toml,
                 section="package",
+                field="version",
+                ci_format="semver_pre",
+            )
+        )
+    elif _toml_string_field_exists(cargo_toml, section="workspace.package", field="version"):
+        targets.append(
+            VersionTarget(
+                path=cargo_toml,
+                section="workspace.package",
                 field="version",
                 ci_format="semver_pre",
             )
@@ -443,6 +488,120 @@ def _describe_version_target(target: VersionTarget, *, root: Path) -> str:
     if target.pattern:
         return f"{relative} (pattern)"
     return relative
+
+
+def find_explicit_config_file(root: Path) -> Path | None:
+    """Return the first config file that contains explicit rrt configuration."""
+    for config_file in iter_config_files(root):
+        try:
+            load_config_from_path(root, config_file)
+        except MissingRrtConfigError:
+            continue
+        return config_file
+    return None
+
+
+def recommend_init_config(root: Path) -> str:
+    """Return a recommended .rrt.toml file for the current repository."""
+    config = autodetect_config(root)
+    if config is not None:
+        return _render_recommended_rrt_toml(root, config.resolve_group())
+
+    if (root / "go.mod").exists():
+        return "\n".join(
+            [
+                "# Edit the starter target below before using `rrt bump`.",
+                GO_TOOL_RRT_EXAMPLE,
+            ]
+        )
+
+    return GENERIC_TOOL_RRT_EXAMPLE
+
+
+def _render_recommended_rrt_toml(root: Path, group: VersionGroup) -> str:
+    """Render an explicit .rrt.toml mirroring the current recommended defaults."""
+    lines = [
+        "[tool.rrt]",
+        f'release_branch = {_toml_basic_string(group.release_branch)}',
+        f'changelog_file = {_toml_basic_string(str(group.changelog_file.relative_to(root)))}',
+    ]
+
+    lock_command, generated_files = _recommended_lock_settings(root, group.version_targets)
+    if lock_command:
+        lines.append(f"lock_command = {_toml_string_list(lock_command)}")
+    if generated_files:
+        lines.append(f"generated_files = {_toml_string_list(generated_files)}")
+    if len(group.version_targets) > 1:
+        lines.append(
+            f'version_source = {_toml_basic_string(str(group.primary_target().path.relative_to(root)))}'
+        )
+
+    for target in group.version_targets:
+        lines.extend(["", "[[tool.rrt.version_targets]]"])
+        lines.append(f'path = {_toml_basic_string(str(target.path.relative_to(root)))}')
+        if target.kind is not None:
+            lines.append(f'kind = {_toml_basic_string(target.kind)}')
+        if target.pattern is not None:
+            lines.append(f"pattern = {_toml_literal_string(target.pattern)}")
+        if target.section is not None:
+            lines.append(f'section = {_toml_basic_string(target.section)}')
+        if target.field is not None:
+            lines.append(f'field = {_toml_basic_string(target.field)}')
+        if target.ci_format is not None:
+            lines.append(f'ci_format = {_toml_basic_string(target.ci_format)}')
+
+    return "\n".join(lines)
+
+
+def _recommended_lock_settings(
+    root: Path,
+    targets: list[VersionTarget],
+) -> tuple[list[str], list[str]]:
+    """Return lockfile settings worth materialising into generated local config."""
+    ecosystems = {_target_ecosystem(target) for target in targets}
+    ecosystems.discard(None)
+    if len(ecosystems) != 1:
+        return [], []
+
+    ecosystem = next(iter(ecosystems))
+    if ecosystem == "python-pep621":
+        return list(DEFAULT_LOCK_COMMAND), ["uv.lock"]
+    if ecosystem == "python-poetry":
+        return ["poetry", "lock"], ["poetry.lock"]
+    if ecosystem in {"node", "rust", "go"}:
+        return _detect_lock_and_files(root, targets)
+    return [], []
+
+
+def _target_ecosystem(target: VersionTarget) -> str | None:
+    """Classify a version target by ecosystem for config recommendations."""
+    if target.kind == "pep621":
+        return "python-pep621"
+    if target.kind == "package_json":
+        return "node"
+    if target.section == "tool.poetry":
+        return "python-poetry"
+    if target.path.name == "Cargo.toml" and target.section in {"package", "workspace.package"}:
+        return "rust"
+    if target.path.name == "go.mod" or target.path.suffix == ".go":
+        return "go"
+    return None
+
+
+def _toml_basic_string(value: str) -> str:
+    """Render a TOML basic string."""
+    return json.dumps(value)
+
+
+def _toml_literal_string(value: str) -> str:
+    """Render a TOML literal string."""
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _toml_string_list(values: list[str]) -> str:
+    """Render a TOML string list."""
+    rendered = ", ".join(_toml_basic_string(value) for value in values)
+    return f"[{rendered}]"
 
 
 def load_config_from_path(root: Path, config_file: Path) -> RrtConfig:
@@ -589,7 +748,7 @@ def auto_detect_config(root: Path) -> RrtConfig | None:
 
         # PEP 621 – requires an explicit version field.
         if isinstance(project_section, dict) and "version" in project_section:
-            target = VersionTarget(path=pyproject, kind="pep621")
+            target = VersionTarget(path=pyproject, kind="pep621", ci_format="pep440")
             group = VersionGroup(
                 name="default",
                 release_branch=DEFAULT_RELEASE_BRANCH,
@@ -607,7 +766,12 @@ def auto_detect_config(root: Path) -> RrtConfig | None:
 
         # Poetry – requires an explicit version field.
         if isinstance(poetry_section, dict) and "version" in poetry_section:
-            target = VersionTarget(path=pyproject, section="tool.poetry", field="version")
+            target = VersionTarget(
+                path=pyproject,
+                section="tool.poetry",
+                field="version",
+                ci_format="pep440",
+            )
             lock_cmd, gen_files = _detect_lock_and_files(root, [target])
             if not lock_cmd:
                 lock_cmd = ["poetry", "lock"]
@@ -629,7 +793,7 @@ def auto_detect_config(root: Path) -> RrtConfig | None:
 
     package_json = root / "package.json"
     if package_json.exists():
-        target = VersionTarget(path=package_json, kind="package_json")
+        target = VersionTarget(path=package_json, kind="package_json", ci_format="semver_pre")
         lock_cmd, gen_files = _detect_lock_and_files(root, [target])
         group = VersionGroup(
             name="default",
@@ -655,9 +819,19 @@ def auto_detect_config(root: Path) -> RrtConfig | None:
         workspace_package_section = data.get("workspace", {}).get("package", {})
 
         if isinstance(package_section, dict) and "version" in package_section:
-            target = VersionTarget(path=cargo_toml, section="package", field="version")
+            target = VersionTarget(
+                path=cargo_toml,
+                section="package",
+                field="version",
+                ci_format="semver_pre",
+            )
         elif isinstance(workspace_package_section, dict) and "version" in workspace_package_section:
-            target = VersionTarget(path=cargo_toml, section="workspace.package", field="version")
+            target = VersionTarget(
+                path=cargo_toml,
+                section="workspace.package",
+                field="version",
+                ci_format="semver_pre",
+            )
         else:
             target = None
 

--- a/src/repo_release_tools/version_targets.py
+++ b/src/repo_release_tools/version_targets.py
@@ -59,6 +59,11 @@ def read_group_current_version(group: VersionGroup) -> Version:
     return Version.parse(read_version_string(group.primary_target()))
 
 
+def read_group_version_strings(group: VersionGroup) -> list[tuple[VersionTarget, str]]:
+    """Read the current version string from every target in a group."""
+    return [(target, read_version_string(target)) for target in group.version_targets]
+
+
 def read_version_string(target: VersionTarget) -> str:
     """Read the current version string from a target."""
     text = target.path.read_text(encoding="utf-8")

--- a/src/repo_release_tools/version_targets.py
+++ b/src/repo_release_tools/version_targets.py
@@ -64,6 +64,27 @@ def read_group_version_strings(group: VersionGroup) -> list[tuple[VersionTarget,
     return [(target, read_version_string(target)) for target in group.version_targets]
 
 
+def check_autodetected_version_consistency(config: RrtConfig) -> str | None:
+    """Return an error message when auto-detected targets disagree on the version.
+
+    Returns ``None`` when all targets agree or config is not auto-detected.
+    """
+    if not config.autodetected:
+        return None
+
+    group = config.resolve_group()
+    versions = read_group_version_strings(group)
+    distinct_versions = {version for _, version in versions}
+    if len(distinct_versions) <= 1:
+        return None
+
+    details = ", ".join(f"{target.path.name}={version}" for target, version in versions)
+    return (
+        "Auto-detected version files do not agree: "
+        f"{details}. Make them consistent, or add rrt config to choose explicit targets/groups."
+    )
+
+
 def read_version_string(target: VersionTarget) -> str:
     """Read the current version string from a target."""
     text = target.path.read_text(encoding="utf-8")

--- a/tests/test_ci_version.py
+++ b/tests/test_ci_version.py
@@ -228,7 +228,50 @@ def test_cmd_compute_no_config_no_base_fails(
 ) -> None:
     monkeypatch.chdir(tmp_path)
     result = cmd_ci_version_compute(_ns())
+    captured = capsys.readouterr()
     assert result == 1
+    assert "No supported rrt config file found." in captured.err
+
+
+def test_cmd_compute_reads_base_from_autodetected_package_json(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (tmp_path / "package.json").write_text(
+        """{
+  "name": "example",
+  "version": "0.2.0"
+}
+""",
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    result = cmd_ci_version_compute(_ns(ref="refs/heads/main", run_id="12", run_attempt="1"))
+    captured = capsys.readouterr()
+    assert result == 0
+    assert captured.out.strip() == "0.2.0.dev1201"
+    assert "Using auto-detected version targets: package.json (version)." in captured.err
+
+
+def test_cmd_compute_autodetect_mismatch_fails(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "example"\nversion = "0.2.0"\n', encoding="utf-8"
+    )
+    (tmp_path / "Cargo.toml").write_text(
+        '[package]\nname = "example"\nversion = "0.3.0"\n', encoding="utf-8"
+    )
+
+    monkeypatch.chdir(tmp_path)
+    result = cmd_ci_version_compute(_ns(ref="refs/heads/main", run_id="12", run_attempt="1"))
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "Auto-detected version files do not agree" in captured.err
 
 
 def test_cmd_compute_reads_base_from_rrt_toml(
@@ -338,6 +381,28 @@ version = "1.0.0"
     captured = capsys.readouterr()
     assert result == 1
     assert "ci_format" in captured.err
+
+
+def test_cmd_apply_autodetects_python_and_rust_without_config(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "example"\nversion = "0.2.0"\n', encoding="utf-8"
+    )
+    (tmp_path / "Cargo.toml").write_text(
+        '[package]\nname = "example"\nversion = "0.2.0"\n', encoding="utf-8"
+    )
+
+    monkeypatch.chdir(tmp_path)
+    result = cmd_ci_version_apply(argparse.Namespace(version="0.2.0.dev12345601", dry_run=False))
+    captured = capsys.readouterr()
+
+    assert result == 0
+    assert "Using auto-detected version targets:" in captured.err
+    assert "0.2.0.dev12345601" in (tmp_path / "pyproject.toml").read_text(encoding="utf-8")
+    assert "0.2.0-dev.12345601" in (tmp_path / "Cargo.toml").read_text(encoding="utf-8")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,3 +16,4 @@ def test_module_help_smoke() -> None:
     assert "repo-release-tools" in result.stdout
     assert "branch" in result.stdout
     assert "bump" in result.stdout
+    assert "init" in result.stdout

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,7 +4,13 @@ from pathlib import Path
 
 import pytest
 
-from repo_release_tools.config import VersionTarget, find_config_file, load_config
+from repo_release_tools.config import (
+    VersionTarget,
+    autodetect_config,
+    find_config_file,
+    format_autodetected_config_notice,
+    load_config,
+)
 
 
 _RRT_CONFIG = """\
@@ -48,6 +54,19 @@ def test_load_config_supports_dot_config_path(tmp_path: Path) -> None:
     config = load_config(tmp_path)
 
     assert config.config_file == config_dir / "rrt.toml"
+
+
+def test_autodetected_notice_mentions_init_command(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "example"\nversion = "0.1.0"\n',
+        encoding="utf-8",
+    )
+
+    config = autodetect_config(tmp_path)
+
+    assert config is not None
+    notice = format_autodetected_config_notice(config)
+    assert "rrt init" in notice
 
 
 def test_load_config_skips_existing_file_without_tool_rrt(tmp_path: Path) -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from argparse import Namespace
+from pathlib import Path
+
+from repo_release_tools.commands.init import cmd_init
+from repo_release_tools.config import recommend_init_config
+
+
+def test_recommend_init_config_for_pep621_repo(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "example"\nversion = "0.1.0"\n',
+        encoding="utf-8",
+    )
+
+    rendered = recommend_init_config(tmp_path)
+
+    assert '[tool.rrt]' in rendered
+    assert 'changelog_file = "CHANGELOG.md"' in rendered
+    assert 'lock_command = ["uv", "lock", "-U"]' in rendered
+    assert 'generated_files = ["uv.lock"]' in rendered
+    assert 'path = "pyproject.toml"' in rendered
+    assert 'kind = "pep621"' in rendered
+    assert 'ci_format = "pep440"' in rendered
+
+
+def test_recommend_init_config_for_hybrid_repo_sets_version_source(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "example"\nversion = "0.1.0"\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "package.json").write_text(
+        '{\n  "name": "example-web",\n  "version": "0.1.0"\n}\n',
+        encoding="utf-8",
+    )
+
+    rendered = recommend_init_config(tmp_path)
+
+    assert 'version_source = "pyproject.toml"' in rendered
+    assert 'path = "pyproject.toml"' in rendered
+    assert 'path = "package.json"' in rendered
+    assert "lock_command =" not in rendered
+    assert "generated_files =" not in rendered
+
+
+def test_cmd_init_writes_rrt_toml(monkeypatch, tmp_path: Path) -> None:
+    (tmp_path / "package.json").write_text(
+        '{\n  "name": "example",\n  "version": "1.2.3"\n}\n',
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    result = cmd_init(Namespace(dry_run=False, force=False))
+
+    assert result == 0
+    content = (tmp_path / ".rrt.toml").read_text(encoding="utf-8")
+    assert 'path = "package.json"' in content
+    assert 'kind = "package_json"' in content
+
+
+def test_cmd_init_dry_run_does_not_write_file(monkeypatch, tmp_path: Path, capsys) -> None:
+    (tmp_path / "Cargo.toml").write_text(
+        '[package]\nname = "example"\nversion = "0.4.0"\n',
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    result = cmd_init(Namespace(dry_run=True, force=False))
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert not (tmp_path / ".rrt.toml").exists()
+    assert "Would write .rrt.toml" in captured.out

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -15,7 +15,7 @@ def test_recommend_init_config_for_pep621_repo(tmp_path: Path) -> None:
 
     rendered = recommend_init_config(tmp_path)
 
-    assert '[tool.rrt]' in rendered
+    assert "[tool.rrt]" in rendered
     assert 'changelog_file = "CHANGELOG.md"' in rendered
     assert 'lock_command = ["uv", "lock", "-U"]' in rendered
     assert 'generated_files = ["uv.lock"]' in rendered

--- a/uv.lock
+++ b/uv.lock
@@ -163,7 +163,7 @@ wheels = [
 
 [[package]]
 name = "repo-release-tools"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
This pull request introduces a "zero-config" mode for version bumping and CI versioning, improves error handling and user guidance for configuration, and adds a new `init` command. It also updates documentation to reflect these enhancements and bumps the package version to 0.1.5.

**Zero-config support and improved configuration handling:**
- Added auto-detection of version files (`pyproject.toml`, `package.json`, `Cargo.toml`) for `bump` and `ci-version` commands, allowing basic usage without explicit `[tool.rrt]` configuration. All detected files must agree on the current version, or an error is shown. [[1]](diffhunk://#diff-4116106dd85450820afd623d3956a19164bef38d84928b7f8374cfc5f055a5a3L12-R47) [[2]](diffhunk://#diff-4116106dd85450820afd623d3956a19164bef38d84928b7f8374cfc5f055a5a3L64-R113) [[3]](diffhunk://#diff-26f9bed9a8ba88bd285b0de0dd9b1c0e498103b113d3ee9d33c29e6cced55154L34-R46) [[4]](diffhunk://#diff-26f9bed9a8ba88bd285b0de0dd9b1c0e498103b113d3ee9d33c29e6cced55154L132-R184) [[5]](diffhunk://#diff-26f9bed9a8ba88bd285b0de0dd9b1c0e498103b113d3ee9d33c29e6cced55154L178-R238)
- Improved error messages and guidance when configuration is missing or incomplete, including suggestions to run `rrt init` and clearer output for auto-detected or conflicting version files. [[1]](diffhunk://#diff-4116106dd85450820afd623d3956a19164bef38d84928b7f8374cfc5f055a5a3L64-R113) [[2]](diffhunk://#diff-26f9bed9a8ba88bd285b0de0dd9b1c0e498103b113d3ee9d33c29e6cced55154L132-R184) [[3]](diffhunk://#diff-26f9bed9a8ba88bd285b0de0dd9b1c0e498103b113d3ee9d33c29e6cced55154L178-R238)
- Added notices when running in zero-config mode and checks for version mismatches across detected files. [[1]](diffhunk://#diff-4116106dd85450820afd623d3956a19164bef38d84928b7f8374cfc5f055a5a3L64-R113) [[2]](diffhunk://#diff-26f9bed9a8ba88bd285b0de0dd9b1c0e498103b113d3ee9d33c29e6cced55154L132-R184)

**New command and CLI integration:**
- Added the `init` command to generate a recommended `.rrt.toml` configuration file, and registered it with the CLI. [[1]](diffhunk://#diff-377e07e060a095fde5dfb83d8d062afed7dd4b78e5016064659dbb20f853edd6L8-R8) [[2]](diffhunk://#diff-377e07e060a095fde5dfb83d8d062afed7dd4b78e5016064659dbb20f853edd6R21)

**Documentation updates:**
- Updated `README.md` and `docs/rrt-cli.md` to document zero-config mode, the `init` command, and clarified configuration file usage and workflow. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R17) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R28-R35) [[3]](diffhunk://#diff-12896542500295f7a93dd67807f82f480f0f03a704f8e3a864f696f38caf0a6eR20-R56) [[4]](diffhunk://#diff-12896542500295f7a93dd67807f82f480f0f03a704f8e3a864f696f38caf0a6eL37-R69)

**Project metadata and housekeeping:**
- Bumped the package version to 0.1.5 in `pyproject.toml` and `__init__.py`. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3) [[2]](diffhunk://#diff-53bd4ffed688f042108fe16db9b3d441ca5ab6039b1ecef76cf4a53eb1152c18L3-R3)
- Added `.serena` project files and updated `.gitignore` for Serena integration. [[1]](diffhunk://#diff-83dca83284565acb688107beee2bca23b0571fe2af934bdc28764a2c9a286bd9R1-R2) [[2]](diffhunk://#diff-fd53d15bc16f79894e36155c602091255f9f945f7097c34ba130953421f2ad84R1-R152)
- Updated pre-commit hook to use `ruff` version 0.15.9.