### PR TITLE
feat: Add Git workflows, safety checks, and log commands

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -26,3 +26,13 @@
   always_run: true
   stages: [commit-msg]
   minimum_pre_commit_version: "3.2.0"
+
+- id: rrt-dirty-tree
+  name: repo-release-tools dirty tree
+  description: Fail when the repository has uncommitted changes
+  entry: rrt-hooks check-dirty-tree
+  language: python
+  pass_filenames: false
+  always_run: true
+  stages: [manual, pre-push]
+  minimum_pre_commit_version: "3.2.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+## [0.1.6] - 2026-04-05
+
+### Added
+- `rrt git` workflow commands for status, log, doctor, sync, move, commit,
+  commit-all, squash-local, undo-safe, rebootstrap, and dirty-tree checks
+- reusable dirty-tree enforcement through `rrt-hooks check-dirty-tree` and an
+  optional GitHub Action input
+- a dedicated glyph registry for compact Git and diff rendering in terminal
+  output
+
+### Changed
+- CLI output now uses compact Git summaries and typed worktree entries for
+  status-oriented commands
+- documentation now includes a dedicated Git workflow page and a fuller
+  `rrt git` command reference

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # repo-release-tools
 
 `repo-release-tools` is a small product for conventional branches, changelog
-policy, and version bumps across local development, CI, and Copilot workflows.
+policy, version bumps, and opinionated Git workflows across local development,
+CI, and Copilot workflows.
 
 ## Product surfaces
 
@@ -16,6 +17,7 @@ policy, and version bumps across local development, CI, and Copilot workflows.
 pip install repo-release-tools
 rrt init
 rrt branch new feat "add parser"
+rrt git commit "add parser"
 rrt bump patch
 ```
 
@@ -75,9 +77,15 @@ and supported branch types.
 - [pre-commit](docs/pre-commit.md)
 - [Skill](docs/skill.md)
 - [Conventional branches](docs/semantic-branches.md)
+- [Git magic](docs/git-magic.md)
 
 ## License
 
 `repo-release-tools` is released under the MIT License.
+
+Some workflow ideas were initially inspired by
+[`joseluisq/gitnow`](https://github.com/joseluisq/gitnow), but the `rrt git`
+surface is intentionally narrower and reshaped around conventional branching,
+safe commits, and release automation.
 
 Built with ❤️ for safe, simple release automation.

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,9 @@ inputs:
   changelog-file:
     description: Explicit changelog path to validate
     default: "CHANGELOG.md"
+  check-dirty-tree:
+    description: Whether to fail when the checked-out work tree is dirty
+    default: "false"
 
 runs:
   using: composite
@@ -91,3 +94,11 @@ runs:
           --subject "$commit_subject" \
           --changelog-file "$INPUT_CHANGELOG_FILE" \
           --ref HEAD
+
+    - name: Validate clean working tree
+      if: inputs.check-dirty-tree == 'true'
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        set -euo pipefail
+        rrt-hooks check-dirty-tree

--- a/docs/git-magic.md
+++ b/docs/git-magic.md
@@ -1,0 +1,97 @@
+# Git magic
+
+`repo-release-tools` does not want to become a generic Git alias pack. The
+goal is narrower: ship a set of opinionated commit and branch workflows that
+protect release hygiene and stay reusable across CLI, hooks, and GitHub
+Actions.
+
+Some early workflow discussions were inspired by
+[`joseluisq/gitnow`](https://github.com/joseluisq/gitnow), but `rrt` reshapes
+the surface around conventional branches, commit policy, and release safety.
+
+## 10 magic commit frameworks
+
+1. Branch-driven commit drafting
+   Use `rrt git commit "message"` to infer the conventional commit type from the
+   current branch, keeping branch intent and commit intent aligned.
+2. Stage-and-commit sweep
+   Use `rrt git commit-all "message"` when you want one explicit snapshot
+   commit, but still want `rrt` to build the conventional subject.
+3. Dirty-tree sync
+   Use `rrt git sync` to fetch, auto-stash local work, pull, then restore the
+   worktree. Rebase is the default path because the product assumes linear
+   history where possible.
+4. Safe branch move
+   Use `rrt git move <branch>` to switch branches without manually juggling a
+   stash.
+5. Wrong-branch rescue
+   Use `rrt branch rescue <type> "description"` when commits landed on the wrong
+   branch and need to be moved into a correctly named branch.
+6. Local story squash
+   Use `rrt git squash-local "message"` to collapse a local branch into one
+   reviewable conventional commit before push.
+7. Safe undo
+   Use `rrt git undo-safe` or `rrt git undo-safe --keep-staged` to rewind a bad
+   commit without losing the work.
+8. Dirty-tree gate
+   Use `rrt git check-dirty-tree` when a hook, script, or CI job should fail if
+   the repo is not clean. The command now prints a compact branch status line
+   plus typed change entries for modified, added, removed, renamed, conflicted,
+   and untracked paths.
+9. Release bump envelope
+   Use `rrt bump ...` when the workflow should create the branch, stage the
+   version files, refresh generated files, and create the release commit in one
+   pass.
+10. History rebootstrap
+    Use `rrt git rebootstrap` only for deliberate history replacement, such as
+    templates or pre-publication cleanup. It stays behind a destructive
+    confirmation flag and remote guard.
+
+## Current command surface
+
+```bash
+rrt git status
+rrt git check-dirty-tree
+rrt git commit "handle empty config"
+rrt git commit-all "snapshot parser cleanup"
+rrt git sync
+rrt git move feat/new-parser
+rrt git squash-local "ship parser cleanup"
+rrt git undo-safe --keep-staged
+rrt git rebootstrap --yes-i-know-this-destroys-history --dry-run
+```
+
+## Reuse in hooks and Actions
+
+Yes. These workflows can later back both local hooks and GitHub Actions.
+
+The important point is to reuse the same low-level signals everywhere:
+
+- current branch name and inferred branch type
+- current commit subject and conventional-commit validity
+- dirty vs clean working tree
+- upstream configured vs missing
+- commits ahead of a base ref
+- changelog required vs missing
+
+`repo_release_tools.git.working_tree_clean()` already gives the dirty-tree
+signal, and the existing hook layer already validates branch names, commit
+subjects, and changelog requirements. `rrt-hooks check-dirty-tree` now exposes
+the same clean-worktree signal for reuse in hooks and GitHub Actions. The next
+step is to keep adding small, shared predicates like these instead of burying
+policy inside one CLI command.
+
+That gives one policy model with several entrypoints:
+
+- `rrt git ...` for interactive workflow
+- `rrt-hooks ...` for local enforcement
+- GitHub Actions for CI enforcement
+- future composite checks that compare branch state, commit subject, and dirty
+  tree status in one report
+
+## Design rules
+
+- Prefer workflows over aliases.
+- Prefer validation and preview over hidden Git side effects.
+- Keep destructive operations explicit and hard to trigger accidentally.
+- Keep commit generation aligned with conventional branches and release policy.

--- a/docs/git-magic.md
+++ b/docs/git-magic.md
@@ -51,6 +51,8 @@ the surface around conventional branches, commit policy, and release safety.
 
 ```bash
 rrt git status
+rrt git log -n 12
+rrt git doctor
 rrt git check-dirty-tree
 rrt git commit "handle empty config"
 rrt git commit-all "snapshot parser cleanup"
@@ -86,8 +88,8 @@ That gives one policy model with several entrypoints:
 - `rrt git ...` for interactive workflow
 - `rrt-hooks ...` for local enforcement
 - GitHub Actions for CI enforcement
-- future composite checks that compare branch state, commit subject, and dirty
-  tree status in one report
+- `rrt git doctor` for one-shot cross-checks of branch state, commit subject,
+  dirty tree status, upstream wiring, and changelog risk
 
 ## Design rules
 

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -12,6 +12,7 @@
     check-branch-name: "true"
     check-changelog: "true"
     check-commit-subject: "true"
+    check-dirty-tree: "false"
 ```
 
 ## What it checks
@@ -19,6 +20,7 @@
 - branch naming
 - changelog updates for feature/fix/breaking work
 - conventional commit subjects
+- optional clean-worktree enforcement
 
 ## Important behavior
 
@@ -31,10 +33,15 @@
 - `check-branch-name`
 - `check-changelog`
 - `check-commit-subject`
+- `check-dirty-tree`
 - `branch-name`
 - `branch-ref-type`
 - `commit-subject`
 - `changelog-file`
+
+`check-dirty-tree` defaults to `false` because a GitHub Action checkout is
+usually clean already. It is still useful for workflows that generate files and
+want to assert that the job did not leave uncommitted changes behind.
 
 ## Docs publishing
 

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -7,7 +7,7 @@
 ```yaml
 - uses: actions/checkout@v6
 
-- uses: Anselmoo/repo-release-tools@v0.1.0
+- uses: Anselmoo/repo-release-tools@v0.1.6
   with:
     check-branch-name: "true"
     check-changelog: "true"

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,7 @@ pre-commit, and Copilot skill entrypoints.
 - [pre-commit](pre-commit.md) — local hooks for branch, changelog, and commit checks
 - [Skill](skill.md) — Copilot CLI skill usage via `uvx`
 - [Conventional branches](semantic-branches.md) — branch naming model for trunk-based publishing
+- [Git magic](git-magic.md) — opinionated commit workflows and reusable Git safety checks
 
 ## What This Docs Set Covers
 
@@ -17,6 +18,7 @@ The docs are intentionally split so the landing page stays short:
 
 - the CLI and config model live in `rrt-cli.md`
 - branch policy and release naming live in `semantic-branches.md`
+- workflow design and Git safety checks live in `git-magic.md`
 - CI and local enforcement live in `github-action.md` and `pre-commit.md`
 - zero-install guidance lives in `skill.md`
 

--- a/docs/pre-commit.md
+++ b/docs/pre-commit.md
@@ -9,7 +9,7 @@ default_install_hook_types: [pre-commit, commit-msg]
 
 repos:
   - repo: https://github.com/Anselmoo/repo-release-tools
-    rev: v0.1.0
+    rev: v0.1.6
     hooks:
       - id: rrt-branch-name
       - id: rrt-changelog
@@ -39,7 +39,7 @@ clean repository before publishing work:
 ```yaml
 repos:
   - repo: https://github.com/Anselmoo/repo-release-tools
-    rev: v0.1.0
+    rev: v0.1.6
     hooks:
       - id: rrt-dirty-tree
         stages: [pre-push]

--- a/docs/pre-commit.md
+++ b/docs/pre-commit.md
@@ -27,3 +27,26 @@ pre-commit install --hook-type pre-commit --hook-type commit-msg
 - `rrt-branch-name` — validates branch names
 - `rrt-changelog` — requires staged changelog updates for feature/fix/breaking work
 - `rrt-commit-subject` — validates conventional commit subjects
+- `rrt-dirty-tree` — optional manual or pre-push check that fails on uncommitted changes
+
+## Dirty tree check
+
+`rrt-dirty-tree` is not enabled in the minimal config because a normal
+`pre-commit` run happens while the working tree is intentionally dirty. It is
+better suited for `pre-push` or manual execution when you want to enforce a
+clean repository before publishing work:
+
+```yaml
+repos:
+  - repo: https://github.com/Anselmoo/repo-release-tools
+    rev: v0.1.0
+    hooks:
+      - id: rrt-dirty-tree
+        stages: [pre-push]
+```
+
+You can also run the same logic directly:
+
+```bash
+rrt-hooks check-dirty-tree
+```

--- a/docs/rrt-cli.md
+++ b/docs/rrt-cli.md
@@ -20,10 +20,36 @@ uvx repo-release-tools branch new feat "add parser"
 rrt init
 rrt branch new feat "add parser"
 rrt branch rescue fix "recover release work"
+rrt git commit "add parser"
+rrt git sync
 rrt bump patch
 rrt bump minor --dry-run
 rrt bump 1.2.3 --no-changelog
 ```
+
+## Git workflows
+
+`rrt git` is intentionally not a full alias layer over raw Git. It focuses on
+repeatable workflows that match `repo-release-tools` policy:
+
+- `rrt git status` shows a compact branch summary and typed worktree entries
+- `rrt git commit "message"` builds a conventional commit and infers the type
+  from the current branch when possible
+- `rrt git commit-all "message"` stages all files first, then creates the
+  conventional commit
+- `rrt git sync` fetches, auto-stashes when needed, then pulls with rebase by
+  default, showing a compact branch/worktree summary in the preview panel
+- `rrt git move <branch>` switches branches without dropping local changes
+- `rrt git squash-local "message"` squashes local commits since upstream into
+  one conventional commit
+- `rrt git undo-safe` rewinds a commit while keeping work staged or unstaged
+- `rrt git check-dirty-tree` exits non-zero when the working tree is dirty, for
+  use in hooks and CI, with typed entries for dirty paths
+- `rrt git rebootstrap` destroys history and creates a fresh initial history,
+  guarded by an explicit confirmation flag
+
+See [Git magic](git-magic.md) for the design rationale and the full workflow
+catalog.
 
 ## Zero-config mode
 

--- a/docs/rrt-cli.md
+++ b/docs/rrt-cli.md
@@ -33,6 +33,9 @@ rrt bump 1.2.3 --no-changelog
 repeatable workflows that match `repo-release-tools` policy:
 
 - `rrt git status` shows a compact branch summary and typed worktree entries
+- `rrt git log` shows recent history in a compact `rrt`-styled view
+- `rrt git doctor` checks branch policy, upstream state, dirty tree, latest
+  commit subject, and changelog risk in one report
 - `rrt git commit "message"` builds a conventional commit and infers the type
   from the current branch when possible
 - `rrt git commit-all "message"` stages all files first, then creates the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "repo-release-tools"
-version = "0.1.5"
+version = "0.1.6"
 description = "Config-driven branch and release helpers for Git repositories"
 readme = "README.md"
 license = "MIT"

--- a/src/repo_release_tools/__init__.py
+++ b/src/repo_release_tools/__init__.py
@@ -1,3 +1,3 @@
 """repo-release-tools package."""
 
-__version__ = "0.1.5"
+__version__ = "0.1.6"

--- a/src/repo_release_tools/cli.py
+++ b/src/repo_release_tools/cli.py
@@ -5,19 +5,20 @@ from __future__ import annotations
 import argparse
 import sys
 
-from repo_release_tools.commands import branch, bump, ci_version, init
+from repo_release_tools.commands import branch, bump, ci_version, git_cmd, init
 
 
 def build_parser() -> argparse.ArgumentParser:
     """Build the root parser."""
     parser = argparse.ArgumentParser(
         prog="rrt",
-        description="repo-release-tools: branch and version helpers for Git repositories.",
+        description="repo-release-tools: branch, commit, and version helpers for Git repositories.",
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
     branch.register(subparsers)
     bump.register(subparsers)
     ci_version.register(subparsers)
+    git_cmd.register(subparsers)
     init.register(subparsers)
     return parser
 

--- a/src/repo_release_tools/commands/git_cmd.py
+++ b/src/repo_release_tools/commands/git_cmd.py
@@ -12,7 +12,14 @@ from pathlib import Path
 
 from repo_release_tools import git, output
 from repo_release_tools.commands.branch import CONVENTIONAL_TYPES, join_description
-from repo_release_tools.hooks import ALLOWED_BRANCH_NAMES, MAGIC_BRANCH_TYPES
+from repo_release_tools.hooks import (
+    ALLOWED_BRANCH_NAMES,
+    MAGIC_BRANCH_TYPES,
+    branch_requires_changelog,
+    changelog_is_updated,
+    validate_branch_name,
+    validate_commit_subject,
+)
 
 
 COMMIT_TYPES = (*CONVENTIONAL_TYPES, "deps")
@@ -186,6 +193,118 @@ def cmd_status(args: argparse.Namespace) -> int:
     for line in status_lines:
         print(render_status_entry(line))
     return 0
+
+
+def cmd_log(args: argparse.Namespace) -> int:
+    """Show a compact git log view using rrt glyphs."""
+    root = Path.cwd()
+    if not git.is_git_repository(root):
+        print(f"{root} is not inside a Git work tree.", file=sys.stderr)
+        return 1
+
+    raw = git.capture(
+        ["git", "log", f"-n{args.limit}", "--pretty=format:%h%x09%s%x09%D"],
+        root,
+    )
+    lines = [line for line in raw.splitlines() if line.strip()]
+
+    print()
+    print(output.panel("Git log", [("Count", str(len(lines))), ("Limit", str(args.limit))]))
+    print()
+
+    if not lines:
+        print(output.warning("No commits found."))
+        return 0
+
+    for line in lines:
+        sha, subject, *rest = line.split("\t", 2)
+        refs_raw = rest[0] if rest else ""
+        refs = [ref.strip() for ref in refs_raw.split(",") if ref.strip()]
+        print(
+            output.status(output.GLYPHS.bullet.dot, output.GLYPHS.git.log_line(sha, subject, refs))
+        )
+    return 0
+
+
+def cmd_doctor(args: argparse.Namespace) -> int:
+    """Run a compact repository health report for rrt workflows."""
+    root = Path.cwd()
+    if not git.is_git_repository(root):
+        print(f"{root} is not inside a Git work tree.", file=sys.stderr)
+        return 1
+
+    branch_name = git.current_branch(root) or "<detached>"
+    upstream = git.upstream_branch(root)
+    status_lines = git.status_porcelain(root)
+    latest_subject = git.capture(["git", "log", "-1", "--pretty=%s"], root).strip()
+
+    branch_problem = validate_branch_name(branch_name)
+    subject_problem = (
+        validate_commit_subject(latest_subject) if latest_subject else "No commits found."
+    )
+    dirty_problem = None if not status_lines else "Working tree has uncommitted changes."
+
+    changelog_problem: str | None = None
+    if latest_subject and branch_requires_changelog(branch_name):
+        changed_files = git.capture(
+            ["git", "diff-tree", "--no-commit-id", "--name-only", "--root", "-r", "HEAD"],
+            root,
+        )
+        changed = [line for line in changed_files.splitlines() if line.strip()]
+        if not changelog_is_updated(changed, changelog_file=args.changelog_file, cwd=root):
+            changelog_problem = (
+                f"Branch {branch_name!r} suggests changelog work, but {args.changelog_file} "
+                "is not part of HEAD."
+            )
+
+    summary = summarize_status(branch_name, status_lines, upstream=upstream)
+    print()
+    print(
+        output.panel(
+            "Git doctor",
+            [
+                ("Branch", branch_name),
+                ("Upstream", upstream or "<none>"),
+                ("Status", summary),
+                ("Commit", latest_subject or "<none>"),
+            ],
+        )
+    )
+    print()
+
+    print(output.section("Checks"))
+    failures = 0
+
+    checks: list[tuple[bool, str]] = [
+        (branch_problem is None, "Branch naming matches rrt policy."),
+        (upstream is not None, "Upstream branch is configured."),
+        (dirty_problem is None, "Working tree is clean."),
+        (subject_problem is None, "Latest commit subject is conventional."),
+        (changelog_problem is None, f"Changelog state is valid for {args.changelog_file}."),
+    ]
+    problems = [
+        branch_problem or "",
+        "No upstream branch configured." if upstream is None else "",
+        dirty_problem or "",
+        subject_problem or "",
+        changelog_problem or "",
+    ]
+
+    for (ok, success), problem in zip(checks, problems, strict=True):
+        if ok:
+            print(output.ok(success))
+            continue
+        failures += 1
+        print(output.error(problem))
+
+    if failures == 0:
+        print()
+        print(output.ok("Doctor checks passed."))
+        return 0
+
+    print()
+    print(output.warning(f"Doctor found {failures} issue(s)."), file=sys.stderr)
+    return 1
 
 
 def cmd_check_dirty_tree(args: argparse.Namespace) -> int:
@@ -592,6 +711,30 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
         help="Show a compact branch and worktree status view.",
     )
     status_parser.set_defaults(handler=cmd_status)
+
+    log_parser = git_sub.add_parser(
+        "log",
+        help="Show a compact commit history view.",
+    )
+    log_parser.add_argument(
+        "-n",
+        "--limit",
+        default=10,
+        type=int,
+        help="Number of commits to show.",
+    )
+    log_parser.set_defaults(handler=cmd_log)
+
+    doctor_parser = git_sub.add_parser(
+        "doctor",
+        help="Run a compact repository health report for rrt workflows.",
+    )
+    doctor_parser.add_argument(
+        "--changelog-file",
+        default="CHANGELOG.md",
+        help="Changelog path used for doctor checks.",
+    )
+    doctor_parser.set_defaults(handler=cmd_doctor)
 
     dirty_parser = git_sub.add_parser(
         "check-dirty-tree",

--- a/src/repo_release_tools/commands/git_cmd.py
+++ b/src/repo_release_tools/commands/git_cmd.py
@@ -15,8 +15,8 @@ from repo_release_tools.commands.branch import CONVENTIONAL_TYPES, join_descript
 from repo_release_tools.hooks import (
     ALLOWED_BRANCH_NAMES,
     MAGIC_BRANCH_TYPES,
-    branch_requires_changelog,
     changelog_is_updated,
+    commit_subject_requires_changelog,
     validate_branch_name,
     validate_commit_subject,
 )
@@ -160,6 +160,14 @@ def summarize_status(branch_name: str, status_lines: list[str], *, upstream: str
     )
 
 
+def load_status_lines(root: Path) -> list[str]:
+    """Load status lines or raise a user-facing runtime error."""
+    try:
+        return git.status_porcelain(root)
+    except RuntimeError as exc:
+        raise RuntimeError(str(exc)) from exc
+
+
 def cmd_status(args: argparse.Namespace) -> int:
     """Show a compact repository status view."""
     root = Path.cwd()
@@ -169,7 +177,11 @@ def cmd_status(args: argparse.Namespace) -> int:
 
     branch_name = git.current_branch(root) or "<detached>"
     upstream = git.upstream_branch(root)
-    status_lines = git.status_porcelain(root)
+    try:
+        status_lines = load_status_lines(root)
+    except RuntimeError as exc:
+        print(output.error(str(exc)), file=sys.stderr)
+        return 1
     summary = summarize_status(branch_name, status_lines, upstream=upstream)
 
     print()
@@ -235,7 +247,11 @@ def cmd_doctor(args: argparse.Namespace) -> int:
 
     branch_name = git.current_branch(root) or "<detached>"
     upstream = git.upstream_branch(root)
-    status_lines = git.status_porcelain(root)
+    try:
+        status_lines = load_status_lines(root)
+    except RuntimeError as exc:
+        print(output.error(str(exc)), file=sys.stderr)
+        return 1
     latest_subject = git.capture(["git", "log", "-1", "--pretty=%s"], root).strip()
 
     branch_problem = validate_branch_name(branch_name)
@@ -245,7 +261,7 @@ def cmd_doctor(args: argparse.Namespace) -> int:
     dirty_problem = None if not status_lines else "Working tree has uncommitted changes."
 
     changelog_problem: str | None = None
-    if latest_subject and branch_requires_changelog(branch_name):
+    if latest_subject and commit_subject_requires_changelog(latest_subject):
         changed_files = git.capture(
             ["git", "diff-tree", "--no-commit-id", "--name-only", "--root", "-r", "HEAD"],
             root,
@@ -327,7 +343,11 @@ def cmd_check_dirty_tree(args: argparse.Namespace) -> int:
 
     branch_name = git.current_branch(root) or "<detached>"
     upstream = git.upstream_branch(root)
-    changed = git.status_porcelain(root)
+    try:
+        changed = load_status_lines(root)
+    except RuntimeError as exc:
+        print(output.error(str(exc)), file=sys.stderr)
+        return 1
     print(output.warning("Working tree has uncommitted changes."), file=sys.stderr)
     print(
         output.status(
@@ -402,7 +422,11 @@ def cmd_sync(args: argparse.Namespace) -> int:
         return 1
 
     dirty = not git.working_tree_clean(root)
-    status_lines = git.status_porcelain(root)
+    try:
+        status_lines = load_status_lines(root)
+    except RuntimeError as exc:
+        print(output.error(str(exc)), file=sys.stderr)
+        return 1
     strategy = "merge" if args.merge else "rebase"
     title = "[DRY RUN] Sync" if args.dry_run else "Sync"
     print()

--- a/src/repo_release_tools/commands/git_cmd.py
+++ b/src/repo_release_tools/commands/git_cmd.py
@@ -388,6 +388,9 @@ def cmd_commit_all(args: argparse.Namespace) -> int:
 def cmd_sync(args: argparse.Namespace) -> int:
     """Fetch, stash when needed, and pull the current branch."""
     root = Path.cwd()
+    if not git.is_git_repository(root):
+        print(output.error(f"{root} is not inside a Git work tree."), file=sys.stderr)
+        return 1
     branch_name = git.current_branch(root) or "<detached>"
     upstream = git.upstream_branch(root)
     if upstream is None:
@@ -454,6 +457,9 @@ def cmd_sync(args: argparse.Namespace) -> int:
 def cmd_move(args: argparse.Namespace) -> int:
     """Switch branches safely by stashing and restoring local changes."""
     root = Path.cwd()
+    if not git.is_git_repository(root):
+        print(output.error(f"{root} is not inside a Git work tree."), file=sys.stderr)
+        return 1
     current = git.current_branch(root) or "<detached>"
     dirty = not git.working_tree_clean(root)
     target_label = f"new branch {args.target}" if args.create else args.target

--- a/src/repo_release_tools/commands/git_cmd.py
+++ b/src/repo_release_tools/commands/git_cmd.py
@@ -1,0 +1,709 @@
+"""Opinionated Git workflow helpers for rrt."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import shutil
+import sys
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from repo_release_tools import git, output
+from repo_release_tools.commands.branch import CONVENTIONAL_TYPES, join_description
+from repo_release_tools.hooks import ALLOWED_BRANCH_NAMES, MAGIC_BRANCH_TYPES
+
+
+COMMIT_TYPES = (*CONVENTIONAL_TYPES, "deps")
+DEFAULT_REBOOTSTRAP_EMPTY_MESSAGE = "chore: bootstrap repository"
+DEFAULT_REBOOTSTRAP_MESSAGE = "chore: initial commit"
+MOVE_STASH_MESSAGE = "rrt git move auto-stash"
+SYNC_STASH_MESSAGE = "rrt git sync auto-stash"
+
+
+@dataclass(frozen=True)
+class CommitSubject:
+    """A conventional commit subject assembled from CLI input."""
+
+    type: str
+    description: str
+    scope: str | None = None
+    breaking: bool = False
+
+    def render(self) -> str:
+        """Return the conventional commit subject."""
+        scope_part = f"({self.scope})" if self.scope else ""
+        breaking_part = "!" if self.breaking else ""
+        return f"{self.type}{scope_part}{breaking_part}: {self.description}"
+
+
+def normalize_commit_subject_type(value: str) -> str:
+    """Validate a commit type accepted by commit helpers."""
+    normalized = value.lower()
+    if normalized not in COMMIT_TYPES:
+        allowed = ", ".join(COMMIT_TYPES)
+        raise argparse.ArgumentTypeError(
+            f"invalid commit type: {value!r} (choose one of: {allowed})"
+        )
+    return normalized
+
+
+def infer_commit_type(branch_name: str) -> str | None:
+    """Infer a conventional commit type from the current branch name."""
+    if (
+        not branch_name
+        or branch_name in ALLOWED_BRANCH_NAMES
+        or branch_name.startswith("release/v")
+        or "/" not in branch_name
+    ):
+        return None
+
+    type_part, _ = branch_name.split("/", 1)
+    if type_part in MAGIC_BRANCH_TYPES:
+        return None
+    if type_part in CONVENTIONAL_TYPES:
+        return type_part
+    return None
+
+
+def resolve_commit_subject(args: argparse.Namespace, root: Path) -> tuple[str, str]:
+    """Resolve the current branch and conventional commit subject."""
+    branch_name = git.current_branch(root)
+    commit_type = args.type or infer_commit_type(branch_name)
+    if commit_type is None:
+        raise ValueError(
+            "Could not infer a conventional commit type from the current branch. "
+            "Use --type explicitly."
+        )
+
+    subject = CommitSubject(
+        type=commit_type,
+        description=join_description(args.description),
+        scope=args.scope,
+        breaking=args.breaking,
+    ).render()
+    return branch_name or "<detached>", subject
+
+
+def backup_path_for_git_dir(root: Path) -> Path:
+    """Return an external backup path for the current .git directory."""
+    stamp = dt.datetime.now(dt.UTC).strftime("%Y%m%d%H%M%S")
+    return root.parent / f".{root.name}.git-backup-{stamp}"
+
+
+def require_explicit_confirmation(args: argparse.Namespace) -> bool:
+    """Return whether the destructive rebootstrap command is confirmed."""
+    return bool(args.yes_i_know_this_destroys_history)
+
+
+def classify_status_line(line: str) -> tuple[str, str]:
+    """Classify a porcelain status line into a compact diff category."""
+    status_code = line[:2]
+    path_text = line[3:] if len(line) > 3 else line
+    if status_code == "??":
+        return ("untracked", path_text)
+    if "U" in status_code or status_code in {"AA", "DD"}:
+        return ("conflict", path_text)
+    if "R" in status_code or "C" in status_code:
+        return ("renamed", path_text)
+    if "A" in status_code:
+        return ("added", path_text)
+    if "D" in status_code:
+        return ("removed", path_text)
+    return ("modified", path_text)
+
+
+def render_status_entry(line: str) -> str:
+    """Render one git status line with a typed glyph."""
+    kind, path_text = classify_status_line(line)
+    symbol_map = {
+        "added": output.GLYPHS.diff.added,
+        "removed": output.GLYPHS.diff.removed,
+        "modified": output.GLYPHS.diff.modified,
+        "renamed": output.GLYPHS.diff.renamed,
+        "conflict": output.GLYPHS.diff.conflict,
+        "untracked": output.GLYPHS.git.untracked,
+    }
+    return output.status(symbol_map[kind], path_text)
+
+
+def summarize_status(branch_name: str, status_lines: list[str], *, upstream: str | None) -> str:
+    """Render a compact one-line branch status summary."""
+    modified = 0
+    untracked = 0
+    for line in status_lines:
+        kind, _ = classify_status_line(line)
+        if kind == "untracked":
+            untracked += 1
+        else:
+            modified += 1
+
+    ahead = 0
+    behind = 0
+    if upstream is not None:
+        ahead, behind = git.ahead_behind(Path.cwd(), upstream)
+
+    return output.GLYPHS.git.status_line(
+        branch_name,
+        ahead=ahead,
+        behind=behind,
+        modified=modified,
+        untracked=untracked,
+    )
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    """Show a compact repository status view."""
+    root = Path.cwd()
+    if not git.is_git_repository(root):
+        print(f"{root} is not inside a Git work tree.", file=sys.stderr)
+        return 1
+
+    branch_name = git.current_branch(root) or "<detached>"
+    upstream = git.upstream_branch(root)
+    status_lines = git.status_porcelain(root)
+    summary = summarize_status(branch_name, status_lines, upstream=upstream)
+
+    print()
+    print(
+        output.panel(
+            "Git status",
+            [
+                ("Branch", branch_name),
+                ("Upstream", upstream or "<none>"),
+                ("Status", summary),
+            ],
+        )
+    )
+    print()
+
+    if not status_lines:
+        print(output.ok("Working tree is clean."))
+        return 0
+
+    print(output.section("Changes"))
+    for line in status_lines:
+        print(render_status_entry(line))
+    return 0
+
+
+def cmd_check_dirty_tree(args: argparse.Namespace) -> int:
+    """Return non-zero when the working tree is dirty."""
+    root = Path.cwd()
+    if not git.is_git_repository(root):
+        print(f"{root} is not inside a Git work tree.", file=sys.stderr)
+        return 1
+    clean = git.working_tree_clean(root)
+    if clean:
+        branch_name = git.current_branch(root) or "<detached>"
+        upstream = git.upstream_branch(root)
+        print(output.ok("Working tree is clean."))
+        print(
+            output.status(
+                output.GLYPHS.bullet.dot, summarize_status(branch_name, [], upstream=upstream)
+            )
+        )
+        return 0
+
+    branch_name = git.current_branch(root) or "<detached>"
+    upstream = git.upstream_branch(root)
+    changed = git.status_porcelain(root)
+    print(output.warning("Working tree has uncommitted changes."), file=sys.stderr)
+    print(
+        output.status(
+            output.GLYPHS.bullet.dot, summarize_status(branch_name, changed, upstream=upstream)
+        ),
+        file=sys.stderr,
+    )
+    for line in changed:
+        print(render_status_entry(line), file=sys.stderr)
+    return 1
+
+
+def run_commit(args: argparse.Namespace, *, stage_all: bool) -> int:
+    """Create a conventional commit, optionally staging all files first."""
+    root = Path.cwd()
+    try:
+        branch_name, subject = resolve_commit_subject(args, root)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    title = "[DRY RUN] Commit" if args.dry_run else "Commit"
+    print()
+    print(
+        output.panel(
+            title,
+            [
+                ("Branch", branch_name),
+                ("Mode", "stage all" if stage_all else "commit only"),
+                ("Subject", subject),
+            ],
+        )
+    )
+    print()
+
+    print(output.section("Git"))
+    if stage_all:
+        git.run(["git", "add", "."], root, dry_run=args.dry_run, label="git add")
+    git.run(["git", "commit", "-m", subject], root, dry_run=args.dry_run, label="git commit")
+
+    print()
+    print(output.ok(f"Done. Created commit: {subject!r}"))
+    if args.dry_run:
+        print(output.dry_run_complete("no changes made"))
+    return 0
+
+
+def cmd_commit(args: argparse.Namespace) -> int:
+    """Create a conventional commit from the current branch context."""
+    return run_commit(args, stage_all=False)
+
+
+def cmd_commit_all(args: argparse.Namespace) -> int:
+    """Stage all tracked and untracked files, then create a conventional commit."""
+    return run_commit(args, stage_all=True)
+
+
+def cmd_sync(args: argparse.Namespace) -> int:
+    """Fetch, stash when needed, and pull the current branch."""
+    root = Path.cwd()
+    branch_name = git.current_branch(root) or "<detached>"
+    upstream = git.upstream_branch(root)
+    if upstream is None:
+        print(
+            "No upstream branch is configured for the current branch. "
+            "Set one first or use git push -u.",
+            file=sys.stderr,
+        )
+        return 1
+
+    dirty = not git.working_tree_clean(root)
+    status_lines = git.status_porcelain(root)
+    strategy = "merge" if args.merge else "rebase"
+    title = "[DRY RUN] Sync" if args.dry_run else "Sync"
+    print()
+    print(
+        output.panel(
+            title,
+            [
+                ("Branch", branch_name),
+                ("Upstream", upstream),
+                ("Strategy", strategy),
+                ("Working tree", "dirty" if dirty else "clean"),
+                ("Status", summarize_status(branch_name, status_lines, upstream=upstream)),
+            ],
+        )
+    )
+    print()
+
+    print(output.section("Syncing"))
+    git.run(["git", "fetch", "--prune"], root, dry_run=args.dry_run, label="git fetch")
+    if dirty:
+        git.run(
+            ["git", "stash", "push", "-u", "-m", SYNC_STASH_MESSAGE],
+            root,
+            dry_run=args.dry_run,
+            label="git stash push",
+        )
+
+    pull_command = ["git", "pull"]
+    if not args.merge:
+        pull_command.append("--rebase")
+
+    try:
+        git.run(pull_command, root, dry_run=args.dry_run, label="git pull")
+    except RuntimeError:
+        if dirty and not args.dry_run:
+            print(
+                output.warning("Pull failed. The auto-stash remains on the stash stack."),
+                file=sys.stderr,
+            )
+        raise
+
+    if dirty:
+        git.run(["git", "stash", "pop"], root, dry_run=args.dry_run, label="git stash pop")
+
+    print()
+    print(output.ok(f"Done. {branch_name} is synced from {upstream} using {strategy}."))
+    if args.dry_run:
+        print(output.dry_run_complete("working tree preserved"))
+    return 0
+
+
+def cmd_move(args: argparse.Namespace) -> int:
+    """Switch branches safely by stashing and restoring local changes."""
+    root = Path.cwd()
+    current = git.current_branch(root) or "<detached>"
+    dirty = not git.working_tree_clean(root)
+    target_label = f"new branch {args.target}" if args.create else args.target
+    title = "[DRY RUN] Move" if args.dry_run else "Move"
+    print()
+    print(
+        output.panel(
+            title,
+            [
+                ("From", current),
+                ("To", target_label),
+                ("Working tree", "dirty" if dirty else "clean"),
+            ],
+        )
+    )
+    print()
+
+    print(output.section("Switching"))
+    if dirty:
+        git.run(
+            ["git", "stash", "push", "-u", "-m", MOVE_STASH_MESSAGE],
+            root,
+            dry_run=args.dry_run,
+            label="git stash push",
+        )
+
+    checkout = (
+        ["git", "checkout", "-b", args.target] if args.create else ["git", "checkout", args.target]
+    )
+    try:
+        git.run(checkout, root, dry_run=args.dry_run, label="git checkout")
+    except RuntimeError:
+        if dirty and not args.dry_run:
+            print(
+                output.warning("Branch switch failed. The auto-stash remains on the stash stack."),
+                file=sys.stderr,
+            )
+        raise
+
+    if dirty:
+        git.run(["git", "stash", "pop"], root, dry_run=args.dry_run, label="git stash pop")
+
+    print()
+    print(output.ok(f"Done. Switched to {args.target!r}."))
+    if args.dry_run:
+        print(output.dry_run_complete("branch switch preview only"))
+    return 0
+
+
+def cmd_squash_local(args: argparse.Namespace) -> int:
+    """Squash local commits since a base ref into one conventional commit."""
+    root = Path.cwd()
+    if not args.dry_run and not git.working_tree_clean(root):
+        print("Working tree has uncommitted changes. Commit or stash them first.", file=sys.stderr)
+        return 1
+
+    base_ref = args.base_ref or git.upstream_branch(root)
+    if base_ref is None:
+        print("No upstream branch is configured and no --base-ref was provided.", file=sys.stderr)
+        return 1
+
+    try:
+        branch_name, subject = resolve_commit_subject(args, root)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    commits = git.commits_ahead(root, base_ref)
+    if not commits:
+        print(f"No commits found ahead of {base_ref!r}. Nothing to squash.", file=sys.stderr)
+        return 1
+
+    squash_base = git.merge_base(root, base_ref)
+    if squash_base is None:
+        print(f"Could not determine merge-base for {base_ref!r} and HEAD.", file=sys.stderr)
+        return 1
+
+    title = "[DRY RUN] Squash local" if args.dry_run else "Squash local"
+    print()
+    print(
+        output.panel(
+            title,
+            [
+                ("Branch", branch_name),
+                ("Base", base_ref),
+                ("Commits", str(len(commits))),
+                ("Subject", subject),
+            ],
+        )
+    )
+    print()
+
+    print(output.section("Commits to squash"))
+    for line in commits:
+        print(output.status(output.GLYPHS.bullet.dot, line))
+
+    print(f"\n{output.section('Squashing')}")
+    git.run(
+        ["git", "reset", "--soft", squash_base],
+        root,
+        dry_run=args.dry_run,
+        label="git reset --soft",
+    )
+    git.run(["git", "commit", "-m", subject], root, dry_run=args.dry_run, label="git commit")
+
+    print()
+    print(output.ok(f"Done. Squashed {len(commits)} commit(s) into {subject!r}."))
+    if args.dry_run:
+        print(output.dry_run_complete("commit graph preserved"))
+    return 0
+
+
+def cmd_undo_safe(args: argparse.Namespace) -> int:
+    """Undo the last commit while keeping work in the index or working tree."""
+    mode = "--soft" if args.keep_staged else "--mixed"
+    title = "[DRY RUN] Undo safe" if args.dry_run else "Undo safe"
+    print()
+    print(
+        output.panel(
+            title,
+            [
+                ("Target", args.target),
+                ("Mode", "keep staged" if args.keep_staged else "keep files"),
+            ],
+        )
+    )
+    print()
+
+    git.run(
+        ["git", "reset", mode, args.target],
+        Path.cwd(),
+        dry_run=args.dry_run,
+        label="git reset",
+    )
+    print()
+    print(output.ok(f"Done. Reset to {args.target!r} using {mode}."))
+    if args.dry_run:
+        print(output.dry_run_complete("HEAD unchanged"))
+    return 0
+
+
+def cmd_rebootstrap(args: argparse.Namespace) -> int:
+    """Remove repository history and create a fresh initial history."""
+    root = Path.cwd()
+    git_dir = root / ".git"
+    if not git_dir.exists():
+        print(f"{root} does not look like a Git repository.", file=sys.stderr)
+        return 1
+    if not require_explicit_confirmation(args):
+        print(
+            "Refusing to destroy repository history without --yes-i-know-this-destroys-history.",
+            file=sys.stderr,
+        )
+        return 1
+
+    remotes = git.remote_names(root)
+    if remotes and not args.allow_remote:
+        print(
+            "Refusing to rebootstrap a repository with configured remotes. "
+            "Use --allow-remote if that is intentional.",
+            file=sys.stderr,
+        )
+        return 1
+
+    branch_name = args.branch or git.current_branch(root) or "main"
+    backup_path = backup_path_for_git_dir(root)
+    title = "[DRY RUN] Rebootstrap history" if args.dry_run else "Rebootstrap history"
+    print()
+    print(
+        output.panel(
+            title,
+            [
+                ("Branch", branch_name),
+                ("Backup", str(backup_path)),
+                ("Remote guard", "ignored" if args.allow_remote else "enabled"),
+                ("Commit", args.message),
+            ],
+        )
+    )
+    print()
+
+    print(output.section("Reinitializing"))
+    if args.dry_run:
+        print(output.dry_run(f"Would move {git_dir} to {backup_path}"))
+        git.run(["git", "init", "-b", branch_name], root, dry_run=True, label="git init")
+        if args.empty_first:
+            git.run(
+                ["git", "commit", "--allow-empty", "-m", args.empty_message],
+                root,
+                dry_run=True,
+                label="git commit --allow-empty",
+            )
+        git.run(["git", "add", "."], root, dry_run=True, label="git add")
+        git.run(["git", "commit", "-m", args.message], root, dry_run=True, label="git commit")
+        print()
+        print(output.dry_run_complete("history preserved via preview only"))
+        return 0
+
+    shutil.move(str(git_dir), str(backup_path))
+    print(output.action(f"Moved original git data to {backup_path}"))
+
+    try:
+        git.run(["git", "init", "-b", branch_name], root, dry_run=False, label="git init")
+        if args.empty_first:
+            git.run(
+                ["git", "commit", "--allow-empty", "-m", args.empty_message],
+                root,
+                dry_run=False,
+                label="git commit --allow-empty",
+            )
+        git.run(["git", "add", "."], root, dry_run=False, label="git add")
+        git.run(["git", "commit", "-m", args.message], root, dry_run=False, label="git commit")
+    except RuntimeError as exc:
+        print(
+            output.warning(f"Rebootstrap failed. Original git data is backed up at {backup_path}."),
+            file=sys.stderr,
+        )
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    print()
+    print(output.ok(f"Done. Repository history reinitialized on {branch_name!r}."))
+    print(output.status(output.GLYPHS.bullet.dot, f"Original git data: {backup_path}"))
+    return 0
+
+
+def add_dry_run_flag(parser: argparse.ArgumentParser) -> None:
+    """Register a shared dry-run flag."""
+    parser.add_argument("--dry-run", action="store_true", help="Preview without changing git.")
+
+
+def add_commit_arguments(parser: argparse.ArgumentParser) -> None:
+    """Register shared commit drafting arguments."""
+    parser.add_argument("description", nargs="+", help="Commit description words.")
+    parser.add_argument(
+        "--type",
+        dest="type",
+        default=None,
+        type=normalize_commit_subject_type,
+        metavar="TYPE",
+        help="Explicit conventional commit type. Defaults to the current branch type.",
+    )
+    parser.add_argument("--scope", default=None, metavar="SCOPE", help="Optional commit scope.")
+    parser.add_argument("--breaking", action="store_true", help="Mark the commit as breaking.")
+    add_dry_run_flag(parser)
+
+
+def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    """Register the git command group."""
+    parser = subparsers.add_parser("git", help="Git workflow helpers.")
+    git_sub = parser.add_subparsers(dest="git_command", required=True)
+
+    status_parser = git_sub.add_parser(
+        "status",
+        help="Show a compact branch and worktree status view.",
+    )
+    status_parser.set_defaults(handler=cmd_status)
+
+    dirty_parser = git_sub.add_parser(
+        "check-dirty-tree",
+        help="Exit non-zero when the working tree is dirty. Useful in hooks and CI.",
+    )
+    dirty_parser.set_defaults(handler=cmd_check_dirty_tree)
+
+    commit_parser = git_sub.add_parser(
+        "commit",
+        help="Create a conventional commit, inferring type from the current branch.",
+    )
+    add_commit_arguments(commit_parser)
+    commit_parser.set_defaults(handler=cmd_commit)
+
+    commit_all_parser = git_sub.add_parser(
+        "commit-all",
+        help="Stage all files and create a conventional commit from the branch context.",
+    )
+    add_commit_arguments(commit_all_parser)
+    commit_all_parser.set_defaults(handler=cmd_commit_all)
+
+    sync_parser = git_sub.add_parser(
+        "sync",
+        help="Fetch, stash if needed, and pull the current branch safely.",
+    )
+    sync_parser.add_argument(
+        "--merge",
+        action="store_true",
+        help="Use plain git pull instead of git pull --rebase.",
+    )
+    add_dry_run_flag(sync_parser)
+    sync_parser.set_defaults(handler=cmd_sync)
+
+    move_parser = git_sub.add_parser(
+        "move",
+        help="Switch branches safely by stashing and restoring local changes.",
+    )
+    move_parser.add_argument("target", help="Target branch name.")
+    move_parser.add_argument(
+        "-b",
+        "--create",
+        action="store_true",
+        help="Create the target branch before switching to it.",
+    )
+    add_dry_run_flag(move_parser)
+    move_parser.set_defaults(handler=cmd_move)
+
+    squash_parser = git_sub.add_parser(
+        "squash-local",
+        help="Squash local commits since upstream or a base ref into one commit.",
+    )
+    add_commit_arguments(squash_parser)
+    squash_parser.add_argument(
+        "--base-ref",
+        default=None,
+        metavar="REF",
+        help="Base ref to squash against. Defaults to the current upstream branch.",
+    )
+    squash_parser.set_defaults(handler=cmd_squash_local)
+
+    undo_parser = git_sub.add_parser(
+        "undo-safe",
+        help="Undo a commit while keeping work staged or in the working tree.",
+    )
+    undo_parser.add_argument(
+        "--target",
+        default="HEAD~1",
+        metavar="REF",
+        help="Ref to reset to. Defaults to HEAD~1.",
+    )
+    undo_parser.add_argument(
+        "--keep-staged",
+        action="store_true",
+        help="Use git reset --soft so changes stay staged.",
+    )
+    add_dry_run_flag(undo_parser)
+    undo_parser.set_defaults(handler=cmd_undo_safe)
+
+    rebootstrap_parser = git_sub.add_parser(
+        "rebootstrap",
+        help="Destroy current git history and create a fresh repository history.",
+    )
+    rebootstrap_parser.add_argument(
+        "--yes-i-know-this-destroys-history",
+        action="store_true",
+        help="Required confirmation for the destructive history reset.",
+    )
+    rebootstrap_parser.add_argument(
+        "--allow-remote",
+        action="store_true",
+        help="Allow rebootstrap even when remotes are configured.",
+    )
+    rebootstrap_parser.add_argument(
+        "--branch",
+        default=None,
+        metavar="BRANCH",
+        help="Initial branch name for the new repository. Defaults to the current branch.",
+    )
+    rebootstrap_parser.add_argument(
+        "--message",
+        default=DEFAULT_REBOOTSTRAP_MESSAGE,
+        help="Commit message for the new initial commit.",
+    )
+    rebootstrap_parser.add_argument(
+        "--empty-first",
+        action="store_true",
+        help="Create an empty bootstrap commit before adding files.",
+    )
+    rebootstrap_parser.add_argument(
+        "--empty-message",
+        default=DEFAULT_REBOOTSTRAP_EMPTY_MESSAGE,
+        help="Commit message for the optional empty bootstrap commit.",
+    )
+    add_dry_run_flag(rebootstrap_parser)
+    rebootstrap_parser.set_defaults(handler=cmd_rebootstrap)

--- a/src/repo_release_tools/git.py
+++ b/src/repo_release_tools/git.py
@@ -99,8 +99,16 @@ def status_porcelain(cwd: Path, *, include_branch: bool = False) -> list[str]:
     command = ["git", "status", "--short"]
     if include_branch:
         command.append("--branch")
-    out = capture(command, cwd)
-    return [line for line in out.splitlines() if line.strip()]
+    result = subprocess.run(
+        command,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return []
+    return [line for line in result.stdout.splitlines() if line]
 
 
 def upstream_branch(cwd: Path) -> str | None:

--- a/src/repo_release_tools/git.py
+++ b/src/repo_release_tools/git.py
@@ -107,7 +107,7 @@ def status_porcelain(cwd: Path, *, include_branch: bool = False) -> list[str]:
         check=False,
     )
     if result.returncode != 0:
-        return []
+        raise RuntimeError(f"git status --short failed (exit {result.returncode})")
     return [line for line in result.stdout.splitlines() if line]
 
 

--- a/src/repo_release_tools/git.py
+++ b/src/repo_release_tools/git.py
@@ -61,10 +61,91 @@ def branch_exists(cwd: Path, branch: str) -> bool:
 
 def working_tree_clean(cwd: Path) -> bool:
     """Return whether the repository has no uncommitted changes."""
-    return capture(["git", "status", "--porcelain"], cwd) == ""
+    result = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.returncode == 0 and result.stdout.strip() == ""
 
 
 def commits_ahead(cwd: Path, base_ref: str) -> list[str]:
     """Return short log lines for commits on HEAD not in the base ref."""
     out = capture(["git", "log", f"{base_ref}..HEAD", "--pretty=format:%h %s"], cwd)
     return [line for line in out.splitlines() if line]
+
+
+def ahead_behind(cwd: Path, base_ref: str) -> tuple[int, int]:
+    """Return commits ahead/behind relative to a base ref."""
+    result = subprocess.run(
+        ["git", "rev-list", "--left-right", "--count", f"HEAD...{base_ref}"],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return (0, 0)
+    raw = result.stdout.strip().split()
+    if len(raw) != 2:
+        return (0, 0)
+    return (int(raw[0]), int(raw[1]))
+
+
+def status_porcelain(cwd: Path, *, include_branch: bool = False) -> list[str]:
+    """Return git status lines in porcelain format."""
+    command = ["git", "status", "--short"]
+    if include_branch:
+        command.append("--branch")
+    out = capture(command, cwd)
+    return [line for line in out.splitlines() if line.strip()]
+
+
+def upstream_branch(cwd: Path) -> str | None:
+    """Return the configured upstream ref for the current branch, if any."""
+    result = subprocess.run(
+        ["git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    value = result.stdout.strip()
+    return value or None
+
+
+def merge_base(cwd: Path, left: str, right: str = "HEAD") -> str | None:
+    """Return the merge-base sha for two refs, if one exists."""
+    result = subprocess.run(
+        ["git", "merge-base", left, right],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    value = result.stdout.strip()
+    return value or None
+
+
+def remote_names(cwd: Path) -> list[str]:
+    """Return configured remote names."""
+    out = capture(["git", "remote"], cwd)
+    return [line.strip() for line in out.splitlines() if line.strip()]
+
+
+def is_git_repository(cwd: Path) -> bool:
+    """Return whether cwd is inside a Git work tree."""
+    result = subprocess.run(
+        ["git", "rev-parse", "--is-inside-work-tree"],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.returncode == 0 and result.stdout.strip() == "true"

--- a/src/repo_release_tools/glyphs.py
+++ b/src/repo_release_tools/glyphs.py
@@ -1,0 +1,168 @@
+"""Small platform-aware glyph registry for repo-release-tools.
+
+This module is intentionally narrow. It adapts a few ideas from the author's
+broader glyph/emoji exploration into a stable, non-emoji terminal layer for
+rrt. The public surface is kept compact so CLI output stays predictable.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from dataclasses import dataclass, field
+
+
+IS_LEGACY_TERMINAL = sys.platform == "win32"
+
+
+def _g(windows_ascii: str, unicode_glyph: str) -> str:
+    """Return an ASCII fallback on legacy Windows terminals."""
+    return windows_ascii if IS_LEGACY_TERMINAL else unicode_glyph
+
+
+@dataclass(frozen=True)
+class Glyph:
+    """A platform-aware terminal glyph."""
+
+    symbol: str
+    name: str
+
+    def __str__(self) -> str:
+        return self.symbol
+
+    def __mul__(self, count: int) -> str:
+        return self.symbol * count
+
+    def __rmul__(self, count: int) -> str:
+        return self.symbol * count
+
+
+@dataclass(frozen=True)
+class BoxGlyphs:
+    """Box-drawing glyphs used for summaries and sections."""
+
+    h: Glyph = field(default_factory=lambda: Glyph(_g("-", "─"), "h"))
+    v: Glyph = field(default_factory=lambda: Glyph(_g("|", "│"), "v"))
+    tl: Glyph = field(default_factory=lambda: Glyph(_g("+", "┌"), "top_left"))
+    tr: Glyph = field(default_factory=lambda: Glyph(_g("+", "┐"), "top_right"))
+    bl: Glyph = field(default_factory=lambda: Glyph(_g("+", "└"), "bottom_left"))
+    br: Glyph = field(default_factory=lambda: Glyph(_g("+", "┘"), "bottom_right"))
+    left: Glyph = field(default_factory=lambda: Glyph(_g("+", "├"), "left"))
+    right: Glyph = field(default_factory=lambda: Glyph(_g("+", "┤"), "right"))
+    cross: Glyph = field(default_factory=lambda: Glyph(_g("+", "┼"), "cross"))
+
+
+@dataclass(frozen=True)
+class ArrowGlyphs:
+    """Directional glyphs for transitions and actions."""
+
+    right: Glyph = field(default_factory=lambda: Glyph(_g("->", "→"), "right"))
+    left: Glyph = field(default_factory=lambda: Glyph(_g("<-", "←"), "left"))
+    up: Glyph = field(default_factory=lambda: Glyph(_g("^", "↑"), "up"))
+    down: Glyph = field(default_factory=lambda: Glyph(_g("v", "↓"), "down"))
+
+
+@dataclass(frozen=True)
+class BulletGlyphs:
+    """Status glyphs for compact terminal output."""
+
+    dot: Glyph = field(default_factory=lambda: Glyph(_g("*", "•"), "dot"))
+    ok: Glyph = field(default_factory=lambda: Glyph(_g("[OK]", "✔"), "ok"))
+    skip: Glyph = field(default_factory=lambda: Glyph(_g("[-]", "⊖"), "skip"))
+    warning: Glyph = field(default_factory=lambda: Glyph(_g("/!\\", "▲"), "warning"))
+    error: Glyph = field(default_factory=lambda: Glyph(_g("[E]", "✖"), "error"))
+
+
+@dataclass(frozen=True)
+class TypographyGlyphs:
+    """Typography glyphs that benefit from fallbacks."""
+
+    ellipsis: Glyph = field(default_factory=lambda: Glyph(_g("...", "…"), "ellipsis"))
+    mdash: Glyph = field(default_factory=lambda: Glyph(_g("--", "—"), "mdash"))
+    ndash: Glyph = field(default_factory=lambda: Glyph(_g("-", "–"), "ndash"))
+
+
+@dataclass(frozen=True)
+class DiffGlyphs:
+    """Minimal diff glyphs for file and line summaries."""
+
+    added: Glyph = field(default_factory=lambda: Glyph("+", "added"))
+    removed: Glyph = field(default_factory=lambda: Glyph("-", "removed"))
+    modified: Glyph = field(default_factory=lambda: Glyph("~", "modified"))
+    unchanged: Glyph = field(default_factory=lambda: Glyph(" ", "unchanged"))
+    renamed: Glyph = field(default_factory=lambda: Glyph(_g("=>", "⇒"), "renamed"))
+    moved: Glyph = field(default_factory=lambda: Glyph(_g("->", "→"), "moved"))
+    conflict: Glyph = field(default_factory=lambda: Glyph(_g("!=", "≠"), "conflict"))
+
+    def line(self, kind: str, text: str, lineno: int | None = None) -> str:
+        """Render a compact diff line."""
+        glyph_map = {
+            "added": self.added,
+            "removed": self.removed,
+            "modified": self.modified,
+            "unchanged": self.unchanged,
+        }
+        glyph = glyph_map.get(kind, self.unchanged)
+        prefix = f"{lineno:>4} " if lineno is not None else ""
+        return f"{prefix}{glyph} {text}"
+
+
+@dataclass(frozen=True)
+class GitGlyphs:
+    """Git-centric glyphs for future status and log summaries."""
+
+    branch: Glyph = field(default_factory=lambda: Glyph(_g("br", "⎇"), "branch"))
+    commit: Glyph = field(default_factory=lambda: Glyph(_g("o", "●"), "commit"))
+    ahead: Glyph = field(default_factory=lambda: Glyph(_g("^", "↑"), "ahead"))
+    behind: Glyph = field(default_factory=lambda: Glyph(_g("v", "↓"), "behind"))
+    clean: Glyph = field(default_factory=lambda: Glyph(_g("OK", "✔"), "clean"))
+    dirty: Glyph = field(default_factory=lambda: Glyph(_g("*", "✎"), "dirty"))
+    modified: Glyph = field(default_factory=lambda: Glyph("~", "modified"))
+    untracked: Glyph = field(default_factory=lambda: Glyph("?", "untracked"))
+    ref_l: Glyph = field(default_factory=lambda: Glyph("(", "ref_left"))
+    ref_r: Glyph = field(default_factory=lambda: Glyph(")", "ref_right"))
+
+    def status_line(
+        self,
+        branch_name: str,
+        *,
+        ahead: int = 0,
+        behind: int = 0,
+        modified: int = 0,
+        untracked: int = 0,
+    ) -> str:
+        """Render a compact git status line."""
+        parts = [f"{self.branch} {branch_name}"]
+        if ahead:
+            parts.append(f"{self.ahead}{ahead}")
+        if behind:
+            parts.append(f"{self.behind}{behind}")
+        if modified:
+            parts.append(f"{self.modified}{modified}")
+        if untracked:
+            parts.append(f"{self.untracked}{untracked}")
+        parts.append(str(self.clean if not (modified or untracked) else self.dirty))
+        return "  ".join(parts)
+
+    def log_line(self, sha: str, message: str, refs: list[str] | tuple[str, ...] = ()) -> str:
+        """Render a compact git log line."""
+        ref_text = ""
+        if refs:
+            joined = " ".join(f"{self.ref_l}{ref}{self.ref_r}" for ref in refs)
+            ref_text = f" {joined}"
+        return f"{self.commit} {sha[:7]}{ref_text} {message}"
+
+
+@dataclass(frozen=True)
+class GlyphSet:
+    """Shared glyph registry for terminal output."""
+
+    box: BoxGlyphs = field(default_factory=BoxGlyphs)
+    arrow: ArrowGlyphs = field(default_factory=ArrowGlyphs)
+    bullet: BulletGlyphs = field(default_factory=BulletGlyphs)
+    typography: TypographyGlyphs = field(default_factory=TypographyGlyphs)
+    diff: DiffGlyphs = field(default_factory=DiffGlyphs)
+    git: GitGlyphs = field(default_factory=GitGlyphs)
+
+
+GLYPHS = GlyphSet()

--- a/src/repo_release_tools/hooks.py
+++ b/src/repo_release_tools/hooks.py
@@ -224,8 +224,10 @@ def run_dirty_tree_check(cwd: Path, *, title: str) -> int:
     if git.working_tree_clean(cwd):
         return 0
 
-    changed = git.capture(["git", "status", "--short"], cwd)
-    lines = [line for line in changed.splitlines() if line.strip()]
+    try:
+        lines = git.status_porcelain(cwd)
+    except RuntimeError as exc:
+        return emit_failure(title, [str(exc)])
     return emit_failure(
         title,
         [

--- a/src/repo_release_tools/hooks.py
+++ b/src/repo_release_tools/hooks.py
@@ -213,6 +213,28 @@ def run_commit_subject_check(subject: str, *, title: str) -> int:
     )
 
 
+def run_dirty_tree_check(cwd: Path, *, title: str) -> int:
+    """Validate that the working tree is clean."""
+    if not git.is_git_repository(cwd):
+        return emit_failure(
+            title,
+            [f"{cwd} is not inside a Git work tree."],
+        )
+
+    if git.working_tree_clean(cwd):
+        return 0
+
+    changed = git.capture(["git", "status", "--short"], cwd)
+    lines = [line for line in changed.splitlines() if line.strip()]
+    return emit_failure(
+        title,
+        [
+            "Working tree has uncommitted changes.",
+            (f"Changed entries: {', '.join(lines) if lines else '<unavailable>'}."),
+        ],
+    )
+
+
 def run_pre_commit(cwd: Path) -> int:
     """Validate the active branch during pre-commit."""
     branch_name = git.current_branch(cwd)
@@ -347,6 +369,11 @@ def main(argv: list[str] | None = None) -> int:
         help="Git ref whose changed files should be inspected when --changed-file is omitted.",
     )
 
+    subparsers.add_parser(
+        "check-dirty-tree",
+        help="Validate that the current working tree is clean.",
+    )
+
     parsed = parser.parse_args(sys.argv[1:] if argv is None else argv)
     if parsed.command == "pre-commit":
         return run_pre_commit(Path.cwd())
@@ -358,6 +385,8 @@ def main(argv: list[str] | None = None) -> int:
         return run_branch_name_check(parsed.branch, title="Branch name validation failed.")
     if parsed.command == "check-commit-subject":
         return run_commit_subject_check(parsed.subject, title="Commit subject validation failed.")
+    if parsed.command == "check-dirty-tree":
+        return run_dirty_tree_check(Path.cwd(), title="Dirty tree validation failed.")
     return run_changelog_check(
         parsed.subject,
         cwd=Path.cwd(),

--- a/src/repo_release_tools/output.py
+++ b/src/repo_release_tools/output.py
@@ -1,89 +1,11 @@
-"""Terminal output helpers with platform-aware glyph fallbacks."""
+"""Terminal output helpers with a small shared glyph registry."""
 
 from __future__ import annotations
 
-import sys
-
-from dataclasses import dataclass, field
+from repo_release_tools.glyphs import GLYPHS, Glyph
 
 
-IS_LEGACY_TERMINAL = sys.platform == "win32"
 SECTION_WIDTH = 52
-
-
-def _g(windows_ascii: str, unicode_glyph: str) -> str:
-    """Return an ASCII fallback on legacy Windows terminals."""
-    return windows_ascii if IS_LEGACY_TERMINAL else unicode_glyph
-
-
-@dataclass(frozen=True)
-class Glyph:
-    """A platform-aware terminal glyph."""
-
-    symbol: str
-    name: str
-
-    def __str__(self) -> str:
-        return self.symbol
-
-    def __mul__(self, count: int) -> str:
-        return self.symbol * count
-
-    def __rmul__(self, count: int) -> str:
-        return self.symbol * count
-
-
-@dataclass(frozen=True)
-class BoxGlyphs:
-    """Box-drawing glyphs used for summaries and sections."""
-
-    h: Glyph = field(default_factory=lambda: Glyph(_g("-", "─"), "h"))
-    v: Glyph = field(default_factory=lambda: Glyph(_g("|", "│"), "v"))
-    tl: Glyph = field(default_factory=lambda: Glyph(_g("+", "┌"), "top_left"))
-    tr: Glyph = field(default_factory=lambda: Glyph(_g("+", "┐"), "top_right"))
-    bl: Glyph = field(default_factory=lambda: Glyph(_g("+", "└"), "bottom_left"))
-    br: Glyph = field(default_factory=lambda: Glyph(_g("+", "┘"), "bottom_right"))
-    left: Glyph = field(default_factory=lambda: Glyph(_g("+", "├"), "left"))
-    right: Glyph = field(default_factory=lambda: Glyph(_g("+", "┤"), "right"))
-    cross: Glyph = field(default_factory=lambda: Glyph(_g("+", "┼"), "cross"))
-
-
-@dataclass(frozen=True)
-class ArrowGlyphs:
-    """Directional glyphs for transitions and actions."""
-
-    right: Glyph = field(default_factory=lambda: Glyph(_g("->", "→"), "right"))
-
-
-@dataclass(frozen=True)
-class BulletGlyphs:
-    """Status glyphs for successful, skipped, and warning states."""
-
-    dot: Glyph = field(default_factory=lambda: Glyph(_g("*", "•"), "dot"))
-    ok: Glyph = field(default_factory=lambda: Glyph(_g("[OK]", "✔"), "ok"))
-    skip: Glyph = field(default_factory=lambda: Glyph(_g("[-]", "⊖"), "skip"))
-    warning: Glyph = field(default_factory=lambda: Glyph(_g("/!\\", "▲"), "warning"))
-
-
-@dataclass(frozen=True)
-class TypographyGlyphs:
-    """Typography glyphs that benefit from fallbacks."""
-
-    ellipsis: Glyph = field(default_factory=lambda: Glyph(_g("...", "…"), "ellipsis"))
-    mdash: Glyph = field(default_factory=lambda: Glyph(_g("--", "—"), "mdash"))
-
-
-@dataclass(frozen=True)
-class GlyphSet:
-    """Shared glyph registry for terminal output."""
-
-    box: BoxGlyphs = field(default_factory=BoxGlyphs)
-    arrow: ArrowGlyphs = field(default_factory=ArrowGlyphs)
-    bullet: BulletGlyphs = field(default_factory=BulletGlyphs)
-    typography: TypographyGlyphs = field(default_factory=TypographyGlyphs)
-
-
-GLYPHS = GlyphSet()
 
 
 def section(title: str) -> str:
@@ -147,6 +69,11 @@ def ok(message: str, *, indent: int = 2) -> str:
 def warning(message: str, *, indent: int = 2) -> str:
     """Render a warning line."""
     return status(GLYPHS.bullet.warning, message, indent=indent)
+
+
+def error(message: str, *, indent: int = 2) -> str:
+    """Render an error line."""
+    return status(GLYPHS.bullet.error, message, indent=indent)
 
 
 def dry_run(message: str, *, indent: int = 2) -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,4 +16,5 @@ def test_module_help_smoke() -> None:
     assert "repo-release-tools" in result.stdout
     assert "branch" in result.stdout
     assert "bump" in result.stdout
+    assert "git" in result.stdout
     assert "init" in result.stdout

--- a/tests/test_git_cmd.py
+++ b/tests/test_git_cmd.py
@@ -61,6 +61,78 @@ def test_cmd_status_renders_clean_tree(monkeypatch, capsys) -> None:
     assert "Working tree is clean." in captured.out
 
 
+def test_cmd_log_renders_compact_history(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(git_cmd.git, "is_git_repository", lambda cwd: True)
+    monkeypatch.setattr(
+        git_cmd.git,
+        "capture",
+        lambda cmd, cwd: (
+            "abc1234\tfeat: add parser\tHEAD -> feat/add-parser, origin/feat/add-parser\n"
+            "def5678\tfix: handle empty input\t"
+        ),
+    )
+    args = argparse.Namespace(limit=2)
+
+    assert git_cmd.cmd_log(args) == 0
+
+    captured = capsys.readouterr()
+    assert "Git log" in captured.out
+    assert "abc1234" in captured.out
+    assert "feat: add parser" in captured.out
+    assert "origin/feat/add-parser" in captured.out
+
+
+def test_cmd_doctor_reports_failures(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(git_cmd.git, "is_git_repository", lambda cwd: True)
+    monkeypatch.setattr(git_cmd.git, "current_branch", lambda cwd: "feat/add-parser")
+    monkeypatch.setattr(git_cmd.git, "upstream_branch", lambda cwd: None)
+    monkeypatch.setattr(
+        git_cmd.git, "status_porcelain", lambda cwd: [" M src/repo_release_tools/cli.py"]
+    )
+    monkeypatch.setattr(git_cmd.git, "ahead_behind", lambda cwd, ref: (0, 0))
+
+    def fake_capture(cmd, cwd):
+        if cmd[:4] == ["git", "log", "-1", "--pretty=%s"]:
+            return "update stuff"
+        if cmd[:5] == ["git", "diff-tree", "--no-commit-id", "--name-only", "--root"]:
+            return "src/repo_release_tools/cli.py"
+        raise AssertionError(cmd)
+
+    monkeypatch.setattr(git_cmd.git, "capture", fake_capture)
+    args = argparse.Namespace(changelog_file="CHANGELOG.md")
+
+    assert git_cmd.cmd_doctor(args) == 1
+
+    captured = capsys.readouterr()
+    assert "Git doctor" in captured.out
+    assert "No upstream branch configured." in captured.out
+    assert "Working tree has uncommitted changes." in captured.out
+    assert "update stuff" in captured.out
+
+
+def test_cmd_doctor_reports_success(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(git_cmd.git, "is_git_repository", lambda cwd: True)
+    monkeypatch.setattr(git_cmd.git, "current_branch", lambda cwd: "feat/add-parser")
+    monkeypatch.setattr(git_cmd.git, "upstream_branch", lambda cwd: "origin/feat/add-parser")
+    monkeypatch.setattr(git_cmd.git, "status_porcelain", lambda cwd: [])
+    monkeypatch.setattr(git_cmd.git, "ahead_behind", lambda cwd, ref: (2, 1))
+
+    def fake_capture(cmd, cwd):
+        if cmd[:4] == ["git", "log", "-1", "--pretty=%s"]:
+            return "feat: add parser"
+        if cmd[:5] == ["git", "diff-tree", "--no-commit-id", "--name-only", "--root"]:
+            return "CHANGELOG.md\nsrc/repo_release_tools/cli.py"
+        raise AssertionError(cmd)
+
+    monkeypatch.setattr(git_cmd.git, "capture", fake_capture)
+    args = argparse.Namespace(changelog_file="CHANGELOG.md")
+
+    assert git_cmd.cmd_doctor(args) == 0
+
+    captured = capsys.readouterr()
+    assert "Doctor checks passed." in captured.out
+
+
 def test_cmd_sync_dry_run_stashes_before_rebase(monkeypatch, capsys) -> None:
     monkeypatch.setattr(git_cmd.git, "current_branch", lambda cwd: "feat/add-parser")
     monkeypatch.setattr(git_cmd.git, "upstream_branch", lambda cwd: "origin/feat/add-parser")

--- a/tests/test_git_cmd.py
+++ b/tests/test_git_cmd.py
@@ -61,6 +61,23 @@ def test_cmd_status_renders_clean_tree(monkeypatch, capsys) -> None:
     assert "Working tree is clean." in captured.out
 
 
+def test_cmd_status_reports_status_failure(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(git_cmd.git, "is_git_repository", lambda cwd: True)
+    monkeypatch.setattr(git_cmd.git, "current_branch", lambda cwd: "main")
+    monkeypatch.setattr(git_cmd.git, "upstream_branch", lambda cwd: "origin/main")
+    monkeypatch.setattr(
+        git_cmd.git,
+        "status_porcelain",
+        lambda cwd: (_ for _ in ()).throw(RuntimeError("git status --short failed (exit 128)")),
+    )
+    args = argparse.Namespace()
+
+    assert git_cmd.cmd_status(args) == 1
+
+    captured = capsys.readouterr()
+    assert "git status --short failed" in captured.err
+
+
 def test_cmd_log_renders_compact_history(monkeypatch, capsys) -> None:
     monkeypatch.setattr(git_cmd.git, "is_git_repository", lambda cwd: True)
     monkeypatch.setattr(
@@ -122,6 +139,29 @@ def test_cmd_doctor_reports_success(monkeypatch, capsys) -> None:
             return "feat: add parser"
         if cmd[:5] == ["git", "diff-tree", "--no-commit-id", "--name-only", "--root"]:
             return "CHANGELOG.md\nsrc/repo_release_tools/cli.py"
+        raise AssertionError(cmd)
+
+    monkeypatch.setattr(git_cmd.git, "capture", fake_capture)
+    args = argparse.Namespace(changelog_file="CHANGELOG.md")
+
+    assert git_cmd.cmd_doctor(args) == 0
+
+    captured = capsys.readouterr()
+    assert "Doctor checks passed." in captured.out
+
+
+def test_cmd_doctor_uses_commit_subject_for_changelog_risk(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(git_cmd.git, "is_git_repository", lambda cwd: True)
+    monkeypatch.setattr(git_cmd.git, "current_branch", lambda cwd: "feat/add-parser")
+    monkeypatch.setattr(git_cmd.git, "upstream_branch", lambda cwd: "origin/feat/add-parser")
+    monkeypatch.setattr(git_cmd.git, "status_porcelain", lambda cwd: [])
+    monkeypatch.setattr(git_cmd.git, "ahead_behind", lambda cwd, ref: (0, 0))
+
+    def fake_capture(cmd, cwd):
+        if cmd[:4] == ["git", "log", "-1", "--pretty=%s"]:
+            return "chore: update docs tooling"
+        if cmd[:5] == ["git", "diff-tree", "--no-commit-id", "--name-only", "--root"]:
+            raise AssertionError("changelog diff should not be queried for chore commits")
         raise AssertionError(cmd)
 
     monkeypatch.setattr(git_cmd.git, "capture", fake_capture)
@@ -195,6 +235,24 @@ def test_cmd_check_dirty_tree_reports_status_lines(monkeypatch, capsys) -> None:
     assert "feat/add-parser" in captured.err
     assert "src/repo_release_tools/cli.py" in captured.err
     assert "docs/git-magic.md" in captured.err
+
+
+def test_cmd_check_dirty_tree_reports_status_failure(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(git_cmd.git, "is_git_repository", lambda cwd: True)
+    monkeypatch.setattr(git_cmd.git, "working_tree_clean", lambda cwd: False)
+    monkeypatch.setattr(git_cmd.git, "current_branch", lambda cwd: "feat/add-parser")
+    monkeypatch.setattr(git_cmd.git, "upstream_branch", lambda cwd: "origin/feat/add-parser")
+    monkeypatch.setattr(
+        git_cmd.git,
+        "status_porcelain",
+        lambda cwd: (_ for _ in ()).throw(RuntimeError("git status --short failed (exit 128)")),
+    )
+    args = argparse.Namespace()
+
+    assert git_cmd.cmd_check_dirty_tree(args) == 1
+
+    captured = capsys.readouterr()
+    assert "git status --short failed" in captured.err
 
 
 def test_cmd_move_dry_run_stashes_before_checkout(monkeypatch, capsys) -> None:

--- a/tests/test_git_cmd.py
+++ b/tests/test_git_cmd.py
@@ -1,0 +1,113 @@
+import argparse
+
+from repo_release_tools.commands import git_cmd
+
+
+def test_infer_commit_type_from_branch() -> None:
+    assert git_cmd.infer_commit_type("feat/add-parser") == "feat"
+    assert git_cmd.infer_commit_type("main") is None
+    assert git_cmd.infer_commit_type("copilot/add-parser") is None
+
+
+def test_cmd_commit_dry_run_uses_branch_type(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(git_cmd.git, "current_branch", lambda cwd: "feat/add-parser")
+    args = argparse.Namespace(
+        description=["handle", "empty", "config"],
+        type=None,
+        scope=None,
+        breaking=False,
+        dry_run=True,
+    )
+
+    assert git_cmd.cmd_commit(args) == 0
+
+    captured = capsys.readouterr()
+    assert "feat: handle empty config" in captured.out
+    assert "[dry-run] complete" in captured.out
+
+
+def test_cmd_status_renders_summary_and_entries(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(git_cmd.git, "is_git_repository", lambda cwd: True)
+    monkeypatch.setattr(git_cmd.git, "current_branch", lambda cwd: "feat/add-parser")
+    monkeypatch.setattr(git_cmd.git, "upstream_branch", lambda cwd: "origin/feat/add-parser")
+    monkeypatch.setattr(
+        git_cmd.git,
+        "status_porcelain",
+        lambda cwd: [" M src/repo_release_tools/cli.py", "?? docs/git-magic.md"],
+    )
+    monkeypatch.setattr(git_cmd.git, "ahead_behind", lambda cwd, ref: (2, 1))
+    args = argparse.Namespace()
+
+    assert git_cmd.cmd_status(args) == 0
+
+    captured = capsys.readouterr()
+    assert "Git status" in captured.out
+    assert "feat/add-parser" in captured.out
+    assert "src/repo_release_tools/cli.py" in captured.out
+    assert "docs/git-magic.md" in captured.out
+
+
+def test_cmd_status_renders_clean_tree(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(git_cmd.git, "is_git_repository", lambda cwd: True)
+    monkeypatch.setattr(git_cmd.git, "current_branch", lambda cwd: "main")
+    monkeypatch.setattr(git_cmd.git, "upstream_branch", lambda cwd: "origin/main")
+    monkeypatch.setattr(git_cmd.git, "status_porcelain", lambda cwd: [])
+    monkeypatch.setattr(git_cmd.git, "ahead_behind", lambda cwd, ref: (0, 0))
+    args = argparse.Namespace()
+
+    assert git_cmd.cmd_status(args) == 0
+
+    captured = capsys.readouterr()
+    assert "Working tree is clean." in captured.out
+
+
+def test_cmd_sync_dry_run_stashes_before_rebase(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(git_cmd.git, "current_branch", lambda cwd: "feat/add-parser")
+    monkeypatch.setattr(git_cmd.git, "upstream_branch", lambda cwd: "origin/feat/add-parser")
+    monkeypatch.setattr(git_cmd.git, "working_tree_clean", lambda cwd: False)
+    monkeypatch.setattr(
+        git_cmd.git, "status_porcelain", lambda cwd: [" M src/repo_release_tools/cli.py"]
+    )
+    monkeypatch.setattr(git_cmd.git, "ahead_behind", lambda cwd, ref: (2, 1))
+    args = argparse.Namespace(merge=False, dry_run=True)
+
+    assert git_cmd.cmd_sync(args) == 0
+
+    captured = capsys.readouterr()
+    assert "git fetch --prune" in captured.out
+    assert "git stash push -u -m rrt git sync auto-stash" in captured.out
+    assert "git pull --rebase" in captured.out
+    assert "git stash pop" in captured.out
+
+
+def test_cmd_check_dirty_tree_reports_status_lines(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(git_cmd.git, "is_git_repository", lambda cwd: True)
+    monkeypatch.setattr(git_cmd.git, "working_tree_clean", lambda cwd: False)
+    monkeypatch.setattr(git_cmd.git, "current_branch", lambda cwd: "feat/add-parser")
+    monkeypatch.setattr(git_cmd.git, "upstream_branch", lambda cwd: "origin/feat/add-parser")
+    monkeypatch.setattr(
+        git_cmd.git,
+        "status_porcelain",
+        lambda cwd: [" M src/repo_release_tools/cli.py", "?? docs/git-magic.md"],
+    )
+    monkeypatch.setattr(git_cmd.git, "ahead_behind", lambda cwd, ref: (2, 1))
+    args = argparse.Namespace()
+
+    assert git_cmd.cmd_check_dirty_tree(args) == 1
+
+    captured = capsys.readouterr()
+    assert "Working tree has uncommitted changes." in captured.err
+    assert "feat/add-parser" in captured.err
+    assert "src/repo_release_tools/cli.py" in captured.err
+    assert "docs/git-magic.md" in captured.err
+
+
+def test_cmd_rebootstrap_requires_confirmation(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".git").mkdir()
+    args = argparse.Namespace(yes_i_know_this_destroys_history=False)
+
+    assert git_cmd.cmd_rebootstrap(args) == 1
+
+    captured = capsys.readouterr()
+    assert "--yes-i-know-this-destroys-history" in captured.err

--- a/tests/test_git_cmd.py
+++ b/tests/test_git_cmd.py
@@ -133,7 +133,30 @@ def test_cmd_doctor_reports_success(monkeypatch, capsys) -> None:
     assert "Doctor checks passed." in captured.out
 
 
+def test_cmd_sync_requires_git_repository(monkeypatch, tmp_path, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(git_cmd.git, "is_git_repository", lambda cwd: False)
+    args = argparse.Namespace(merge=False, dry_run=True)
+
+    assert git_cmd.cmd_sync(args) == 1
+
+    captured = capsys.readouterr()
+    assert "is not inside a Git work tree" in captured.err
+
+
+def test_cmd_move_requires_git_repository(monkeypatch, tmp_path, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(git_cmd.git, "is_git_repository", lambda cwd: False)
+    args = argparse.Namespace(target="feat/add-parser", create=False, dry_run=True)
+
+    assert git_cmd.cmd_move(args) == 1
+
+    captured = capsys.readouterr()
+    assert "is not inside a Git work tree" in captured.err
+
+
 def test_cmd_sync_dry_run_stashes_before_rebase(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(git_cmd.git, "is_git_repository", lambda cwd: True)
     monkeypatch.setattr(git_cmd.git, "current_branch", lambda cwd: "feat/add-parser")
     monkeypatch.setattr(git_cmd.git, "upstream_branch", lambda cwd: "origin/feat/add-parser")
     monkeypatch.setattr(git_cmd.git, "working_tree_clean", lambda cwd: False)
@@ -172,6 +195,20 @@ def test_cmd_check_dirty_tree_reports_status_lines(monkeypatch, capsys) -> None:
     assert "feat/add-parser" in captured.err
     assert "src/repo_release_tools/cli.py" in captured.err
     assert "docs/git-magic.md" in captured.err
+
+
+def test_cmd_move_dry_run_stashes_before_checkout(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(git_cmd.git, "is_git_repository", lambda cwd: True)
+    monkeypatch.setattr(git_cmd.git, "current_branch", lambda cwd: "main")
+    monkeypatch.setattr(git_cmd.git, "working_tree_clean", lambda cwd: False)
+    args = argparse.Namespace(target="feat/add-parser", create=False, dry_run=True)
+
+    assert git_cmd.cmd_move(args) == 0
+
+    captured = capsys.readouterr()
+    assert "git stash push -u -m rrt git move auto-stash" in captured.out
+    assert "git checkout feat/add-parser" in captured.out
+    assert "git stash pop" in captured.out
 
 
 def test_cmd_rebootstrap_requires_confirmation(tmp_path, monkeypatch, capsys) -> None:

--- a/tests/test_git_helpers.py
+++ b/tests/test_git_helpers.py
@@ -22,3 +22,17 @@ def test_status_porcelain_preserves_leading_spaces(monkeypatch, tmp_path: Path) 
     lines = git.status_porcelain(tmp_path)
 
     assert lines == [" M src/repo_release_tools/cli.py", "?? docs/git-magic.md"]
+
+
+def test_status_porcelain_raises_on_git_failure(monkeypatch, tmp_path: Path) -> None:
+    def fake_run(cmd, cwd, capture_output, text, check):
+        return subprocess.CompletedProcess(cmd, 128, stdout="", stderr="fatal")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    try:
+        git.status_porcelain(tmp_path)
+    except RuntimeError as exc:
+        assert "git status --short failed" in str(exc)
+    else:
+        raise AssertionError("Expected RuntimeError")

--- a/tests/test_git_helpers.py
+++ b/tests/test_git_helpers.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import subprocess
+
+from pathlib import Path
+
+from repo_release_tools import git
+
+
+def test_status_porcelain_preserves_leading_spaces(monkeypatch, tmp_path: Path) -> None:
+    def fake_run(cmd, cwd, capture_output, text, check):
+        assert cmd == ["git", "status", "--short"]
+        return subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout=" M src/repo_release_tools/cli.py\n?? docs/git-magic.md\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    lines = git.status_porcelain(tmp_path)
+
+    assert lines == [" M src/repo_release_tools/cli.py", "?? docs/git-magic.md"]

--- a/tests/test_glyphs.py
+++ b/tests/test_glyphs.py
@@ -1,0 +1,30 @@
+from repo_release_tools.glyphs import GLYPHS
+from repo_release_tools.glyphs import Glyph
+
+
+def test_glyph_multiplies_like_a_string() -> None:
+    glyph = Glyph("-", "dash")
+
+    assert glyph * 3 == "---"
+    assert 2 * glyph == "--"
+
+
+def test_git_status_line_stays_compact() -> None:
+    line = GLYPHS.git.status_line(
+        "feat/add-parser",
+        ahead=2,
+        behind=1,
+        modified=3,
+        untracked=1,
+    )
+
+    assert "feat/add-parser" in line
+    assert "2" in line
+    assert "1" in line
+
+
+def test_diff_line_accepts_line_numbers() -> None:
+    rendered = GLYPHS.diff.line("added", "return result", lineno=12)
+
+    assert "12" in rendered
+    assert "return result" in rendered

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -113,8 +113,20 @@ def test_run_dirty_tree_check_rejects_dirty_tree(monkeypatch) -> None:
     monkeypatch.setattr(hooks.git, "working_tree_clean", lambda cwd: False)
     monkeypatch.setattr(
         hooks.git,
-        "capture",
-        lambda cmd, cwd: " M src/repo_release_tools/cli.py\n?? docs/git-magic.md",
+        "status_porcelain",
+        lambda cwd: [" M src/repo_release_tools/cli.py", "?? docs/git-magic.md"],
+    )
+
+    assert hooks.run_dirty_tree_check(Path.cwd(), title="Dirty tree validation failed.") == 1
+
+
+def test_run_dirty_tree_check_reports_status_failure(monkeypatch) -> None:
+    monkeypatch.setattr(hooks.git, "is_git_repository", lambda cwd: True)
+    monkeypatch.setattr(hooks.git, "working_tree_clean", lambda cwd: False)
+    monkeypatch.setattr(
+        hooks.git,
+        "status_porcelain",
+        lambda cwd: (_ for _ in ()).throw(RuntimeError("git status --short failed (exit 128)")),
     )
 
     assert hooks.run_dirty_tree_check(Path.cwd(), title="Dirty tree validation failed.") == 1

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -101,6 +101,32 @@ def test_main_check_commit_subject_rejects_invalid_subject() -> None:
     assert hooks.main(["check-commit-subject", "--subject", "update stuff"]) == 1
 
 
+def test_run_dirty_tree_check_accepts_clean_tree(monkeypatch) -> None:
+    monkeypatch.setattr(hooks.git, "is_git_repository", lambda cwd: True)
+    monkeypatch.setattr(hooks.git, "working_tree_clean", lambda cwd: True)
+
+    assert hooks.run_dirty_tree_check(Path.cwd(), title="Dirty tree validation failed.") == 0
+
+
+def test_run_dirty_tree_check_rejects_dirty_tree(monkeypatch) -> None:
+    monkeypatch.setattr(hooks.git, "is_git_repository", lambda cwd: True)
+    monkeypatch.setattr(hooks.git, "working_tree_clean", lambda cwd: False)
+    monkeypatch.setattr(
+        hooks.git,
+        "capture",
+        lambda cmd, cwd: " M src/repo_release_tools/cli.py\n?? docs/git-magic.md",
+    )
+
+    assert hooks.run_dirty_tree_check(Path.cwd(), title="Dirty tree validation failed.") == 1
+
+
+def test_main_check_dirty_tree_uses_hook_entrypoint(monkeypatch) -> None:
+    monkeypatch.setattr(hooks.git, "is_git_repository", lambda cwd: True)
+    monkeypatch.setattr(hooks.git, "working_tree_clean", lambda cwd: True)
+
+    assert hooks.main(["check-dirty-tree"]) == 0
+
+
 def test_run_pre_commit_changelog_rejects_missing_staged_changelog(monkeypatch) -> None:
     monkeypatch.setattr(hooks.git, "current_branch", lambda cwd: "feat/add-hook-checks")
     monkeypatch.setattr(hooks, "staged_files", lambda cwd: ["src/repo_release_tools/hooks.py"])
@@ -171,6 +197,7 @@ def test_pre_commit_hooks_use_console_script_entrypoints() -> None:
     assert "entry: rrt-hooks pre-commit" in manifest
     assert "entry: rrt-hooks pre-commit-changelog" in manifest
     assert "entry: rrt-hooks commit-msg" in manifest
+    assert "entry: rrt-hooks check-dirty-tree" in manifest
 
 
 def test_action_installs_from_action_path_and_runs_hooks() -> None:
@@ -185,5 +212,7 @@ def test_action_installs_from_action_path_and_runs_hooks() -> None:
     assert "check-changelog:" in action_text
     assert "changelog-file:" in action_text
     assert "rrt-hooks check-changelog" in action_text
+    assert "check-dirty-tree:" in action_text
+    assert "rrt-hooks check-dirty-tree" in action_text
     assert '--changelog-file "$INPUT_CHANGELOG_FILE"' in action_text
     assert "--ref HEAD" in action_text

--- a/uv.lock
+++ b/uv.lock
@@ -163,7 +163,7 @@ wheels = [
 
 [[package]]
 name = "repo-release-tools"
-version = "0.1.5"
+version = "0.1.6"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
This pull request introduces a new `rrt git` workflow surface, adds reusable dirty-tree enforcement for hooks and CI, and improves documentation around Git workflows and safety checks. It also bumps the version to `0.1.6` and updates related documentation and configuration files.

**New Features and Workflow Additions:**

* Added a comprehensive `rrt git` command surface for status, log, doctor, sync, move, commit, commit-all, squash-local, undo-safe, rebootstrap, and dirty-tree checks, all focused on conventional branch and commit workflows. (`src/repo_release_tools/cli.py` [[1]](diffhunk://#diff-377e07e060a095fde5dfb83d8d062afed7dd4b78e5016064659dbb20f853edd6L8-R21) `docs/rrt-cli.md` [[2]](diffhunk://#diff-12896542500295f7a93dd67807f82f480f0f03a704f8e3a864f696f38caf0a6eR23-R56) `docs/git-magic.md` [[3]](diffhunk://#diff-e731d7dcaa983186ca3ca4d868b6f13714e3232419a62201273f79cf8ffd06c8R1-R99) `CHANGELOG.md` [[4]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R17)
* Introduced reusable dirty-tree enforcement via the new `rrt-hooks check-dirty-tree` command, a corresponding pre-commit hook (`rrt-dirty-tree`), and a GitHub Action input for clean worktree validation. (`.pre-commit-hooks.yaml` [[1]](diffhunk://#diff-cb921d5df435fe404b4daf451cf783709ccebe9c346038af6036644e7386c13dR29-R38) `action.yml` [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R35-R37) [[3]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R97-R104) `docs/pre-commit.md` [[4]](diffhunk://#diff-687e3c9e2e6a3e468b6de884b3382434cbf71b609001a2d34fc1ac9d40b1010eR30-R52) `docs/github-action.md` [[5]](diffhunk://#diff-5565610d10fa90d1b0be11c7f459812e0ddf7015e2d76c364d41d166b06dd43dR36-R45)

**Documentation Improvements:**

* Added a dedicated "Git magic" documentation page to explain the rationale and catalog the new `rrt git` workflows, and linked it from the main docs. (`docs/git-magic.md` [[1]](diffhunk://#diff-e731d7dcaa983186ca3ca4d868b6f13714e3232419a62201273f79cf8ffd06c8R1-R99) `docs/index.md` [[2]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6R13-R21)
* Updated the README and CLI docs to reflect the new workflows and clarify the product's focus on opinionated, policy-driven Git automation. (`README.md` [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L4-R5) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R20) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R80-R90) `docs/rrt-cli.md` [[4]](diffhunk://#diff-12896542500295f7a93dd67807f82f480f0f03a704f8e3a864f696f38caf0a6eR23-R56)
* Improved GitHub Action and pre-commit documentation to cover the new dirty-tree enforcement and updated version references. (`docs/github-action.md` [[1]](diffhunk://#diff-5565610d10fa90d1b0be11c7f459812e0ddf7015e2d76c364d41d166b06dd43dL10-R23) [[2]](diffhunk://#diff-5565610d10fa90d1b0be11c7f459812e0ddf7015e2d76c364d41d166b06dd43dR36-R45) `docs/pre-commit.md` [[3]](diffhunk://#diff-687e3c9e2e6a3e468b6de884b3382434cbf71b609001a2d34fc1ac9d40b1010eL12-R12)

**Core Git Functionality Enhancements:**

* Extended `src/repo_release_tools/git.py` with new helpers for ahead/behind counts, porcelain status, upstream branch detection, merge-base, remote names, and Git repository detection, supporting the new workflows and status rendering.

**Release and Versioning:**

* Bumped the package version to `0.1.6` in `pyproject.toml` and `src/repo_release_tools/__init__.py`, and updated all docs and config references accordingly. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3) [[2]](diffhunk://#diff-53bd4ffed688f042108fe16db9b3d441ca5ab6039b1ecef76cf4a53eb1152c18L3-R3) `CHANGELOG.md` [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R17) `docs/pre-commit.md` [[4]](diffhunk://#diff-687e3c9e2e6a3e468b6de884b3382434cbf71b609001a2d34fc1ac9d40b1010eL12-R12)

These changes together make `repo-release-tools` more robust for conventional Git workflows, safer releases, and easier policy enforcement across local, hook, and CI environments.