### PR TITLE
feat: add support for python_version and go_version target kinds with…

### DIFF
--- a/src/repo_release_tools/__init__.py
+++ b/src/repo_release_tools/__init__.py
@@ -1,3 +1,3 @@
 """repo-release-tools package."""
 
-__version__ = "0.1.7"
+__version__ = "0.1.8"

--- a/src/repo_release_tools/config.py
+++ b/src/repo_release_tools/config.py
@@ -43,8 +43,9 @@ _IGNORE_DIR_NAMES: frozenset[str] = frozenset(
     {".venv", "venv", "env", ".env", "node_modules", "__pycache__", ".git", ".tox", "dist", "build"}
 )
 
-# Matches the first occurrence of a `__version__ = "..."` / `'...'` declaration.
-_PYTHON_VERSION_VAR_RE: re.Pattern[str] = re.compile(r"(?m)^__version__\s*=\s*['\"]")
+# Matches the first occurrence of a `__version__ = "..."` / `'...'` declaration,
+# allowing optional leading whitespace before the assignment.
+_PYTHON_VERSION_VAR_RE: re.Pattern[str] = re.compile(r"(?m)^\s*__version__\s*=\s*['\"]")
 
 # Branch type prefixes that are built-in and must not appear in extra_branch_types.
 # Mirrors CONVENTIONAL_TYPES, MAGIC_BRANCH_TYPES, and BOT_BRANCH_TYPES from hooks.py.

--- a/src/repo_release_tools/config.py
+++ b/src/repo_release_tools/config.py
@@ -36,7 +36,15 @@ CONFIG_SECTION_BY_FILE: dict[str, str] = {
 # Sentinel: lock_command / generated_files not explicitly configured → auto-detect.
 _AUTO: list[str] | None = None
 
-VALID_TARGET_KINDS = frozenset({"pep621", "package_json"})
+VALID_TARGET_KINDS = frozenset({"pep621", "package_json", "python_version", "go_version"})
+
+# Directory names to skip when scanning for Python __version__ files.
+_IGNORE_DIR_NAMES: frozenset[str] = frozenset(
+    {".venv", "venv", "env", ".env", "node_modules", "__pycache__", ".git", ".tox", "dist", "build"}
+)
+
+# Matches the first occurrence of a `__version__ = "..."` / `'...'` declaration.
+_PYTHON_VERSION_VAR_RE: re.Pattern[str] = re.compile(r"(?m)^__version__\s*=\s*['\"]")
 
 # Branch type prefixes that are built-in and must not appear in extra_branch_types.
 # Mirrors CONVENTIONAL_TYPES, MAGIC_BRANCH_TYPES, and BOT_BRANCH_TYPES from hooks.py.
@@ -117,7 +125,7 @@ GO_TOOL_RRT_EXAMPLE = dedent(
 
     [[tool.rrt.version_targets]]
     path = "internal/version/version.go"
-    pattern = '^(const Version = ")([^"]+)(")$'
+    kind = "go_version"
     """
 ).strip()
 
@@ -167,9 +175,9 @@ class VersionTarget:
         has_section_field = has_section and has_field
         configured_modes = sum((has_kind, has_pattern, has_section_field))
         if configured_modes == 0:
+            kind_opts = " or ".join(f"kind={k!r}" for k in sorted(VALID_TARGET_KINDS))
             raise ValueError(
-                "Each version target must define either "
-                "kind='pep621', kind='package_json', pattern, or section+field"
+                f"Each version target must define either {kind_opts}, pattern, or section+field"
             )
         if configured_modes > 1:
             raise ValueError(
@@ -362,12 +370,13 @@ def autodetect_config(root: Path) -> RrtConfig | None:
     """Build an implicit config from common root-level version files."""
     targets = _autodetect_version_targets(root)
     if len(targets) > 1:
+        lock_cmd, gen_files = _recommended_lock_settings(root, targets)
         group = VersionGroup(
             name="default",
             release_branch=DEFAULT_RELEASE_BRANCH,
             changelog_file=root / DEFAULT_CHANGELOG,
-            lock_command=[],
-            generated_files=[],
+            lock_command=lock_cmd,
+            generated_files=[root / f for f in gen_files],
             version_targets=targets,
             version_source=targets[0].path,
         )
@@ -425,8 +434,9 @@ def format_missing_tool_rrt_guidance(root: Path, checked_files: list[Path] | Non
     lines.extend(
         [
             "",
-            "Zero-config mode auto-detects these root-level version files:",
+            "Zero-config mode auto-detects these version files:",
             "  - pyproject.toml -> [project].version",
+            "  - src/<package>/__init__.py, src/<package>/__version__.py -> __version__",
             "  - package.json -> top-level version",
             "  - Cargo.toml -> [package].version",
             "",
@@ -452,7 +462,7 @@ def format_missing_tool_rrt_guidance(root: Path, checked_files: list[Path] | Non
             "Rust / Cargo.toml:",
             *[f"    {line}" for line in RUST_TOOL_RRT_EXAMPLE.splitlines()],
             "",
-            "Go example (Go has no standard in-file project version, so use an explicit pattern):",
+            "Go example (Go projects with an in-file version constant or variable):",
             *[f"    {line}" for line in GO_TOOL_RRT_EXAMPLE.splitlines()],
             "",
             "Local repo config works too: put that table in .rrt.toml or .config/rrt.toml",
@@ -460,6 +470,40 @@ def format_missing_tool_rrt_guidance(root: Path, checked_files: list[Path] | Non
         ]
     )
     return "\n".join(lines)
+
+
+def _find_python_version_files(root: Path) -> list[Path]:
+    """Find Python files that declare ``__version__`` in common src/flat package layouts.
+
+    Scans one level deep under ``src/`` and directly under *root* for
+    ``__version__.py`` and ``__init__.py`` files that contain a
+    ``__version__ = ...`` assignment.  Common non-package directories are
+    skipped.
+    """
+    found: list[Path] = []
+    seen: set[Path] = set()
+    for base in (root / "src", root):
+        if not base.is_dir():
+            continue
+        try:
+            children = sorted(base.iterdir())
+        except OSError:
+            continue
+        for pkg_dir in children:
+            if not pkg_dir.is_dir() or pkg_dir.name in _IGNORE_DIR_NAMES:
+                continue
+            for name in ("__version__.py", "__init__.py"):
+                candidate = pkg_dir / name
+                if candidate in seen or not candidate.exists():
+                    continue
+                try:
+                    text = candidate.read_text(encoding="utf-8")
+                except OSError:
+                    continue
+                if _PYTHON_VERSION_VAR_RE.search(text):
+                    seen.add(candidate)
+                    found.append(candidate)
+    return found
 
 
 def _autodetect_version_targets(root: Path) -> list[VersionTarget]:
@@ -505,6 +549,14 @@ def _autodetect_version_targets(root: Path) -> list[VersionTarget]:
             )
         )
 
+    # Python __version__ variable files (secondary targets alongside pep621/poetry).
+    has_python = any(t.kind == "pep621" or t.section == "tool.poetry" for t in targets)
+    if has_python:
+        for py_file in _find_python_version_files(root):
+            if any(t.path == py_file for t in targets):
+                continue
+            targets.append(VersionTarget(path=py_file, kind="python_version", ci_format="pep440"))
+
     return targets
 
 
@@ -548,6 +600,10 @@ def _describe_version_target(target: VersionTarget, *, root: Path) -> str:
         return f"{relative} ([project].version)"
     if target.kind == "package_json":
         return f"{relative} (version)"
+    if target.kind == "python_version":
+        return f"{relative} (__version__)"
+    if target.kind == "go_version":
+        return f"{relative} (Version)"
     if target.section and target.field:
         return f"{relative} ([{target.section}].{target.field})"
     if target.pattern:
@@ -644,6 +700,12 @@ def _target_ecosystem(target: VersionTarget) -> str | None:
         return "python-pep621"
     if target.kind == "package_json":
         return "node"
+    if target.kind == "python_version":
+        # Ecosystem-neutral: a secondary __version__ file inherits the lock
+        # settings of whatever primary target (pep621/poetry) it accompanies.
+        return None
+    if target.kind == "go_version":
+        return "go"
     if target.section == "tool.poetry":
         return "python-poetry"
     if target.path.name == "Cargo.toml" and target.section in {"package", "workspace.package"}:

--- a/src/repo_release_tools/version_targets.py
+++ b/src/repo_release_tools/version_targets.py
@@ -14,6 +14,8 @@ from repo_release_tools.versioning import Version
 
 
 PEP621_PATTERN = re.compile(r'(?ms)(^\[project\]\s.*?^version\s*=\s*")([^"]+)(")')
+PYTHON_VERSION_PATTERN = re.compile(r'(?m)^(__version__\s*=\s*["\'])([^"\']+)(["\'])')
+GO_VERSION_PATTERN = re.compile(r'(?m)^((?:const|var)\s+Version\s*=\s*")([^"]+)(")')
 
 
 def replace_version_in_file(
@@ -34,6 +36,10 @@ def replace_version_in_file(
         updated = PEP621_PATTERN.sub(rf"\g<1>{new_version}\g<3>", text, count=1)
     elif target.kind == "package_json":
         updated = replace_package_json_version(text, new_version)
+    elif target.kind == "python_version":
+        updated = PYTHON_VERSION_PATTERN.sub(rf"\g<1>{new_version}\g<3>", text, count=1)
+    elif target.kind == "go_version":
+        updated = GO_VERSION_PATTERN.sub(rf"\g<1>{new_version}\g<3>", text, count=1)
     elif target.pattern:
         updated = replace_pattern_version(text, target.pattern, new_version)
     else:
@@ -96,6 +102,16 @@ def read_version_string(target: VersionTarget) -> str:
         return match.group(2)
     if target.kind == "package_json":
         return read_package_json_version(target.path)
+    if target.kind == "python_version":
+        match = PYTHON_VERSION_PATTERN.search(text)
+        if match is None:
+            raise RuntimeError(f"Could not find __version__ in {target.path}")
+        return match.group(2)
+    if target.kind == "go_version":
+        match = GO_VERSION_PATTERN.search(text)
+        if match is None:
+            raise RuntimeError(f"Could not find Version constant/variable in {target.path}")
+        return match.group(2)
 
     if target.pattern:
         match = search_pattern(text, target.pattern)

--- a/src/repo_release_tools/version_targets.py
+++ b/src/repo_release_tools/version_targets.py
@@ -14,8 +14,18 @@ from repo_release_tools.versioning import Version
 
 
 PEP621_PATTERN = re.compile(r'(?ms)(^\[project\]\s.*?^version\s*=\s*")([^"]+)(")')
-PYTHON_VERSION_PATTERN = re.compile(r'(?m)^(__version__\s*=\s*["\'])([^"\']+)(["\'])')
-GO_VERSION_PATTERN = re.compile(r'(?m)^((?:const|var)\s+Version\s*=\s*")([^"]+)(")')
+# Allows optional leading whitespace; uses a backreference (\2) to enforce matching
+# opening/closing quote types (both " or both ').
+PYTHON_VERSION_PATTERN = re.compile(r'(?m)^(\s*__version__\s*=\s*)(["\'])([^"\']+)\2')
+# Allows optional leading whitespace for simple declarations and also matches
+# Version inside a const (...) grouped block via the (?ms) (DOTALL) alternation.
+GO_VERSION_PATTERN = re.compile(
+    r"(?ms)^("
+    r"\s*(?:const|var)\s+Version\s*=\s*\""
+    r"|"
+    r"\s*(?:const|var)\s*\(\s*.*?^\s*Version\s*=\s*\""
+    r')([^"]+)(")'
+)
 
 
 def replace_version_in_file(
@@ -37,7 +47,7 @@ def replace_version_in_file(
     elif target.kind == "package_json":
         updated = replace_package_json_version(text, new_version)
     elif target.kind == "python_version":
-        updated = PYTHON_VERSION_PATTERN.sub(rf"\g<1>{new_version}\g<3>", text, count=1)
+        updated = PYTHON_VERSION_PATTERN.sub(rf"\g<1>\g<2>{new_version}\g<2>", text, count=1)
     elif target.kind == "go_version":
         updated = GO_VERSION_PATTERN.sub(rf"\g<1>{new_version}\g<3>", text, count=1)
     elif target.pattern:
@@ -106,7 +116,7 @@ def read_version_string(target: VersionTarget) -> str:
         match = PYTHON_VERSION_PATTERN.search(text)
         if match is None:
             raise RuntimeError(f"Could not find __version__ in {target.path}")
-        return match.group(2)
+        return match.group(3)
     if target.kind == "go_version":
         match = GO_VERSION_PATTERN.search(text)
         if match is None:

--- a/tests/test_bump.py
+++ b/tests/test_bump.py
@@ -472,3 +472,184 @@ version = "0.3.0"
     assert result == 0
     content = (tmp_path / "Cargo.toml").read_text(encoding="utf-8")
     assert 'version = "0.4.0"' in content
+
+
+def test_cmd_bump_python_version_kind_explicit_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys
+) -> None:
+    """bump updates __version__ in a Python file when kind='python_version' is configured."""
+    init_file = tmp_path / "src" / "mypkg" / "__init__.py"
+    init_file.parent.mkdir(parents=True)
+    init_file.write_text('__version__ = "0.1.0"\n', encoding="utf-8")
+
+    (tmp_path / ".rrt.toml").write_text(
+        """\
+[tool.rrt]
+release_branch = "release/v{version}"
+lock_command = []
+
+[[tool.rrt.version_targets]]
+path = "src/mypkg/__init__.py"
+kind = "python_version"
+""",
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    result = cmd_bump(
+        Namespace(
+            bump="minor",
+            dry_run=True,
+            no_commit=True,
+            no_changelog=True,
+            no_update=False,
+            include_maintenance=False,
+            base_branch=None,
+            group=None,
+        )
+    )
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "release/v0.2.0" in captured.out
+    assert "Would update" in captured.out
+
+
+def test_cmd_bump_python_version_kind_writes_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """bump actually writes the new __version__ when not in dry-run mode."""
+    init_file = tmp_path / "src" / "mypkg" / "__init__.py"
+    init_file.parent.mkdir(parents=True)
+    init_file.write_text('__version__ = "1.0.0"\n', encoding="utf-8")
+
+    (tmp_path / ".rrt.toml").write_text(
+        """\
+[tool.rrt]
+release_branch = "release/v{version}"
+lock_command = []
+
+[[tool.rrt.version_targets]]
+path = "src/mypkg/__init__.py"
+kind = "python_version"
+""",
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.working_tree_clean", lambda root: True
+    )
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.branch_exists", lambda root, branch: False
+    )
+    monkeypatch.setattr("repo_release_tools.commands.bump.git.current_branch", lambda root: "main")
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.run", lambda cmd, root, *, dry_run, label: ""
+    )
+
+    result = cmd_bump(
+        Namespace(
+            bump="patch",
+            dry_run=False,
+            no_commit=True,
+            no_changelog=True,
+            no_update=True,
+            include_maintenance=False,
+            base_branch=None,
+            group=None,
+        )
+    )
+
+    assert result == 0
+    assert '__version__ = "1.0.1"' in init_file.read_text(encoding="utf-8")
+
+
+def test_cmd_bump_autodetects_python_version_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Zero-config bump auto-detects __version__ in src/<pkg>/__init__.py."""
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "example"\nversion = "0.5.0"\n',
+        encoding="utf-8",
+    )
+    init_file = tmp_path / "src" / "example" / "__init__.py"
+    init_file.parent.mkdir(parents=True)
+    init_file.write_text('__version__ = "0.5.0"\n', encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.working_tree_clean", lambda root: True
+    )
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.branch_exists", lambda root, branch: False
+    )
+    monkeypatch.setattr("repo_release_tools.commands.bump.git.current_branch", lambda root: "main")
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.run", lambda cmd, root, *, dry_run, label: ""
+    )
+
+    result = cmd_bump(
+        Namespace(
+            bump="minor",
+            dry_run=False,
+            no_commit=True,
+            no_changelog=True,
+            no_update=True,
+            include_maintenance=False,
+            base_branch=None,
+            group=None,
+        )
+    )
+
+    assert result == 0
+    assert 'version = "0.6.0"' in (tmp_path / "pyproject.toml").read_text(encoding="utf-8")
+    assert '__version__ = "0.6.0"' in init_file.read_text(encoding="utf-8")
+
+
+def test_cmd_bump_go_version_kind(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """bump updates const Version in a Go file when kind='go_version' is configured."""
+    ver_file = tmp_path / "internal" / "version" / "version.go"
+    ver_file.parent.mkdir(parents=True)
+    ver_file.write_text('package version\n\nconst Version = "0.1.0"\n', encoding="utf-8")
+
+    (tmp_path / ".rrt.toml").write_text(
+        """\
+[tool.rrt]
+release_branch = "release/v{version}"
+lock_command = []
+
+[[tool.rrt.version_targets]]
+path = "internal/version/version.go"
+kind = "go_version"
+""",
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.working_tree_clean", lambda root: True
+    )
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.branch_exists", lambda root, branch: False
+    )
+    monkeypatch.setattr("repo_release_tools.commands.bump.git.current_branch", lambda root: "main")
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.run", lambda cmd, root, *, dry_run, label: ""
+    )
+
+    result = cmd_bump(
+        Namespace(
+            bump="major",
+            dry_run=False,
+            no_commit=True,
+            no_changelog=True,
+            no_update=True,
+            include_maintenance=False,
+            base_branch=None,
+            group=None,
+        )
+    )
+
+    assert result == 0
+    assert 'const Version = "1.0.0"' in ver_file.read_text(encoding="utf-8")

--- a/tests/test_bump.py
+++ b/tests/test_bump.py
@@ -496,6 +496,16 @@ kind = "python_version"
     )
 
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.working_tree_clean", lambda root: True
+    )
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.branch_exists", lambda root, branch: False
+    )
+    monkeypatch.setattr("repo_release_tools.commands.bump.git.current_branch", lambda root: "main")
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.run", lambda cmd, root, *, dry_run, label: ""
+    )
     result = cmd_bump(
         Namespace(
             bump="minor",

--- a/tests/test_version_targets.py
+++ b/tests/test_version_targets.py
@@ -81,9 +81,72 @@ def test_replace_python_version_same_version_raises(tmp_path: Path) -> None:
         replace_version_in_file(target, "1.0.0", dry_run=False)
 
 
+def test_read_python_version_indented(tmp_path: Path) -> None:
+    f = tmp_path / "__init__.py"
+    f.write_text('    __version__ = "3.0.0"\n', encoding="utf-8")
+    target = VersionTarget(path=f, kind="python_version")
+    assert read_version_string(target) == "3.0.0"
+
+
+def test_replace_python_version_indented(tmp_path: Path) -> None:
+    f = tmp_path / "__init__.py"
+    f.write_text('    __version__ = "3.0.0"\n', encoding="utf-8")
+    target = VersionTarget(path=f, kind="python_version")
+    replace_version_in_file(target, "3.1.0", dry_run=False)
+    assert '    __version__ = "3.1.0"' in f.read_text(encoding="utf-8")
+
+
+def test_python_version_mismatched_quotes_not_matched(tmp_path: Path) -> None:
+    """A pattern with mismatched opening/closing quotes should not be matched."""
+    f = tmp_path / "__init__.py"
+    # Double-quote open, single-quote close – not a valid Python string literal
+    f.write_text("__version__ = \"1.0.0'\n", encoding="utf-8")
+    target = VersionTarget(path=f, kind="python_version")
+    with pytest.raises(RuntimeError, match="Could not find __version__"):
+        read_version_string(target)
+
+
 # ---------------------------------------------------------------------------
-# go_version – read
+# go_version – leading whitespace and const (...) block
 # ---------------------------------------------------------------------------
+
+
+def test_read_go_version_leading_whitespace(tmp_path: Path) -> None:
+    f = tmp_path / "version.go"
+    f.write_text('package version\n\n\tconst Version = "1.2.3"\n', encoding="utf-8")
+    target = VersionTarget(path=f, kind="go_version")
+    assert read_version_string(target) == "1.2.3"
+
+
+def test_replace_go_version_leading_whitespace(tmp_path: Path) -> None:
+    f = tmp_path / "version.go"
+    f.write_text('package version\n\n\tconst Version = "1.2.3"\n', encoding="utf-8")
+    target = VersionTarget(path=f, kind="go_version")
+    replace_version_in_file(target, "1.3.0", dry_run=False)
+    assert 'Version = "1.3.0"' in f.read_text(encoding="utf-8")
+
+
+def test_read_go_version_const_block(tmp_path: Path) -> None:
+    f = tmp_path / "version.go"
+    f.write_text(
+        'package version\n\nconst (\n\tVersion = "2.0.0"\n\tOther = "x"\n)\n',
+        encoding="utf-8",
+    )
+    target = VersionTarget(path=f, kind="go_version")
+    assert read_version_string(target) == "2.0.0"
+
+
+def test_replace_go_version_const_block(tmp_path: Path) -> None:
+    f = tmp_path / "version.go"
+    original = 'package version\n\nconst (\n\tVersion = "2.0.0"\n\tOther = "x"\n)\n'
+    f.write_text(original, encoding="utf-8")
+    target = VersionTarget(path=f, kind="go_version")
+    replace_version_in_file(target, "2.1.0", dry_run=False)
+    assert 'Version = "2.1.0"' in f.read_text(encoding="utf-8")
+    assert 'Other = "x"' in f.read_text(encoding="utf-8")
+
+
+
 
 
 def test_read_go_version_const(tmp_path: Path) -> None:

--- a/tests/test_version_targets.py
+++ b/tests/test_version_targets.py
@@ -1,0 +1,160 @@
+"""Unit tests for the python_version and go_version target kinds."""
+
+from pathlib import Path
+
+import pytest
+
+from repo_release_tools.config import VersionTarget
+from repo_release_tools.version_targets import read_version_string, replace_version_in_file
+
+
+# ---------------------------------------------------------------------------
+# python_version – read
+# ---------------------------------------------------------------------------
+
+
+def test_read_python_version_double_quotes(tmp_path: Path) -> None:
+    f = tmp_path / "__init__.py"
+    f.write_text('__version__ = "1.2.3"\n', encoding="utf-8")
+    target = VersionTarget(path=f, kind="python_version")
+    assert read_version_string(target) == "1.2.3"
+
+
+def test_read_python_version_single_quotes(tmp_path: Path) -> None:
+    f = tmp_path / "__init__.py"
+    f.write_text("__version__ = '4.5.6'\n", encoding="utf-8")
+    target = VersionTarget(path=f, kind="python_version")
+    assert read_version_string(target) == "4.5.6"
+
+
+def test_read_python_version_with_spaces(tmp_path: Path) -> None:
+    f = tmp_path / "__version__.py"
+    f.write_text('__version__  =  "0.0.1"\n', encoding="utf-8")
+    target = VersionTarget(path=f, kind="python_version")
+    assert read_version_string(target) == "0.0.1"
+
+
+def test_read_python_version_missing_raises(tmp_path: Path) -> None:
+    f = tmp_path / "__init__.py"
+    f.write_text("# no version here\n", encoding="utf-8")
+    target = VersionTarget(path=f, kind="python_version")
+    with pytest.raises(RuntimeError, match="Could not find __version__"):
+        read_version_string(target)
+
+
+# ---------------------------------------------------------------------------
+# python_version – write
+# ---------------------------------------------------------------------------
+
+
+def test_replace_python_version_double_quotes(tmp_path: Path) -> None:
+    f = tmp_path / "__init__.py"
+    f.write_text('"""Package."""\n\n__version__ = "1.0.0"\n', encoding="utf-8")
+    target = VersionTarget(path=f, kind="python_version")
+    replace_version_in_file(target, "2.0.0", dry_run=False)
+    assert '__version__ = "2.0.0"' in f.read_text(encoding="utf-8")
+
+
+def test_replace_python_version_single_quotes(tmp_path: Path) -> None:
+    f = tmp_path / "__init__.py"
+    f.write_text("__version__ = '0.1.0'\n", encoding="utf-8")
+    target = VersionTarget(path=f, kind="python_version")
+    replace_version_in_file(target, "0.2.0", dry_run=False)
+    assert "__version__ = '0.2.0'" in f.read_text(encoding="utf-8")
+
+
+def test_replace_python_version_dry_run_no_write(tmp_path: Path, capsys) -> None:
+    f = tmp_path / "__init__.py"
+    original = '__version__ = "1.0.0"\n'
+    f.write_text(original, encoding="utf-8")
+    target = VersionTarget(path=f, kind="python_version")
+    replace_version_in_file(target, "1.1.0", dry_run=True)
+    assert f.read_text(encoding="utf-8") == original
+    assert "Would update" in capsys.readouterr().out
+
+
+def test_replace_python_version_same_version_raises(tmp_path: Path) -> None:
+    f = tmp_path / "__init__.py"
+    f.write_text('__version__ = "1.0.0"\n', encoding="utf-8")
+    target = VersionTarget(path=f, kind="python_version")
+    with pytest.raises(RuntimeError):
+        replace_version_in_file(target, "1.0.0", dry_run=False)
+
+
+# ---------------------------------------------------------------------------
+# go_version – read
+# ---------------------------------------------------------------------------
+
+
+def test_read_go_version_const(tmp_path: Path) -> None:
+    f = tmp_path / "version.go"
+    f.write_text('package version\n\nconst Version = "1.0.0"\n', encoding="utf-8")
+    target = VersionTarget(path=f, kind="go_version")
+    assert read_version_string(target) == "1.0.0"
+
+
+def test_read_go_version_var(tmp_path: Path) -> None:
+    f = tmp_path / "version.go"
+    f.write_text('package version\n\nvar Version = "2.3.4"\n', encoding="utf-8")
+    target = VersionTarget(path=f, kind="go_version")
+    assert read_version_string(target) == "2.3.4"
+
+
+def test_read_go_version_missing_raises(tmp_path: Path) -> None:
+    f = tmp_path / "version.go"
+    f.write_text("package version\n", encoding="utf-8")
+    target = VersionTarget(path=f, kind="go_version")
+    with pytest.raises(RuntimeError, match="Could not find Version"):
+        read_version_string(target)
+
+
+# ---------------------------------------------------------------------------
+# go_version – write
+# ---------------------------------------------------------------------------
+
+
+def test_replace_go_version_const(tmp_path: Path) -> None:
+    f = tmp_path / "version.go"
+    f.write_text('package version\n\nconst Version = "1.0.0"\n', encoding="utf-8")
+    target = VersionTarget(path=f, kind="go_version")
+    replace_version_in_file(target, "1.1.0", dry_run=False)
+    assert 'const Version = "1.1.0"' in f.read_text(encoding="utf-8")
+
+
+def test_replace_go_version_var(tmp_path: Path) -> None:
+    f = tmp_path / "version.go"
+    f.write_text('package version\n\nvar Version = "0.9.0"\n', encoding="utf-8")
+    target = VersionTarget(path=f, kind="go_version")
+    replace_version_in_file(target, "1.0.0", dry_run=False)
+    assert 'var Version = "1.0.0"' in f.read_text(encoding="utf-8")
+
+
+def test_replace_go_version_dry_run_no_write(tmp_path: Path, capsys) -> None:
+    f = tmp_path / "version.go"
+    original = 'package version\n\nconst Version = "1.0.0"\n'
+    f.write_text(original, encoding="utf-8")
+    target = VersionTarget(path=f, kind="go_version")
+    replace_version_in_file(target, "2.0.0", dry_run=True)
+    assert f.read_text(encoding="utf-8") == original
+    assert "Would update" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# VersionTarget.validate() – new kinds accepted
+# ---------------------------------------------------------------------------
+
+
+def test_validate_python_version_kind() -> None:
+    target = VersionTarget(path=Path("__init__.py"), kind="python_version")
+    target.validate()  # must not raise
+
+
+def test_validate_go_version_kind() -> None:
+    target = VersionTarget(path=Path("version.go"), kind="go_version")
+    target.validate()  # must not raise
+
+
+def test_validate_unknown_kind_raises() -> None:
+    target = VersionTarget(path=Path("file.py"), kind="ruby_version")
+    with pytest.raises(ValueError, match="kind must be one of"):
+        target.validate()

--- a/tests/test_version_targets.py
+++ b/tests/test_version_targets.py
@@ -146,7 +146,9 @@ def test_replace_go_version_const_block(tmp_path: Path) -> None:
     assert 'Other = "x"' in f.read_text(encoding="utf-8")
 
 
-
+# ---------------------------------------------------------------------------
+# go_version – read
+# ---------------------------------------------------------------------------
 
 
 def test_read_go_version_const(tmp_path: Path) -> None:


### PR DESCRIPTION
This pull request adds first-class support for managing version numbers in Python and Go source files using new `python_version` and `go_version` target kinds. It enables automatic detection and updating of `__version__` variables in Python files and `Version` constants/variables in Go files, both in explicit configuration and zero-config mode. The update includes robust pattern matching, config validation, and comprehensive tests for these new features.

Fixes #14 

**New version target kinds and detection:**

- Added `python_version` and `go_version` as valid `kind` values for version targets, allowing direct management of `__version__` in Python files and `Version` in Go files. (`src/repo_release_tools/config.py` [[1]](diffhunk://#diff-4827415908d567e602a946ac9cd5f614e8c1925ff0e7324708aa8632b465bf39L39-R47) [[2]](diffhunk://#diff-4827415908d567e602a946ac9cd5f614e8c1925ff0e7324708aa8632b465bf39L120-R128) [[3]](diffhunk://#diff-4827415908d567e602a946ac9cd5f614e8c1925ff0e7324708aa8632b465bf39R178-R180) [[4]](diffhunk://#diff-4827415908d567e602a946ac9cd5f614e8c1925ff0e7324708aa8632b465bf39R603-R606) [[5]](diffhunk://#diff-4827415908d567e602a946ac9cd5f614e8c1925ff0e7324708aa8632b465bf39R552-R559) [[6]](diffhunk://#diff-4827415908d567e602a946ac9cd5f614e8c1925ff0e7324708aa8632b465bf39R703-R708); `src/repo_release_tools/version_targets.py` [[7]](diffhunk://#diff-c69bdf133a5552edd16b11bb23facf5dcc06aa43c716eb4bb00007c84562682eR17-R18) [[8]](diffhunk://#diff-c69bdf133a5552edd16b11bb23facf5dcc06aa43c716eb4bb00007c84562682eR39-R42) [[9]](diffhunk://#diff-c69bdf133a5552edd16b11bb23facf5dcc06aa43c716eb4bb00007c84562682eR105-R114)
- Enhanced zero-config auto-detection to find Python `__version__` files in common layouts (`src/<package>/__init__.py` or `__version__.py`) and Go version files, and updated user guidance accordingly. (`src/repo_release_tools/config.py` [[1]](diffhunk://#diff-4827415908d567e602a946ac9cd5f614e8c1925ff0e7324708aa8632b465bf39L428-R439) [[2]](diffhunk://#diff-4827415908d567e602a946ac9cd5f614e8c1925ff0e7324708aa8632b465bf39L455-R465) [[3]](diffhunk://#diff-4827415908d567e602a946ac9cd5f614e8c1925ff0e7324708aa8632b465bf39R475-R508)

**Version update and read logic:**

- Implemented regular expressions and logic to read and update version numbers in both Python and Go files, supporting both explicit and auto-detected configuration. (`src/repo_release_tools/version_targets.py` [[1]](diffhunk://#diff-c69bdf133a5552edd16b11bb23facf5dcc06aa43c716eb4bb00007c84562682eR17-R18) [[2]](diffhunk://#diff-c69bdf133a5552edd16b11bb23facf5dcc06aa43c716eb4bb00007c84562682eR39-R42) [[3]](diffhunk://#diff-c69bdf133a5552edd16b11bb23facf5dcc06aa43c716eb4bb00007c84562682eR105-R114)

**Validation and ecosystem handling:**

- Updated config validation to accept the new `kind` values and improved error messages to reflect all supported kinds. (`src/repo_release_tools/config.py` [src/repo_release_tools/config.pyR178-R180](diffhunk://#diff-4827415908d567e602a946ac9cd5f614e8c1925ff0e7324708aa8632b465bf39R178-R180))
- Updated ecosystem detection logic to handle the new target kinds appropriately. (`src/repo_release_tools/config.py` [src/repo_release_tools/config.pyR703-R708](diffhunk://#diff-4827415908d567e602a946ac9cd5f614e8c1925ff0e7324708aa8632b465bf39R703-R708))

**Testing:**

- Added comprehensive tests for reading, updating, and validating `python_version` and `go_version` targets, including dry-run behavior and error cases. (`tests/test_version_targets.py` [[1]](diffhunk://#diff-ab4e574285099ba5ad0e987510331206dd0038ebd6d275e3e4886380d9d147d0R1-R160) `tests/test_bump.py` [[2]](diffhunk://#diff-5cf1c5c4e4059d9cced72b2d33a8b2de8509b375d815407e047246a6f306447aR475-R655)

**Other:**

- Bumped the package version to `0.1.8`. (`src/repo_release_tools/__init__.py` [src/repo_release_tools/__init__.pyL3-R3](diffhunk://#diff-53bd4ffed688f042108fe16db9b3d441ca5ab6039b1ecef76cf4a53eb1152c18L3-R3))