### PR TITLE
feat: Add comprehensive tests for branch management and versioning features

### DIFF
--- a/.github/skills/repo-release-tools-uvx/SKILL.md
+++ b/.github/skills/repo-release-tools-uvx/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: repo-release-tools-uvx
-description: 'Automate Git releases with semantic versioning and conventional commits. Use when: managing release branches, bumping versions safely, automating release workflows without local installation. Use uvx for zero-install access.'
-argument-hint: 'What release task? (branch new|rescue, bump patch|minor|major, or dry-run preview)'
+description: 'Automate Git releases with semantic versioning and conventional commits. Use when: managing release branches, bumping versions safely, automating release workflows without local installation, running health checks, auto-writing changelog bullets, renaming branches, or setting up lefthook. Use uvx for zero-install access.'
+argument-hint: 'What release task? (branch new|rescue|rename, bump patch|minor|major, doctor, init, config, or dry-run preview)'
 ---
 
 # Automated Release Workflows with repo-release-tools
@@ -13,11 +13,13 @@ Manual releases are error-prone: inconsistent branch names, version bumps in wro
 ## The Solution
 
 `repo-release-tools` (`rrt`) enforces **semantic versioning** + **conventional commits** through a CLI that:
-- Creates properly-named feature/fix branches with conventional types (`feat`, `fix`, `chore`, etc.)
-- Bumps versions atomically across multiple files (Python `__version__`, TOML, Cargo)
-- Updates changelogs from git history
+- Creates and renames properly-named feature/fix branches with conventional types
+- Bumps versions atomically across multiple files (Python `__version__`, TOML, Cargo, package.json)
+- Auto-writes changelog bullets from commit subjects (`rrt-update-unreleased` hook)
+- Updates pin targets (GitHub Action refs, pre-commit `rev:` tags) alongside every bump
 - Creates release branches with proper naming (`release/v1.2.3`)
-- Integrates with git hooks and CI/CD for upstream validation
+- Health-checks rrt configuration with `rrt doctor`
+- Integrates with pre-commit, lefthook, and GitHub Actions
 
 The philosophy: releases should be **declarative** (one command), **auditable** (dry-run before executing), and **consistent** (same workflow everywhere).
 
@@ -25,8 +27,10 @@ The philosophy: releases should be **declarative** (one command), **auditable** 
 
 - **Zero-install**: `uvx` runs the tool without pip/homebrew/npm installation
 - **Atomic operations**: Version bumps happen across all targets simultaneously
-- **Pre-commit integration**: Validate branch names and commit messages automatically
-- **CI/CD ready**: GitHub Actions support for automated release validation
+- **Auto-changelog**: `rrt-update-unreleased` writes bullets directly into `[Unreleased]` on every commit
+- **Pin sync**: `pin_targets` keeps GitHub Action refs and pre-commit `rev:` in step with every bump
+- **Health checks**: `rrt doctor` / `rrt-hooks doctor` verify all targets before you release
+- **CI/CD ready**: GitHub Actions support for automated policy enforcement
 - **Dry-run first**: Preview changes before modifying repository state
 
 ## Installation Methods
@@ -38,181 +42,184 @@ Best for: CI/CD, scripts, temporary workflows, trying the tool
 ```bash
 uvx repo-release-tools branch new feat "add parser"
 uvx repo-release-tools bump minor --dry-run
+uvx repo-release-tools doctor
 ```
 
 **Why**: No installation step, no version conflicts, always runs the latest version.
 
-### Alternative: pip (Global Install)
+### Alternative: pip / uv tool (Persistent Install)
 
-Best for: Daily use, team standardization, local development
+Best for: Daily use, lefthook integration, local development
 
 ```bash
-pip install repo-release-tools
+pip install repo-release-tools        # or: uv tool install repo-release-tools
 rrt branch new feat "add parser"
 rrt bump patch
+rrt doctor
 ```
-
-**Why**: Single command `rrt` available anywhere; pin version in requirements for reproducibility.
-
-### Development: uv tool (Project-Local)
-
-Best for: Repository maintainers, complex lock commands, development
-
-```bash
-uv tool install .
-rrt --help
-```
-
-**Why**: Project-local installation; lock command uses same `uv` environment as the project.
 
 ## When to Use This Skill
 
-✅ **You should use this skill when:**
+✅ **Use when:**
 - Starting a feature or bug fix (need conventional branch naming)
-- Preparing a release (need to bump versions consistently)
-- Setting up CI/CD validators (branch name, commit message checks)
-- Running dry-run previews before touching production branches
-- Integrating with pre-commit hooks (automatic branch/commit validation)
+- Renaming an in-progress branch to fix type, scope, or description
+- Preparing a release (need to bump versions + pins consistently)
+- Setting up auto-changelog via hooks (lefthook or pre-commit)
+- Setting up CI/CD validators (branch name, commit message, changelog checks)
+- Running a config health check before releasing (`rrt doctor`)
+- Squashing diverged changelog micro-commits after a squash merge
 
-❌ **You might not need this if:**
+❌ **Skip when:**
 - Your team doesn't use semantic versioning
 - Manual releases work fine and rarely have errors
-- Testing version bump logic in multiple files simultaneously isn't a concern
 
 ## Core Workflows
 
 ### Workflow 1: Starting a Feature
 
-**Goal**: Create a branch with proper conventional naming (`feat/`, `fix/`, etc.)
-
-**Why**: Standardized names enable automated changelog generation from branch history.
-
 ```bash
 # Preview the branch (won't create it)
 uvx repo-release-tools branch new feat "add user authentication" --dry-run
 
-# Output shows: Branch: feat/add-user-authentication, Commit: feat: add user authentication
-
-# Create the real branch
+# Create it
 uvx repo-release-tools branch new feat "add user authentication"
 git push -u origin
-
-# Now work, commit, push normally
 ```
 
-### Workflow 2: Preparing a Release
+### Workflow 2: Renaming the Current Branch
 
-**Goal**: Atomically bump versions, update changelog, create release branch
-
-**Why**: Keeps version numbers in sync across files and creates an auditable record of changes
+Use when you mistyped the type, forgot a scope, or need to rebuild the slug.
 
 ```bash
-# Step 1: Preview what will happen
+# Change only the type — slug kept as-is
+rrt branch rename --type fix
+
+# Add a scope to the existing slug
+rrt branch rename --scope auth
+
+# Full rebuild (type inferred from current branch)
+rrt branch rename fix "repair login" --scope auth
+
+# Remove scope and restate description
+rrt branch rename --no-scope feat "add parser"
+
+# Preview without touching git
+rrt branch rename --type docs --dry-run
+```
+
+`rrt branch rename` calls `git branch -m <old> <new>` — local rename only. Push
+the new name with `git push origin :<old> <new>` or `git push --set-upstream origin <new>`.
+
+### Workflow 3: Preparing a Release
+
+```bash
+# Step 1: Health check first
+rrt doctor
+
+# Step 2: Preview the bump
 uvx repo-release-tools bump patch --dry-run
+# Shows: current → new version, branch name, all files that will change
 
-# Output shows:
-#   Current: 1.0.0 → 1.0.1
-#   Branch: release/v1.0.1
-#   Would update: pyproject.toml, src/__init__.py, uv.lock
-#   Would prepend CHANGELOG.md
-
-# Step 2: Execute (for real)
+# Step 3: Execute
 uvx repo-release-tools bump patch
 
-# Step 3: Push the release branch for review/merge
+# Step 4: Push
 git push -u origin release/v1.0.1
 ```
 
-**Options**:
-- `bump patch` / `bump minor` / `bump major` — semantic version increments
-- `bump 1.2.3` — explicit version
+**`bump` options**:
+- `bump patch` / `bump minor` / `bump major` / `bump 1.2.3` — version increment
 - `--dry-run` — preview without changes
 - `--no-changelog` — skip changelog update
-- `--no-commit` — stage files but don't commit (for manual review)
+- `--no-commit` — stage only, for manual review
+- `--force` — recreate an existing release branch after last-minute fixes
+- `--no-pin-sync` — skip `pin_targets` for this run
 
-### Workflow 3: Emergency Hotfixes
-
-**Goal**: Create a rescue branch for critical fixes
+### Workflow 4: Emergency Hotfixes
 
 ```bash
 uvx repo-release-tools branch rescue fix "critical authentication bypass"
-
 # Creates: rescue/fix/critical-authentication-bypass
-# Commit message: fix: critical authentication bypass
 ```
 
-**Why**: "rescue" branches signal urgent work; they're tracked separately from feature work.
-
-
-## Release Philosophy: Principles
-
-This tool embodies three core principles:
-
-**1. Atomicity**
-A release succeeds completely or fails completely. No partial updates, no forgotten files, no drift between version strings.
-
-**2. Auditability**
-Every release creates a git commit and branch with a clear history. The changelog is part of the repository. Anyone can review what changed and when.
-
-**3. Consistency**
-The same workflow works across all your projects. Feature naming, version increments, changelog format—standardized everywhere.
-
-Add to `.pre-commit-config.yaml` for branch/commit validation:
-
-```yaml
-default_install_hook_types: [pre-commit, commit-msg]
-
-repos:
-  - repo: https://github.com/Anselmoo/repo-release-tools
-    rev: v0.1.0
-    hooks:
-      - id: rrt-branch-name
-      - id: rrt-changelog
-      - id: rrt-commit-subject
-```
-
-Then install and run:
+### Workflow 5: Health Check Before Release
 
 ```bash
-pre-commit install --hook-type pre-commit --hook-type commit-msg
-pre-commit run --all-files
+rrt doctor
+# or via hooks runner:
+rrt-hooks doctor
 ```
 
-## GitHub Action Integration
+Shows a tree of every version target (file exists + version readable), every pin
+target (file exists + pattern compiles + pattern matches), and the changelog file.
+Exits 0 when all checks pass, 1 when any hard check fails.
 
-**What it does**: Validate release branches and commit messages in CI/CD.
+### Workflow 6: Initialising a New Repository
 
-**Why**: Catch policy violations before merge. Run version bump validations on pull requests.
+```bash
+rrt init                   # writes .rrt.toml
+rrt init --target pyproject  # appends [tool.rrt] to pyproject.toml
+rrt init --target cargo      # appends to Cargo.toml
+rrt init --target node       # merges "rrt": {...} into package.json
+rrt init --dry-run           # preview without writing
+```
+
+### Workflow 7: Inspecting Resolved Config
+
+```bash
+rrt config
+```
+
+Prints every version group, release branch pattern, changelog path, lock command,
+version targets, and generated files — exactly what `bump` would act on.
+
+### Workflow 8: Squash-Merge Changelog Cleanup
+
+After a squash merge, `rrt-update-unreleased` may have added per-micro-commit
+bullets that cancel each other out or duplicate. Clean up with:
+
+```bash
+# Run on the default branch after the squash merge lands
+rrt-hooks changelog post-correct          # dry mode — shows what would change
+rrt-hooks changelog post-correct --commit  # rewrites + creates follow-up commit
+```
+
+Can also run as a GitHub Actions step post-merge:
 
 ```yaml
-- uses: Anselmoo/repo-release-tools@v0.1.0
-  with:
-    check-branch-name: "true"
-    check-changelog: "true"
-    check-commit-subject: "true"
+- name: Consolidate changelog after squash merge
+  if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+  run: uvx --from repo-release-tools rrt-hooks changelog post-correct --commit
 ```
 
-**Use case**: Ensure only properly-formatted release PRs merge to `main`. Tag-triggered workflows automatically skip branch-name validation.
+---
 
 ## Configuring Your Repository
 
-Each repository that uses `repo-release-tools` needs a `[tool.rrt]` section in
-`pyproject.toml`, `.rrt.toml`, or `.config/rrt.toml`.
+`rrt` discovers config in this order: `pyproject.toml` → `package.json` →
+`Cargo.toml` → `.rrt.toml` → `.config/rrt.toml`. Each stores the same settings
+in its native format.
 
-**Why**: Version bumps must touch every place the version appears—Python files, lock files, package manifests. This config specifies all those targets.
+### Minimal config
 
 ```toml
 [tool.rrt]
-# Release branch naming pattern
 release_branch = "release/v{version}"
-
-# Changelog file (created by the tool)
 changelog_file = "CHANGELOG.md"
 
-# Lock command run during bump (optional; useful for projects with lock files)
+[[tool.rrt.version_targets]]
+path = "pyproject.toml"
+kind = "pep621"
+```
+
+### Full example with pin targets
+
+```toml
+[tool.rrt]
+release_branch = "release/v{version}"
+changelog_file = "CHANGELOG.md"
 lock_command = ["uv", "lock", "-U"]
 
-# Version targets: every place version needs to appear
 [[tool.rrt.version_targets]]
 path = "pyproject.toml"
 kind = "pep621"
@@ -221,90 +228,251 @@ kind = "pep621"
 path = "src/my_package/__init__.py"
 pattern = '^(\s*__version__\s*=\s*")([^"]+)(")'
 
-[[tool.rrt.version_targets]]
-path = "Cargo.toml"
-section = "workspace.package"
-field = "version"
+# Auto-update GitHub Action refs and pre-commit rev: tags on every bump
+[[tool.rrt.pin_targets]]
+path = "docs/github-action.md"
+pattern = '(Anselmoo/repo-release-tools@v)(\d+\.\d+\.\d+)()'
+
+[[tool.rrt.pin_targets]]
+path = ".pre-commit-config.yaml"
+pattern = '(rev: v)(\d+\.\d+\.\d+)()'
 ```
 
-### Version Target Modes
+`pin_targets` use a 3-group capture pattern: group 1 and 3 are preserved verbatim;
+group 2 (the bare semver) is replaced. All occurrences are updated.
 
-- **`kind = "pep621"`**: Update `[project].version` in `pyproject.toml` (Python standard)
-- **`kind = "package_json"`**: Update the top-level `version` field in `package.json`
-- **`pattern`**: Regex with capture groups—updates any file format. Groups 1 & 3 are preserved; group 2 is replaced with new version
-- **`section` + `field`**: TOML path lookup (e.g., `workspace.package` → `[workspace.package]`)
+### Version target modes
 
-**Design principle**: All targets are atomic—either all succeed or all fail. This prevents partial updates.
+| Mode | Use case |
+|---|---|
+| `kind = "pep621"` | `[project].version` in `pyproject.toml` |
+| `kind = "package_json"` | Top-level `version` in `package.json` |
+| `pattern` | Regex replacement in any file format (3 groups) |
+| `section` + `field` | TOML path lookup (e.g. `workspace.package`) |
 
-## Common Commands
+### Zero-config mode
 
-| Task | Command |
-|------|---------|
-| Create feature branch | `uvx repo-release-tools branch new feat "description"` |
-| Create fix branch | `uvx repo-release-tools branch rescue fix "description"` |
-| Bump patch version | `uvx repo-release-tools bump patch` |
-| Bump minor version | `uvx repo-release-tools bump minor` |
-| Bump major version | `uvx repo-release-tools bump major` |
-| Set explicit version | `uvx repo-release-tools bump 1.2.3` |
-| Dry-run any command | Add `--dry-run` flag |
-| Skip changelog | Add `--no-changelog` flag |
-| Skip commit | Add `--no-commit` flag |
+For basic versioning, `rrt` can work without `[tool.rrt]` — it auto-detects
+root-level `pyproject.toml`, `package.json`, and `Cargo.toml`. Auto-detected
+files must already agree on the current version before `bump`.
 
-## Troubleshooting & Common Issues
-
-### "Missing [tool.rrt] configuration"
-
-**What happened**: The tool couldn't find `[tool.rrt]` in your `pyproject.toml`.
-
-**Fix**: Add the configuration section (see "Configuring Your Repository"). Even a minimal config works:
+### Hybrid repositories (version groups)
 
 ```toml
 [tool.rrt]
-[[tool.rrt.version_targets]]
+default_group = "python"
+
+[[tool.rrt.version_groups]]
+name = "python"
+release_branch = "release/python/v{version}"
+
+[[tool.rrt.version_groups.version_targets]]
 path = "pyproject.toml"
 kind = "pep621"
+
+[[tool.rrt.version_groups]]
+name = "web"
+release_branch = "release/web/v{version}"
+
+[[tool.rrt.version_groups.version_targets]]
+path = "package.json"
+kind = "package_json"
 ```
 
+```bash
+rrt bump patch --group web
+rrt ci-version compute --group python
+```
+
+---
+
+## Hook Integration
+
+### pre-commit (Python-native hook runner)
+
+```yaml
+# .pre-commit-config.yaml
+default_install_hook_types: [pre-commit, commit-msg]
+
+repos:
+  - repo: https://github.com/Anselmoo/repo-release-tools
+    rev: v0.1.10
+    hooks:
+      - id: rrt-branch-name        # pre-commit: validate branch name
+      - id: rrt-update-unreleased  # commit-msg: auto-write changelog bullet
+      - id: rrt-commit-subject     # commit-msg: validate conventional commit
+      - id: rrt-changelog          # pre-commit: require staged changelog for feat/fix
+```
+
+Install:
+
+```bash
+pre-commit install --hook-type pre-commit --hook-type commit-msg
+```
+
+Optional hooks:
+- `rrt-dirty-tree` — fail on uncommitted changes; best at `pre-push` or `manual` stage
+- `rrt-doctor` — health-check rrt config; run as `manual` stage on demand
+
+### lefthook (faster, language-agnostic)
+
+Requires `uv tool install repo-release-tools` so `rrt-hooks` is on `$PATH`.
+
+```yaml
+# lefthook.yml
+pre-commit:
+  commands:
+    rrt-branch-name:
+      run: rrt-hooks pre-commit
+
+commit-msg:
+  commands:
+    rrt-update-unreleased:
+      run: rrt-hooks update-unreleased --message-file {1}
+    rrt-commit-subject:
+      run: rrt-hooks commit-msg {1}
+
+pre-push:
+  commands:
+    rrt-changelog:
+      run: rrt-hooks check-changelog --subject "$(git log -1 --format=%s)" --strategy unreleased
+```
+
+### How `rrt-update-unreleased` works
+
+On every `commit-msg` run it:
+1. Parses the commit subject (conventional commit format).
+2. For `feat`, `fix`, `refactor`, `perf`, `docs` — appends a bullet under `## [Unreleased]` in `CHANGELOG.md`.
+3. For `chore`, `ci`, `build`, `test`, `deps` — **silently skips** (Maintenance section; no entry required).
+4. Writes and **stages** `CHANGELOG.md` so the update is part of the same commit.
+
+### Known issue: duplicate bullets from changelog-meta commits
+
+If you commit a "fix:" that itself contains changelog-related text (e.g.
+`fix: update changelog entries`), `rrt-update-unreleased` adds a new bullet from
+that subject, which then appears in subsequent hook runs. This creates
+near-duplicate or contradictory entries in `[Unreleased]`.
+
+**Solution A — squash before push** (recommended for iterative work):
+```bash
+# Squash local commits since upstream into one clean commit
+rrt git squash-local "feat: add authentication module"
+```
+
+**Solution B — post-correct after squash merge** (recommended for shared branches):
+```bash
+rrt-hooks changelog post-correct --commit
+```
+
+**Solution C — `unreleased` changelog strategy** (avoids per-commit file checks):
+Use `--strategy unreleased` on the pre-push guard. The `[Unreleased]` section
+only needs to be non-empty, not contain a specific file diff. This decouples
+changelog presence enforcement from per-commit writes.
+
+### Changelog strategies
+
+| Strategy | When the check passes |
+|---|---|
+| `per-commit` (default) | `CHANGELOG.md` appears in the commit's changed files |
+| `unreleased` | `## [Unreleased]` section is non-empty |
+| `release-only` | Check always skipped (changelog updated at release time only) |
+
+Pass via CLI: `--strategy unreleased` or via Action: `changelog-strategy: "unreleased"`.
+
+---
+
+## GitHub Action Integration
+
+```yaml
+- uses: actions/checkout@v6
+
+- uses: Anselmoo/repo-release-tools@v0.1.10
+  with:
+    check-branch-name: "true"
+    check-commit-subject: "true"
+    check-changelog: "true"
+    changelog-strategy: "unreleased"   # or "per-commit" / "release-only"
+    check-dirty-tree: "false"
+    check-doctor: "false"              # set "true" to run rrt doctor in CI
+```
+
+**All inputs**:
+
+| Input | Default | Description |
+|---|---|---|
+| `check-branch-name` | `"true"` | Validate branch naming convention |
+| `check-commit-subject` | `"true"` | Validate conventional commit subject |
+| `check-changelog` | `"true"` | Require changelog update for feat/fix commits |
+| `changelog-strategy` | `"per-commit"` | `per-commit` / `unreleased` / `release-only` |
+| `check-dirty-tree` | `"false"` | Fail when work tree has uncommitted changes |
+| `check-doctor` | `"false"` | Run `rrt doctor` health checks (exits 1 on failures) |
+| `branch-name` | — | Override the branch name to validate |
+| `commit-subject` | — | Override the commit subject to validate |
+| `changelog-file` | `"CHANGELOG.md"` | Path to changelog file |
+
+Tag-triggered workflows skip branch-name validation automatically.
+
+---
+
+## Common Commands Reference
+
+| Task | Command |
+|---|---|
+| Create feature branch | `rrt branch new feat "description"` |
+| Create rescue branch | `rrt branch rescue fix "description"` |
+| Rename current branch | `rrt branch rename --type fix --scope auth` |
+| Bump patch version | `rrt bump patch` |
+| Bump minor / major | `rrt bump minor` / `rrt bump major` |
+| Set explicit version | `rrt bump 1.2.3` |
+| Dry-run any command | Add `--dry-run` |
+| Skip changelog | `--no-changelog` |
+| Skip commit | `--no-commit` |
+| Skip pin sync | `--no-pin-sync` |
+| Health check config | `rrt doctor` |
+| Inspect resolved config | `rrt config` |
+| Init rrt config | `rrt init` |
+| Squash local commits | `rrt git squash-local "message"` |
+| Stage + commit helper | `rrt git commit "message"` |
+| Post-squash cleanup | `rrt-hooks changelog post-correct --commit` |
+
+---
+
+## Troubleshooting
+
+### "Missing [tool.rrt] configuration"
+Run `rrt init` — it generates a tailored config for the current repo. Or add a
+minimal `[tool.rrt]` block manually and verify with `rrt config`.
+
+### Health check fails (rrt doctor)
+`rrt doctor` exits 1 and prints `✖` markers for missing files or broken patterns.
+Fix the flagged paths, then re-run `rrt doctor` to confirm all checks pass before bumping.
+
 ### "Branch already exists"
-
-**What happened**: You tried to create a release branch that already exists.
-
-**Options**:
-- Delete the old branch: `git branch -d release/v1.0.1`
-- Choose a different version: `uvx repo-release-tools bump minor`
-- Learn what happened: `git log release/v1.0.1 -1`
+Use `--force` to recreate it: `rrt bump patch --force`.
 
 ### "Version replacement had no effect"
-
-**What happened**: The regex pattern didn't match the file format.
-
-**Debug**:
-```bash
-# Check what the file actually looks like
-cat src/my_package/__init__.py
-
-# Verify your pattern matches (test in Python)
+Test your pattern:
+```python
 import re
 pattern = r'^(\s*__version__\s*=\s*")([^"]+)(")'
-with open("src/my_package/__init__.py") as f:
-    if re.search(pattern, f.read(), re.MULTILINE):
-        print("✓ Pattern matches!")
-    else:
-        print("✗ Pattern doesn't match—adjust it")
+print(bool(re.search(pattern, open("src/pkg/__init__.py").read(), re.MULTILINE)))
 ```
 
 ### "Working tree has uncommitted changes"
+Commit or stash first, or use `--dry-run` to preview without touching the tree.
 
-**What happened**: Your git repository has uncommitted files; the tool won't overwrite them.
+### Duplicate / cancelling changelog bullets after squash merge
+Run `rrt-hooks changelog post-correct --commit` on the default branch. It removes
+exact duplicates and semantically-cancelling pairs (e.g. `add Node 26` / `remove Node 26`)
+from the exact diff hunk introduced by the squash commit, leaving older release
+sections untouched.
 
-**Options**:
-- Commit your work: `git add . && git commit -m "..."`
-- Stash it temporarily: `git stash`
-- Preview first: `uvx repo-release-tools bump patch --dry-run`
+---
 
 ## Next Steps
 
 - **Read more**: https://github.com/Anselmoo/repo-release-tools
-- **Set up pre-commit**: Add hooks to enforce branch naming automatically
-- **Integrate with CI**: Use the GitHub Action for release validation
-- **Customize**: Adjust `[tool.rrt]` to match your versioning needs
+- **Docs**: https://anselmoo.github.io/repo-release-tools/
+- **Set up hooks**: Add pre-commit or lefthook config for automated enforcement
+- **Integrate CI**: Use the GitHub Action for policy gates on pull requests
+- **Health check**: Run `rrt doctor` before every release to catch config drift early

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -46,3 +46,13 @@
   always_run: true
   stages: [manual, pre-push]
   minimum_pre_commit_version: "3.2.0"
+
+- id: rrt-doctor
+  name: repo-release-tools doctor
+  description: Health-check the rrt configuration (version targets, pin targets, changelog)
+  entry: rrt-hooks doctor
+  language: python
+  pass_filenames: false
+  always_run: true
+  stages: [manual]
+  minimum_pre_commit_version: "3.2.0"

--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,9 @@ inputs:
   check-dirty-tree:
     description: Whether to fail when the checked-out work tree is dirty
     default: "false"
+  check-doctor:
+    description: Whether to run rrt doctor health checks (version targets, pin targets, changelog)
+    default: "false"
 
 runs:
   using: composite
@@ -116,3 +119,11 @@ runs:
       run: |
         set -euo pipefail
         rrt-hooks check-dirty-tree
+
+    - name: Run rrt doctor health checks
+      if: inputs.check-doctor == 'true'
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        set -euo pipefail
+        rrt-hooks doctor

--- a/docs/agent-instructions.md
+++ b/docs/agent-instructions.md
@@ -406,3 +406,40 @@ rrt-hooks check-dirty-tree
 
 Use these commands to reproduce a CI failure locally before pushing. All subcommands accept `--dry-run` for safe inspection.
 ````
+
+## pin_targets — auto-sync version pins in docs and CI
+
+`pin_targets` keeps action refs and pre-commit `rev:` tags in sync with your project version automatically during `rrt bump`.
+
+### When to add pin_targets
+
+Add entries whenever your docs or CI reference the tool's own version as a pin that drifts (e.g. `uses: org/repo@v1.2.3` or `rev: v1.2.3`).
+
+### Config placement
+
+```toml
+# pyproject.toml — global (applies to all version groups)
+[[tool.rrt.pin_targets]]
+path = "docs/github-action.md"
+pattern = '(Anselmoo/repo-release-tools@v)(\d+\.\d+\.\d+)()'
+
+[[tool.rrt.pin_targets]]
+path = "docs/pre-commit.md"
+pattern = '(rev: v)(\d+\.\d+\.\d+)()'
+```
+
+Pattern convention: exactly 3 capture groups — `(prefix)(semver)(suffix)`.
+The suffix can be empty: use `()` as the third group.
+
+### Bump behavior
+
+1. `rrt bump <kind>` updates version targets as usual.
+2. Then for each pin entry (global + group-level, deduplicated), runs `replace_pin_in_file`.
+3. Pin files are staged alongside version files before the git commit.
+4. `--no-pin-sync` skips this step entirely for a one-off run.
+
+### Validation
+
+```bash
+rrt bump minor --dry-run   # preview — shows "Would update" for each pin file
+```

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -7,7 +7,7 @@
 ```yaml
 - uses: actions/checkout@v6
 
-- uses: Anselmoo/repo-release-tools@v0.1.7
+- uses: Anselmoo/repo-release-tools@v0.1.10
   with:
     check-branch-name: "true"
     check-changelog: "true"
@@ -21,6 +21,7 @@
 - changelog updates for feature/fix/breaking work
 - conventional commit subjects
 - optional clean-worktree enforcement
+- optional `rrt doctor` config health checks
 
 ## Important behavior
 
@@ -28,20 +29,36 @@
 - The action installs `repo-release-tools` from the action checkout, not from
   the consumer repository.
 
-## Useful inputs
+## Inputs
 
-- `check-branch-name`
-- `check-changelog`
-- `check-commit-subject`
-- `check-dirty-tree`
-- `branch-name`
-- `branch-ref-type`
-- `commit-subject`
-- `changelog-file`
+| Input | Default | Description |
+|---|---|---|
+| `check-branch-name` | `"true"` | Validate branch naming convention |
+| `check-commit-subject` | `"true"` | Validate conventional commit subject |
+| `check-changelog` | `"true"` | Require changelog update for feat/fix/breaking commits |
+| `changelog-strategy` | `"per-commit"` | `per-commit` / `unreleased` / `release-only` |
+| `check-dirty-tree` | `"false"` | Fail when work tree has uncommitted changes after checks |
+| `check-doctor` | `"false"` | Run `rrt doctor` health checks (exits 1 on any failure) |
+| `branch-name` | — | Override the branch name to validate |
+| `branch-ref-type` | — | Override branch ref type detection |
+| `commit-subject` | — | Override the commit subject to validate |
+| `changelog-file` | `"CHANGELOG.md"` | Path to changelog file |
 
-`check-dirty-tree` defaults to `false` because a GitHub Action checkout is
+### Changelog strategies
+
+| Strategy | When the check passes |
+|---|---|
+| `per-commit` (default) | `CHANGELOG.md` appears in the commit's changed files |
+| `unreleased` | `## [Unreleased]` section is non-empty |
+| `release-only` | Check always skipped (changelog updated only at release time) |
+
+`check-dirty-tree` defaults to `"false"` because a GitHub Actions checkout is
 usually clean already. It is still useful for workflows that generate files and
 want to assert that the job did not leave uncommitted changes behind.
+
+`check-doctor` runs `rrt doctor`, which verifies that every version target and
+pin target in `[tool.rrt]` is reachable and well-formed. Recommended as a
+pre-release gate.
 
 ## Docs publishing
 

--- a/docs/pre-commit.md
+++ b/docs/pre-commit.md
@@ -9,11 +9,12 @@ default_install_hook_types: [pre-commit, commit-msg]
 
 repos:
   - repo: https://github.com/Anselmoo/repo-release-tools
-    rev: v0.1.7
+    rev: v0.1.10
     hooks:
-      - id: rrt-branch-name
-      - id: rrt-changelog
-      - id: rrt-commit-subject
+      - id: rrt-branch-name        # pre-commit: validate branch name
+      - id: rrt-update-unreleased  # commit-msg: auto-write changelog bullet
+      - id: rrt-changelog          # pre-commit: require changelog for feat/fix
+      - id: rrt-commit-subject     # commit-msg: validate conventional commit
 ```
 
 Install both hook types:
@@ -24,10 +25,14 @@ pre-commit install --hook-type pre-commit --hook-type commit-msg
 
 ## Hook overview
 
-- `rrt-branch-name` — validates branch names
-- `rrt-changelog` — requires staged changelog updates for feature/fix/breaking work
-- `rrt-commit-subject` — validates conventional commit subjects
-- `rrt-dirty-tree` — optional manual or pre-push check that fails on uncommitted changes
+| Hook | Stage | Description |
+|---|---|---|
+| `rrt-branch-name` | pre-commit | Validate branch naming convention |
+| `rrt-update-unreleased` | commit-msg | Auto-write bullet under `[Unreleased]` for feat/fix commits |
+| `rrt-changelog` | pre-commit | Require a staged changelog update for feat/fix/breaking work |
+| `rrt-commit-subject` | commit-msg | Validate conventional commit subjects |
+| `rrt-dirty-tree` | pre-push / manual | Fail on uncommitted changes |
+| `rrt-doctor` | manual | Run `rrt doctor` health checks on rrt config |
 
 ## Dirty tree check
 
@@ -39,10 +44,22 @@ clean repository before publishing work:
 ```yaml
 repos:
   - repo: https://github.com/Anselmoo/repo-release-tools
-    rev: v0.1.7
+    rev: v0.1.10
     hooks:
       - id: rrt-dirty-tree
         stages: [pre-push]
+```
+
+## Doctor check
+
+`rrt-doctor` runs `rrt doctor` health checks against every version target and
+pin target in `[tool.rrt]`. It is registered at the `manual` stage so it does
+not run on every commit — invoke it on demand before releases:
+
+```bash
+pre-commit run rrt-doctor --hook-stage manual
+# or directly:
+rrt doctor
 ```
 
 You can also run the same logic directly:
@@ -168,6 +185,11 @@ When you commit, lefthook runs two `commit-msg` commands:
 The `pre-push` guard (`rrt-hooks check-changelog --strategy unreleased`) catches the rare case
 where someone committed with `--no-verify`: it checks that `## [Unreleased]` is
 non-empty before the push is allowed.
+
+**Changelog-meta commit guard**: commits whose description contains the word
+`changelog` (e.g. `fix: update changelog entries`) are automatically skipped by
+`rrt-update-unreleased`. This prevents recursive bullets where a changelog
+correction commit would itself appear in `[Unreleased]`.
 
 ### Comparison: pre-commit vs. lefthook
 

--- a/docs/rrt-cli.md
+++ b/docs/rrt-cli.md
@@ -378,7 +378,7 @@ pattern = '(badge/version-v)(\d+\.\d+\.\d+)(-blue)'
 - Files are staged alongside the main version files.
 - If a pattern matches multiple lines, all occurrences are updated.
 - A warning is printed when the pattern produces no match.
-- Already-current pins are skipped silently.
+- Already-current pins are left unchanged and a status line is printed.
 
 ### Skip flag
 
@@ -399,13 +399,13 @@ It produces a tree report — green `✔` for passing checks, red `✖` for fail
 
 ### What it checks
 
-| Check | Pass condition |
-|---|---|
-| Version target files | File exists at the declared path |
-| Version target readability | Version string can be read from the file |
-| Pin target files | File exists at the declared path |
-| Pin target patterns | Pattern compiles and matches at least once |
-| Changelog file | File exists at `changelog_file` |
+| Check | Pass condition | Failure condition |
+|---|---|---|
+| Version target files | File exists at the declared path | File not found → exits 1 |
+| Version target readability | Version string can be read from the file | Unreadable → warning only, exits 0 |
+| Pin target files | File exists at the declared path | File not found → exits 1 |
+| Pin target patterns | Pattern compiles and matches in the file | No match → warning only, exits 0 |
+| Changelog file | File exists at `changelog_file` | File not found → exits 1 |
 
 ### Exit behavior
 

--- a/docs/rrt-cli.md
+++ b/docs/rrt-cli.md
@@ -21,6 +21,9 @@ rrt init
 rrt config
 rrt branch new feat "add parser"
 rrt branch rescue fix "recover release work"
+rrt branch rename --type feat
+rrt branch rename --scope cli
+rrt branch rename fix "add helper" --scope utils
 rrt git commit "add parser"
 rrt git sync
 rrt git diff
@@ -34,6 +37,45 @@ rrt bump 1.2.3 --no-changelog
 Use `rrt bump ... --force` when you need to recreate an existing release branch
 from the chosen base after last-minute fixes, without deleting the branch by
 hand first.
+
+## Branch rename
+
+Rename the **current** branch, updating any combination of type, scope, and
+description without leaving the repo in a broken state.
+
+```bash
+# Change only the type — slug is kept as-is
+rrt branch rename --type feat
+
+# Prepend a scope to the existing slug
+rrt branch rename --scope cli
+
+# Change type + scope (slug kept)
+rrt branch rename --type feat --scope cli
+
+# Full rebuild: type inferred from current branch, new description
+rrt branch rename fix add helper --scope utils
+
+# Remove scope and restate description
+rrt branch rename --no-scope feat "add parser"
+
+# Preview without touching git
+rrt branch rename --type docs --dry-run
+```
+
+### How it works
+
+| What you provide | Behaviour |
+|---|---|
+| `--type` only | Replaces the `type/` prefix; slug unchanged |
+| `--scope` only | Prepends `{scope}-` to the existing slug |
+| description words | Rebuilds from scratch using `BranchName(type, description, scope)` |
+| `--no-scope` + words | Rebuilds without any scope prefix |
+
+`rrt branch rename` calls `git branch -m <old> <new>` — only a local rename,
+no remote tracking branches are moved. Push the new name with
+`git push origin :<old> <new>` or `git push --set-upstream origin <new>` as
+needed.
 
 ## Git workflows
 
@@ -304,3 +346,84 @@ rrt bump patch --group web
 rrt ci-version compute --group python
 rrt ci-version apply 1.4.0.dev1201 --group web
 ```
+
+## Pin targets — auto-sync doc/CI version pins
+
+`pin_targets` lets you declare files that contain version pins (e.g. GitHub Action refs, pre-commit `rev:` tags) and have `rrt bump` update them automatically alongside the main version bump.
+
+### Config
+
+Add entries to `pyproject.toml` (or `.rrt.toml`) using a 3-group capture pattern:
+`(prefix)(bare_semver)(suffix)` — groups 1 and 3 are kept verbatim; group 2 is replaced.
+
+```toml
+# Global — applies to all version groups
+[[tool.rrt.pin_targets]]
+path = "docs/github-action.md"
+pattern = '(Anselmoo/repo-release-tools@v)(\d+\.\d+\.\d+)()'
+
+[[tool.rrt.pin_targets]]
+path = "docs/pre-commit.md"
+pattern = '(rev: v)(\d+\.\d+\.\d+)()'
+
+# Per-group — only applied when bumping that group
+[[tool.rrt.version_groups.pin_targets]]
+path = "README.md"
+pattern = '(badge/version-v)(\d+\.\d+\.\d+)(-blue)'
+```
+
+### Behavior
+
+- Runs after version string updates, before changelog and git commit.
+- Files are staged alongside the main version files.
+- If a pattern matches multiple lines, all occurrences are updated.
+- A warning is printed when the pattern produces no match.
+- Already-current pins are skipped silently.
+
+### Skip flag
+
+```bash
+rrt bump minor --no-pin-sync   # skip pin_targets for this run
+```
+
+## Health checks — rrt doctor
+
+`rrt doctor` verifies that the current `[tool.rrt]` configuration is internally
+consistent and all referenced files are reachable:
+
+```bash
+rrt doctor
+```
+
+It produces a tree report — green `✔` for passing checks, red `✖` for failures.
+
+### What it checks
+
+| Check | Pass condition |
+|---|---|
+| Version target files | File exists at the declared path |
+| Version target readability | Version string can be read from the file |
+| Pin target files | File exists at the declared path |
+| Pin target patterns | Pattern compiles and matches at least once |
+| Changelog file | File exists at `changelog_file` |
+
+### Exit behavior
+
+- Exits `0` when all checks pass.
+- Exits `1` when any check fails. Failing checks print a message under `✖`.
+
+### Usage in CI
+
+```yaml
+- uses: Anselmoo/repo-release-tools@v0.1.10
+  with:
+    check-doctor: "true"
+```
+
+Or run directly in a workflow step:
+
+```bash
+uvx --from repo-release-tools rrt doctor
+```
+
+Run `rrt doctor` before `rrt bump` to confirm targets are set up correctly.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,28 @@ build-backend = "uv_build"
 [dependency-groups]
 dev = ["pytest>=8.0", "pytest-cov>=7.1.0", "ruff>=0.14.0", "ty>=0.0.26"]
 
+[tool.rrt]
+
+[[tool.rrt.version_targets]]
+path = "pyproject.toml"
+kind = "pep621"
+
+[[tool.rrt.version_targets]]
+path = "src/repo_release_tools/__init__.py"
+kind = "python_version"
+
+[[tool.rrt.pin_targets]]
+path = "docs/github-action.md"
+pattern = '(Anselmoo/repo-release-tools@v)(\d+\.\d+\.\d+)()'
+
+[[tool.rrt.pin_targets]]
+path = "docs/pre-commit.md"
+pattern = '(rev: v)(\d+\.\d+\.\d+)()'
+
+[[tool.rrt.pin_targets]]
+path = "docs/agent-instructions.md"
+pattern = '(Anselmoo/repo-release-tools@v|rev: v)(\d+\.\d+\.\d+)()'
+
 [tool.ruff]
 line-length = 100
 target-version = "py312"

--- a/src/repo_release_tools/changelog.py
+++ b/src/repo_release_tools/changelog.py
@@ -291,16 +291,39 @@ def append_to_unreleased(
             new_body = section_body[:sub_pos] + f"\n{bullet}" + section_body[sub_pos:]
         else:
             stripped = section_body.rstrip("\n")
-            new_body = stripped + f"\n\n### {section}\n{bullet}\n"
+            # How many trailing newlines were in the original section body.
+            trailing_n = len(section_body) - len(stripped)
+            # When a version section follows we need at least two newlines
+            # (blank line) as separator.  Without this, stripping the
+            # trailing newlines and adding back only one would abut the
+            # new bullet against the ## [version] header.
+            if section_end_m is not None:
+                trailing_n = max(trailing_n, 2)
+            trailing = "\n" * trailing_n
+            if stripped:
+                # Existing content: append after it with a blank-line gap.
+                # stripped already starts with \n (the blank line after the
+                # [Unreleased] header consumed by \s*$ in the regex).
+                new_body = stripped + f"\n\n### {section}\n{bullet}" + trailing
+            else:
+                # Empty section: one leading \n forms the blank line together
+                # with the \n already at end of content[:insert_pos].
+                new_body = f"\n### {section}\n{bullet}" + trailing
 
         return content[:insert_pos] + new_body + content[section_body_end:]
     else:
-        new_section = f"## [Unreleased]\n\n### {section}\n{bullet}\n\n"
+        new_section = f"## [Unreleased]\n\n### {section}\n{bullet}\n"
         title_m = _CHANGELOG_TITLE_RE.match(content)
         if title_m:
             insert_pos = title_m.end()
-            return content[:insert_pos] + "\n" + new_section + content[insert_pos:]
-        return new_section + content
+            remainder = content[insert_pos:]
+            # Avoid a double blank line: if the existing content already starts
+            # with \n (blank line before first version header), don't add one.
+            separator = "" if remainder.startswith("\n") else "\n"
+            return content[:insert_pos] + "\n" + new_section + separator + remainder
+        # No title line: add a separator before any existing content.
+        separator = "\n" if content and not content.startswith("\n") else ""
+        return new_section + separator + content
 
 
 def _append_to_unreleased_rst(content: str, section: str, bullet: str) -> str:

--- a/src/repo_release_tools/cli.py
+++ b/src/repo_release_tools/cli.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import argparse
 import sys
 
-from repo_release_tools.commands import branch, bump, ci_version, config_cmd, git_cmd, init
+from repo_release_tools.commands import branch, bump, ci_version, config_cmd, doctor, git_cmd, init
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -19,6 +19,7 @@ def build_parser() -> argparse.ArgumentParser:
     bump.register(subparsers)
     ci_version.register(subparsers)
     config_cmd.register(subparsers)
+    doctor.register(subparsers)
     git_cmd.register(subparsers)
     init.register(subparsers)
     return parser

--- a/src/repo_release_tools/commands/branch.py
+++ b/src/repo_release_tools/commands/branch.py
@@ -26,6 +26,7 @@ CONVENTIONAL_TYPES = (
 )
 
 SLUG_MAX = 60
+BRANCH_SLUG_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 
 
 @dataclass(frozen=True)
@@ -181,6 +182,23 @@ def cmd_rename(args: argparse.Namespace) -> int:
             new_slug = f"{scope_slug}-{current_slug}"
         else:
             new_slug = current_slug
+
+        # Validate the resulting slug against the same rules used by branch creation
+        if len(new_slug) > SLUG_MAX:
+            print(
+                f"Computed slug {new_slug!r} is too long ({len(new_slug)} > {SLUG_MAX}). "
+                "Provide a new description to rebuild the slug.",
+                file=sys.stderr,
+            )
+            return 1
+        if not BRANCH_SLUG_RE.fullmatch(new_slug):
+            print(
+                f"Computed slug {new_slug!r} is not valid kebab-case. "
+                "Provide a new description to rebuild the slug.",
+                file=sys.stderr,
+            )
+            return 1
+
         new_name = f"{new_type}/{new_slug}"
         scope_part = f"({scope})" if scope else ""
         commit_title = f"{new_type}{scope_part}: <preserved description>"

--- a/src/repo_release_tools/commands/branch.py
+++ b/src/repo_release_tools/commands/branch.py
@@ -118,6 +118,112 @@ def cmd_new(args: argparse.Namespace) -> int:
     return 0
 
 
+def _parse_current_branch(branch: str) -> tuple[str, str]:
+    """Split ``type/slug`` → ``(type, slug)``.
+
+    Raises :exc:`ValueError` when the branch name does not follow the
+    ``type/slug`` convention expected by *rrt*.
+    """
+    if "/" not in branch:
+        raise ValueError(
+            f"Current branch {branch!r} does not follow the '<type>/<slug>' convention. "
+            "Cannot determine which part to rename."
+        )
+    commit_type, _, slug = branch.partition("/")
+    return commit_type, slug
+
+
+def cmd_rename(args: argparse.Namespace) -> int:
+    """Rename the current branch, changing any combination of type / scope / description."""
+    root = Path.cwd()
+    no_scope: bool = getattr(args, "no_scope", False)
+    new_type_arg: str | None = getattr(args, "type", None)
+    scope: str | None = getattr(args, "scope", None)
+    description_words: list[str] = list(getattr(args, "description", None) or [])
+
+    # Validate: at least one change must be requested
+    if not new_type_arg and not scope and not no_scope and not description_words:
+        print(
+            "Nothing to rename. Specify --type, --scope, --no-scope, or new description words.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # --no-scope without description means we can't strip the embedded scope from the slug
+    if no_scope and not description_words:
+        print(
+            "--no-scope requires description words so the slug can be rebuilt without a scope.",
+            file=sys.stderr,
+        )
+        return 1
+
+    current_branch = git.current_branch(root)
+
+    try:
+        current_type, current_slug = _parse_current_branch(current_branch)
+    except ValueError as exc:
+        print(exc, file=sys.stderr)
+        return 1
+
+    new_type = new_type_arg or current_type
+
+    if description_words:
+        # Full rebuild: type + scope + new description
+        description = join_description(description_words)
+        effective_scope = None if no_scope else scope
+        branch = BranchName(type=new_type, description=description, scope=effective_scope)
+        new_name = branch.slug()
+        commit_title = branch.commit_title()
+    else:
+        # Slug-preserving rename: only type and/or scope prefix changes
+        if scope:
+            scope_slug = re.sub(r"[^a-z0-9]+", "-", scope.lower()).strip("-")
+            new_slug = f"{scope_slug}-{current_slug}"
+        else:
+            new_slug = current_slug
+        new_name = f"{new_type}/{new_slug}"
+        scope_part = f"({scope})" if scope else ""
+        commit_title = f"{new_type}{scope_part}: <preserved description>"
+
+    if new_name == current_branch:
+        print("Branch name is unchanged. Nothing to do.", file=sys.stderr)
+        return 1
+
+    g = output.GLYPHS
+    title = "[DRY RUN] Rename branch" if args.dry_run else "Rename branch"
+    print()
+    print(
+        output.panel(
+            title,
+            [
+                (f"{g.git.branch} From", current_branch),
+                (f"{g.diff.renamed} To", new_name),
+                (f"{g.arrow.right} Commit title", commit_title),
+            ],
+        )
+    )
+    print()
+
+    if not args.dry_run:
+        if git.branch_exists(root, new_name):
+            print(
+                f"Branch '{new_name}' already exists. Delete it first or choose a different name.",
+                file=sys.stderr,
+            )
+            return 1
+        git.run(
+            ["git", "branch", "-m", current_branch, new_name],
+            root,
+            dry_run=False,
+            label="git branch -m",
+        )
+        print(output.ok(f"Done. Renamed '{current_branch}' {g.diff.renamed} '{new_name}'."))
+    print()
+    if args.dry_run:
+        print(output.dry_run_complete("no changes made"))
+    return 0
+
+
 def cmd_rescue(args: argparse.Namespace) -> int:
     """Rescue commits into a new branch."""
     root = Path.cwd()
@@ -232,3 +338,37 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
         help="Rescue commits since this SHA instead of origin/<branch>.",
     )
     rescue_parser.set_defaults(handler=cmd_rescue)
+
+    rename_parser = branch_sub.add_parser(
+        "rename",
+        help="Rename the current branch: change type, scope, description, or any combination.",
+    )
+    rename_parser.add_argument(
+        "--type",
+        dest="type",
+        type=normalize_commit_type,
+        metavar="TYPE",
+        default=None,
+        help="New conventional commit type (e.g. feat, fix, build).",
+    )
+    rename_parser.add_argument(
+        "--scope",
+        metavar="SCOPE",
+        default=None,
+        help="New scope to prefix the slug with.",
+    )
+    rename_parser.add_argument(
+        "--no-scope",
+        action="store_true",
+        default=False,
+        help="Remove the scope from the new branch name (requires description words).",
+    )
+    rename_parser.add_argument(
+        "description",
+        nargs="*",
+        help="New branch description words (replaces the current description).",
+    )
+    rename_parser.add_argument(
+        "--dry-run", action="store_true", help="Preview the rename without touching git."
+    )
+    rename_parser.set_defaults(handler=cmd_rename)

--- a/src/repo_release_tools/commands/bump.py
+++ b/src/repo_release_tools/commands/bump.py
@@ -27,6 +27,7 @@ from repo_release_tools.config import (
 from repo_release_tools.version_targets import (
     check_autodetected_version_consistency,
     read_group_current_version,
+    replace_pin_in_file,
     replace_version_in_file,
 )
 from repo_release_tools.versioning import Version
@@ -227,9 +228,29 @@ def cmd_bump(args: argparse.Namespace) -> int:
                 output.warning(f"Branch '{branch_name}' already exists. Resetting it with --force.")
             )
 
+    g = output.GLYPHS
     print(output.section("Updating version strings"))
-    for target in group.version_targets:
+    total_targets = len(group.version_targets)
+    for i, target in enumerate(group.version_targets, 1):
         replace_version_in_file(target, str(new), dry_run=args.dry_run)
+        if total_targets > 1:
+            print(f"  {g.progress.render_bar(i / total_targets)}")
+
+    all_pins = group.pin_targets + config.global_pin_targets
+    if all_pins and not getattr(args, "no_pin_sync", False):
+        print(f"\n{output.section('Updating doc pins')}")
+        seen_pin_keys: set[tuple[object, str]] = set()
+        unique_pins: list = []
+        for pin in all_pins:
+            key = (pin.path, pin.pattern)
+            if key not in seen_pin_keys:
+                seen_pin_keys.add(key)
+                unique_pins.append(pin)
+        total_pins = len(unique_pins)
+        for i, pin in enumerate(unique_pins, 1):
+            replace_pin_in_file(pin, str(new), dry_run=args.dry_run)
+            if total_pins > 1:
+                print(f"  {g.progress.render_bar(i / total_pins)}")
 
     if not args.no_changelog:
         print(f"\n{output.section('Updating changelog')}")
@@ -266,6 +287,14 @@ def cmd_bump(args: argparse.Namespace) -> int:
             files_to_stage.append(str(path.relative_to(root)))
     if group.changelog_file.exists() and not args.no_changelog:
         files_to_stage.append(str(group.changelog_file.relative_to(root)))
+    if not getattr(args, "no_pin_sync", False):
+        seen_pin_stage: set[tuple[object, str]] = set()
+        for pin in all_pins:
+            key = (pin.path, pin.pattern)
+            if key in seen_pin_stage:
+                continue
+            seen_pin_stage.add(key)
+            files_to_stage.append(str(pin.path.relative_to(root)))
     git.run(
         ["git", "add", *dict.fromkeys(files_to_stage)], root, dry_run=args.dry_run, label="git add"
     )
@@ -302,6 +331,11 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
     )
     parser.add_argument("--no-commit", action="store_true", help="Skip the git commit step.")
     parser.add_argument("--no-changelog", action="store_true", help="Skip updating the changelog.")
+    parser.add_argument(
+        "--no-pin-sync",
+        action="store_true",
+        help="Skip updating doc/CI pin references (pin_targets).",
+    )
     parser.add_argument(
         "--no-update",
         action="store_true",

--- a/src/repo_release_tools/commands/ci_version.py
+++ b/src/repo_release_tools/commands/ci_version.py
@@ -232,8 +232,10 @@ def cmd_ci_version_apply(args: argparse.Namespace) -> int:
 
     version: str = args.version
 
+    g = output.GLYPHS
     print(output.section("Applying CI versions"))
-    for target in ci_targets:
+    total = len(ci_targets)
+    for i, target in enumerate(ci_targets, 1):
         if target.ci_format == "semver_pre":
             version_str = to_semver(version)
             # If the version contains a PEP 440 dev marker but to_semver() made
@@ -253,6 +255,8 @@ def cmd_ci_version_apply(args: argparse.Namespace) -> int:
         except (FileNotFoundError, RuntimeError) as exc:
             print(str(exc), file=sys.stderr)
             return 1
+        if total > 1:
+            print(f"  {g.progress.render_bar(i / total)}")
 
     print()
     if args.dry_run:
@@ -278,7 +282,8 @@ def cmd_ci_version_sync(args: argparse.Namespace) -> int:
     except ValueError as exc:
         print(str(exc), file=sys.stderr)
         return 1
-    print(f"Applying published version: {version}")
+    g = output.GLYPHS
+    print(output.action(f"{g.diff.modified} Applying published version: {version}"))
 
     apply_args = argparse.Namespace(
         version=version, dry_run=args.dry_run, group=getattr(args, "group", None)

--- a/src/repo_release_tools/commands/doctor.py
+++ b/src/repo_release_tools/commands/doctor.py
@@ -1,0 +1,169 @@
+"""rrt doctor — health-check the rrt configuration for the current repository."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+from repo_release_tools import output
+from repo_release_tools.config import (
+    PinTarget,
+    VersionTarget,
+    _describe_version_target,
+    format_autodetected_config_notice,
+    format_missing_tool_rrt_guidance,
+    is_missing_tool_rrt_error,
+    iter_config_files,
+    load_or_autodetect_config,
+)
+from repo_release_tools.version_targets import read_version_string
+
+
+def _check_version_target(target: VersionTarget, root: Path, g) -> tuple[str, bool]:
+    """Return a (label, is_ok) pair for a version target health check."""
+    relative = str(target.path.relative_to(root))
+    kind_hint = _describe_version_target(target, root=root).split("(", 1)
+    suffix = f" ({kind_hint[1]}" if len(kind_hint) > 1 else ""
+
+    if not target.path.exists():
+        return f"{relative}{suffix}  {g.bullet.error} not found", False
+
+    try:
+        version = read_version_string(target)
+        return f"{relative}{suffix}  {g.git.clean} {version}", True
+    except (RuntimeError, ValueError):
+        return f"{relative}{suffix}  {g.bullet.warning} version unreadable", True
+
+
+def _check_pin_target(pin: PinTarget, root: Path, g) -> tuple[str, bool]:
+    """Return a (label, is_ok) pair for a pin target health check."""
+    relative = str(pin.path.relative_to(root))
+
+    if not pin.path.exists():
+        return f"{relative}  {g.bullet.error} not found", False
+
+    try:
+        compiled = re.compile(pin.pattern)
+    except re.error as exc:
+        return f"{relative}  {g.bullet.error} bad pattern: {exc}", False
+
+    text = pin.path.read_text(encoding="utf-8")
+    if compiled.search(text) is None:
+        return f"{relative}  {g.bullet.warning} no match", True
+
+    return f"{relative}  {g.git.clean} match", True
+
+
+def cmd_doctor(args: argparse.Namespace) -> int:  # noqa: ARG001
+    """Check the health of the rrt configuration."""
+    root = Path.cwd()
+    g = output.GLYPHS
+
+    try:
+        config = load_or_autodetect_config(root)
+    except FileNotFoundError:
+        checked = iter_config_files(root)
+        print(format_missing_tool_rrt_guidance(root, checked), file=sys.stderr)
+        return 1
+    except ValueError as exc:
+        if is_missing_tool_rrt_error(exc):
+            print(output.warning("No [tool.rrt] configuration found."), file=sys.stderr)
+            print(format_missing_tool_rrt_guidance(root, iter_config_files(root)), file=sys.stderr)
+            return 1
+        print(str(exc), file=sys.stderr)
+        return 1
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    if config.autodetected:
+        print(output.warning(format_autodetected_config_notice(config)), file=sys.stderr)
+
+    source = "(auto-detected)" if config.autodetected else str(config.config_file.relative_to(root))
+    group_count = len(config.version_groups)
+    plural = "group" if group_count == 1 else "groups"
+    print(
+        output.panel(
+            "rrt doctor",
+            [
+                ("config file", source),
+                ("version groups", f"{group_count} {plural}"),
+            ],
+        )
+    )
+    print()
+
+    all_ok = True
+
+    tree_entries: list[tuple[str, bool, list | None]] = []
+
+    for group in config.version_groups:
+        group_children: list[tuple[str, bool, list | None]] = []
+        group_ok = True
+
+        # Version targets
+        vtarget_children: list[tuple[str, bool, list | None]] = []
+        for target in group.version_targets:
+            label, is_ok = _check_version_target(target, root, g)
+            vtarget_children.append((label, False, None))
+            if not is_ok:
+                group_ok = False
+
+        group_children.append(("version_targets", True, vtarget_children or None))
+
+        # Pin targets (group-level + global, deduplicated)
+        all_pins = group.pin_targets + config.global_pin_targets
+        if all_pins:
+            seen: set[tuple[object, str]] = set()
+            unique_pins = []
+            for pin in all_pins:
+                key = (pin.path, pin.pattern)
+                if key not in seen:
+                    seen.add(key)
+                    unique_pins.append(pin)
+
+            pin_children: list[tuple[str, bool, list | None]] = []
+            for pin in unique_pins:
+                label, is_ok = _check_pin_target(pin, root, g)
+                pin_children.append((label, False, None))
+                if not is_ok:
+                    group_ok = False
+
+            group_children.append(("pin_targets", True, pin_children))
+
+        # Changelog file
+        cl = group.changelog_file
+        if cl.exists():
+            cl_label = f"{cl.relative_to(root)}  {g.git.clean} exists"
+        else:
+            cl_label = f"{cl.relative_to(root)}  {g.bullet.warning} not found"
+
+        group_children.append((cl_label, False, None))
+
+        group_marker = str(g.git.clean) if group_ok else str(g.bullet.error)
+        group_name = f"{group_marker} [{group.name}]"
+        tree_entries.append((group_name, True, group_children))
+
+        if not group_ok:
+            all_ok = False
+
+    print(g.tree.render(tree_entries))
+    print()
+
+    if all_ok:
+        print(output.ok("All health checks passed."))
+        return 0
+    else:
+        print(output.error("One or more health checks failed."))
+        return 1
+
+
+def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    """Register the doctor command."""
+    parser = subparsers.add_parser(
+        "doctor",
+        help="Check the health of the rrt configuration (files, patterns, versions).",
+    )
+    parser.set_defaults(handler=cmd_doctor)

--- a/src/repo_release_tools/commands/doctor.py
+++ b/src/repo_release_tools/commands/doctor.py
@@ -139,6 +139,7 @@ def cmd_doctor(args: argparse.Namespace) -> int:  # noqa: ARG001
             cl_label = f"{cl.relative_to(root)}  {g.git.clean} exists"
         else:
             cl_label = f"{cl.relative_to(root)}  {g.bullet.warning} not found"
+            group_ok = False
 
         group_children.append((cl_label, False, None))
 

--- a/src/repo_release_tools/commands/init.py
+++ b/src/repo_release_tools/commands/init.py
@@ -68,11 +68,12 @@ def _init_rrt_toml(args: argparse.Namespace, *, go: bool = False) -> int:
         print(output.warning(f"Could not generate init config: {exc}"), file=sys.stderr)
         return 1
 
+    g = output.GLYPHS
     print()
     print(
         output.panel(
             "[DRY RUN] Init config" if args.dry_run else "Init config",
-            [("File", DEFAULT_INIT_CONFIG)],
+            [(f"{g.git.commit} File", DEFAULT_INIT_CONFIG)],
         )
     )
     print()
@@ -139,11 +140,12 @@ def _init_manifest(
         print(output.warning(f"Could not generate init config: {exc}"), file=sys.stderr)
         return 1
 
+    g = output.GLYPHS
     print()
     print(
         output.panel(
             "[DRY RUN] Init config" if args.dry_run else "Init config",
-            [("File", manifest), ("Section", section_label)],
+            [(f"{g.git.commit} File", manifest), ("Section", section_label)],
         )
     )
     print()
@@ -200,11 +202,12 @@ def _init_package_json(args: argparse.Namespace) -> int:
 
     preview = _json.dumps({"rrt": rrt_dict}, indent=2)
 
+    g = output.GLYPHS
     print()
     print(
         output.panel(
             "[DRY RUN] Init config" if args.dry_run else "Init config",
-            [("File", "package.json"), ("Key", '"rrt"')],
+            [(f"{g.git.commit} File", "package.json"), ("Key", '"rrt"')],
         )
     )
     print()

--- a/src/repo_release_tools/config.py
+++ b/src/repo_release_tools/config.py
@@ -250,7 +250,7 @@ class PinTarget:
             compiled = re.compile(self.pattern)
         except re.error as exc:
             raise ValueError(f"pin_targets pattern is not a valid regex: {exc}") from exc
-        if compiled.groups < 3:
+        if compiled.groups != 3:
             raise ValueError(
                 "pin_targets pattern must have exactly 3 capture groups (prefix, version, suffix)"
             )

--- a/src/repo_release_tools/config.py
+++ b/src/repo_release_tools/config.py
@@ -6,7 +6,7 @@ import json
 import re
 import tomllib
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from textwrap import dedent
 
@@ -226,6 +226,37 @@ class VersionTarget:
 
 
 @dataclass(frozen=True)
+class PinTarget:
+    """A single doc/CI pin target updated by 'rrt bump'.
+
+    Unlike ``VersionTarget``, ``PinTarget`` is write-only and does not
+    participate in version consistency checks.  Use it to keep version pins
+    in documentation and CI configs (e.g. ``@v1.2.3`` or ``rev: v1.2.3``)
+    in sync with every release.
+
+    The ``pattern`` must follow the 3-group convention used by
+    ``VersionTarget`` custom patterns:
+    - Group 1: constant prefix (e.g. ``(Anselmoo/repo-release-tools@v)``)
+    - Group 2: bare semver being replaced (e.g. ``(\\d+\\.\\d+\\.\\d+)``)
+    - Group 3: constant suffix (e.g. ``()``)
+    """
+
+    path: Path
+    pattern: str
+
+    def validate(self) -> None:
+        """Validate the pin target."""
+        try:
+            compiled = re.compile(self.pattern)
+        except re.error as exc:
+            raise ValueError(f"pin_targets pattern is not a valid regex: {exc}") from exc
+        if compiled.groups < 3:
+            raise ValueError(
+                "pin_targets pattern must have exactly 3 capture groups (prefix, version, suffix)"
+            )
+
+
+@dataclass(frozen=True)
 class VersionGroup:
     """A coordinated release unit inside a repository."""
 
@@ -236,6 +267,7 @@ class VersionGroup:
     generated_files: list[Path]
     version_targets: list[VersionTarget]
     version_source: Path | None = None
+    pin_targets: list[PinTarget] = field(default_factory=list)
 
     def primary_target(self) -> VersionTarget:
         """Return the target used as the canonical version source."""
@@ -261,6 +293,7 @@ class RrtConfig:
     default_group_name: str | None = None
     autodetected: bool = False
     extra_branch_types: tuple[str, ...] = ()
+    global_pin_targets: list[PinTarget] = field(default_factory=list)
 
     def resolve_group(self, name: str | None = None) -> VersionGroup:
         """Resolve a version group by name or default selection rules."""
@@ -942,6 +975,7 @@ def load_config_from_path(root: Path, config_file: Path) -> RrtConfig:
         version_groups=version_groups,
         default_group_name=default_group_name,
         extra_branch_types=extra_branch_types,
+        global_pin_targets=_load_pin_targets(root, raw.get("pin_targets", [])),
     )
 
 
@@ -1183,6 +1217,26 @@ def _load_cargo_toml_config(config_file: Path) -> dict[str, object]:
     )
 
 
+def _load_pin_targets(root: Path, raw_pins: object) -> list[PinTarget]:
+    """Parse a list of pin target tables into ``PinTarget`` objects."""
+    if not isinstance(raw_pins, list):
+        raise ValueError("pin_targets must be an array of tables")
+    pins: list[PinTarget] = []
+    for item in raw_pins:
+        if not isinstance(item, dict):
+            raise ValueError("Each pin_targets entry must be a table")
+        raw_path = item.get("path")
+        raw_pattern = item.get("pattern")
+        if not isinstance(raw_path, str) or not raw_path:
+            raise ValueError("Each pin_targets entry must have a non-empty 'path' string")
+        if not isinstance(raw_pattern, str) or not raw_pattern:
+            raise ValueError("Each pin_targets entry must have a non-empty 'pattern' string")
+        pin = PinTarget(path=root / raw_path, pattern=raw_pattern)
+        pin.validate()
+        pins.append(pin)
+    return pins
+
+
 def _load_version_group(
     root: Path,
     *,
@@ -1260,4 +1314,5 @@ def _load_version_group(
         generated_files=[root / path for path in generated_files],
         version_targets=targets,
         version_source=version_source,
+        pin_targets=_load_pin_targets(root, raw_group.get("pin_targets", [])),
     )

--- a/src/repo_release_tools/hooks.py
+++ b/src/repo_release_tools/hooks.py
@@ -19,6 +19,7 @@ from repo_release_tools.changelog import (
 )
 from repo_release_tools.config import DEFAULT_CHANGELOG, load_extra_branch_types
 from repo_release_tools.commands.branch import CONVENTIONAL_TYPES, SLUG_MAX, normalize_commit_type
+from repo_release_tools.commands.doctor import cmd_doctor
 from repo_release_tools.versioning import Version
 
 
@@ -154,6 +155,21 @@ def commit_subject_requires_changelog(subject: str) -> bool:
     if parsed is None:
         return False
     return commit_type_requires_changelog(parsed.type, breaking=parsed.breaking)
+
+
+def is_changelog_meta_commit(subject: str) -> bool:
+    """Return True when the commit description is itself about updating the changelog.
+
+    Prevents ``rrt-update-unreleased`` from adding a recursive bullet such as
+    ``- update changelog entries`` when someone commits a changelog correction
+    with a subject like ``fix: update changelog to reflect CI changes``.  Any
+    conventional commit whose *description* contains the word ``changelog``
+    (case-insensitive) is treated as a maintenance activity and silently skipped.
+    """
+    parsed = _parse_subject_for_changelog(subject)
+    if parsed is None:
+        return False
+    return "changelog" in parsed.description.lower()
 
 
 def _normalize_repo_path(path: str, *, cwd: Path) -> str:
@@ -543,6 +559,8 @@ def run_update_unreleased(
     """
     if not commit_subject_requires_changelog(subject):
         return 0
+    if is_changelog_meta_commit(subject):
+        return 0
 
     changelog_path = cwd / changelog_file
     if not changelog_path.exists():
@@ -830,6 +848,11 @@ def main(argv: list[str] | None = None) -> int:
         help="Validate that the current working tree is clean.",
     )
 
+    subparsers.add_parser(
+        "doctor",
+        help="Health-check the rrt configuration for the current repository.",
+    )
+
     changelog_parser = subparsers.add_parser(
         "changelog",
         help="Changelog management commands.",
@@ -879,6 +902,8 @@ def main(argv: list[str] | None = None) -> int:
         return run_commit_subject_check(parsed.subject, title="Commit subject validation failed.")
     if parsed.command == "check-dirty-tree":
         return run_dirty_tree_check(Path.cwd(), title="Dirty tree validation failed.")
+    if parsed.command == "doctor":
+        return cmd_doctor(parsed)
     if parsed.command == "update-unreleased":
         if parsed.message_file is not None:
             # Explicit file path — used by lefthook which passes {1} (the commit-msg file).

--- a/src/repo_release_tools/hooks.py
+++ b/src/repo_release_tools/hooks.py
@@ -157,7 +157,9 @@ def commit_subject_requires_changelog(subject: str) -> bool:
 
 
 _CHANGELOG_META_RE = re.compile(
+    # "verb changelog[...]" — maintenance actions on the changelog file itself
     r"\b(?:update|bump|revise|amend|correct|trim)\s+changelog\b"
+    # "changelog noun" — specific meta-nouns that describe changelog maintenance
     r"|\bchangelog\s+(?:entries?|updates?|corrections?|formatting?)\b",
     re.IGNORECASE,
 )

--- a/src/repo_release_tools/hooks.py
+++ b/src/repo_release_tools/hooks.py
@@ -18,7 +18,12 @@ from repo_release_tools.changelog import (
     parse_conventional_commit,
 )
 from repo_release_tools.config import DEFAULT_CHANGELOG, load_extra_branch_types
-from repo_release_tools.commands.branch import BRANCH_SLUG_RE, CONVENTIONAL_TYPES, SLUG_MAX, normalize_commit_type
+from repo_release_tools.commands.branch import (
+    BRANCH_SLUG_RE,
+    CONVENTIONAL_TYPES,
+    SLUG_MAX,
+    normalize_commit_type,
+)
 from repo_release_tools.commands.doctor import cmd_doctor
 from repo_release_tools.versioning import Version
 

--- a/src/repo_release_tools/hooks.py
+++ b/src/repo_release_tools/hooks.py
@@ -18,7 +18,7 @@ from repo_release_tools.changelog import (
     parse_conventional_commit,
 )
 from repo_release_tools.config import DEFAULT_CHANGELOG, load_extra_branch_types
-from repo_release_tools.commands.branch import CONVENTIONAL_TYPES, SLUG_MAX, normalize_commit_type
+from repo_release_tools.commands.branch import BRANCH_SLUG_RE, CONVENTIONAL_TYPES, SLUG_MAX, normalize_commit_type
 from repo_release_tools.commands.doctor import cmd_doctor
 from repo_release_tools.versioning import Version
 
@@ -27,7 +27,6 @@ ALLOWED_BRANCH_NAMES = ("main", "master", "develop")
 MAGIC_BRANCH_TYPES = ("claude", "codex", "copilot")
 BOT_BRANCH_TYPES = ("dependabot", "renovate")
 ALLOWED_BRANCH_TYPES = (*CONVENTIONAL_TYPES, *MAGIC_BRANCH_TYPES, *BOT_BRANCH_TYPES)
-BRANCH_SLUG_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 
 
 def validate_branch_name(
@@ -157,19 +156,29 @@ def commit_subject_requires_changelog(subject: str) -> bool:
     return commit_type_requires_changelog(parsed.type, breaking=parsed.breaking)
 
 
+_CHANGELOG_META_RE = re.compile(
+    r"\b(?:update|bump|revise|amend|correct|trim)\s+changelog\b"
+    r"|\bchangelog\s+(?:entries?|updates?|corrections?|formatting?)\b",
+    re.IGNORECASE,
+)
+
+
 def is_changelog_meta_commit(subject: str) -> bool:
     """Return True when the commit description is itself about updating the changelog.
 
     Prevents ``rrt-update-unreleased`` from adding a recursive bullet such as
     ``- update changelog entries`` when someone commits a changelog correction
-    with a subject like ``fix: update changelog to reflect CI changes``.  Any
-    conventional commit whose *description* contains the word ``changelog``
-    (case-insensitive) is treated as a maintenance activity and silently skipped.
+    with a subject like ``fix: update changelog to reflect CI changes``.
+
+    Only commits whose *description* matches a narrow set of maintenance phrases
+    (e.g. "update changelog", "changelog entries") are treated as meta-commits,
+    so that genuine product changes whose names contain "changelog" (e.g.
+    ``feat: add changelog parser``) are not silently suppressed.
     """
     parsed = _parse_subject_for_changelog(subject)
     if parsed is None:
         return False
-    return "changelog" in parsed.description.lower()
+    return bool(_CHANGELOG_META_RE.search(parsed.description))
 
 
 def _normalize_repo_path(path: str, *, cwd: Path) -> str:

--- a/src/repo_release_tools/version_targets.py
+++ b/src/repo_release_tools/version_targets.py
@@ -195,7 +195,7 @@ def replace_pattern_version(text: str, pattern: str, new_version: str, *, count:
     """Replace a regex-based version, tolerating legacy TOML double escaping.
 
     *count* defaults to 1 (replace only the first occurrence).  Pass ``count=0``
-    to replace all occurrences (used for pin-target substitutions).
+    for unlimited replacements, i.e. all occurrences (used for pin-target substitutions).
     """
     for compiled in compile_pattern_variants(pattern):
         updated, n = compiled.subn(rf"\g<1>{new_version}\g<3>", text, count=count)

--- a/src/repo_release_tools/version_targets.py
+++ b/src/repo_release_tools/version_targets.py
@@ -191,11 +191,15 @@ def replace_package_json_version(text: str, new_version: str) -> str:
     return updated
 
 
-def replace_pattern_version(text: str, pattern: str, new_version: str) -> str:
-    """Replace a regex-based version, tolerating legacy TOML double escaping."""
+def replace_pattern_version(text: str, pattern: str, new_version: str, *, count: int = 1) -> str:
+    """Replace a regex-based version, tolerating legacy TOML double escaping.
+
+    *count* defaults to 1 (replace only the first occurrence).  Pass ``count=0``
+    to replace all occurrences (used for pin-target substitutions).
+    """
     for compiled in compile_pattern_variants(pattern):
-        updated, count = compiled.subn(rf"\g<1>{new_version}\g<3>", text, count=1)
-        if count:
+        updated, n = compiled.subn(rf"\g<1>{new_version}\g<3>", text, count=count)
+        if n:
             return updated
     raise RuntimeError("Configured pattern did not match the target file")
 
@@ -263,7 +267,7 @@ def replace_pin_in_file(
         print(output.status(output.GLYPHS.bullet.dot, f"{path}  already at {new_version}"))
         return
 
-    updated = replace_pattern_version(text, target.pattern, new_version)
+    updated = replace_pattern_version(text, target.pattern, new_version, count=0)
 
     if dry_run:
         print(output.dry_run(f'Would update {path}: pin = "{new_version}"'))

--- a/src/repo_release_tools/version_targets.py
+++ b/src/repo_release_tools/version_targets.py
@@ -9,7 +9,7 @@ import tomllib
 from pathlib import Path
 
 from repo_release_tools import output
-from repo_release_tools.config import RrtConfig, VersionGroup, VersionTarget
+from repo_release_tools.config import PinTarget, RrtConfig, VersionGroup, VersionTarget
 from repo_release_tools.versioning import Version
 
 
@@ -236,3 +236,38 @@ def _detect_json_indent(text: str) -> int | str | None:
             return "\t"
         return len(indent)
     return None
+
+
+def replace_pin_in_file(
+    target: PinTarget,
+    new_version: str,
+    *,
+    dry_run: bool,
+) -> None:
+    """Update a single doc/CI pin reference to ``new_version``.
+
+    Unlike :func:`replace_version_in_file`, this function is lenient:
+    - A non-matching pattern prints a warning and returns without error.
+    - A version already equal to ``new_version`` prints a note and returns.
+    """
+    path = target.path
+    text = path.read_text(encoding="utf-8")
+
+    match = search_pattern(text, target.pattern)
+    if match is None:
+        print(output.warning(f"Pin pattern did not match in {path} — skipping"))
+        return
+
+    current = match.group(2)
+    if current == new_version:
+        print(output.status(output.GLYPHS.bullet.dot, f"{path}  already at {new_version}"))
+        return
+
+    updated = replace_pattern_version(text, target.pattern, new_version)
+
+    if dry_run:
+        print(output.dry_run(f'Would update {path}: pin = "{new_version}"'))
+        return
+
+    path.write_text(updated, encoding="utf-8")
+    print(output.ok(f'{path}  {output.GLYPHS.arrow.right}  pin = "{new_version}"'))

--- a/tests/test_branch.py
+++ b/tests/test_branch.py
@@ -36,3 +36,302 @@ def test_cmd_new_dry_run_uses_summary_panel(capsys) -> None:
 
 def test_branch_validation_accepts_magic_ai_types() -> None:
     assert validate_branch_name("codex/add-parser") is None
+
+
+# ---------------------------------------------------------------------------
+# normalize_commit_type errors
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_commit_type_invalid_raises() -> None:
+    import pytest
+    from argparse import ArgumentTypeError
+    from repo_release_tools.commands.branch import normalize_commit_type
+
+    with pytest.raises((ArgumentTypeError, SystemExit)):
+        normalize_commit_type("invalid_type")
+
+
+def test_normalize_commit_type_uppercase_normalized() -> None:
+    from repo_release_tools.commands.branch import normalize_commit_type
+
+    assert normalize_commit_type("FEAT") == "feat"
+
+
+# ---------------------------------------------------------------------------
+# join_description errors
+# ---------------------------------------------------------------------------
+
+
+def test_join_description_empty_raises() -> None:
+    import pytest
+    from argparse import ArgumentTypeError
+    from repo_release_tools.commands.branch import join_description
+
+    with pytest.raises(ArgumentTypeError, match="empty"):
+        join_description(["", "  "])
+
+
+# ---------------------------------------------------------------------------
+# cmd_rescue dry-run
+# ---------------------------------------------------------------------------
+
+
+def test_cmd_rescue_dry_run(capsys) -> None:
+    """cmd_rescue in dry-run mode should print panel and not touch git."""
+    from repo_release_tools.commands.branch import cmd_rescue
+
+    args = argparse.Namespace(
+        type="fix",
+        description=["extract", "helper"],
+        scope=None,
+        dry_run=True,
+        since=None,
+    )
+
+    result = cmd_rescue(args)
+
+    assert result == 0
+    captured = capsys.readouterr()
+    assert "Rescue commits" in captured.out
+    assert "fix/extract-helper" in captured.out
+    assert "[dry-run] complete" in captured.out
+
+
+def test_cmd_rescue_dry_run_with_since(capsys) -> None:
+    """cmd_rescue with --since in dry-run mode should reference the SHA."""
+    from repo_release_tools.commands.branch import cmd_rescue
+
+    args = argparse.Namespace(
+        type="refactor",
+        description=["cleanup"],
+        scope=None,
+        dry_run=True,
+        since="abc123",
+    )
+
+    result = cmd_rescue(args)
+
+    assert result == 0
+    captured = capsys.readouterr()
+    assert "abc123" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# cmd_rename
+# ---------------------------------------------------------------------------
+
+
+def test_cmd_rename_type_only_dry_run(monkeypatch, capsys) -> None:
+    """--type replaces only the type prefix; slug is preserved."""
+    from repo_release_tools.commands.branch import cmd_rename
+
+    monkeypatch.setattr(
+        "repo_release_tools.commands.branch.git.current_branch",
+        lambda root: "build/introduce-v1",
+    )
+
+    args = argparse.Namespace(
+        type="feat",
+        scope=None,
+        no_scope=False,
+        description=[],
+        dry_run=True,
+    )
+    result = cmd_rename(args)
+
+    assert result == 0
+    out = capsys.readouterr().out
+    assert "build/introduce-v1" in out
+    assert "feat/introduce-v1" in out
+    assert "[dry-run] complete" in out
+
+
+def test_cmd_rename_scope_prepended_dry_run(monkeypatch, capsys) -> None:
+    """--scope prepends the scope to the preserved slug."""
+    from repo_release_tools.commands.branch import cmd_rename
+
+    monkeypatch.setattr(
+        "repo_release_tools.commands.branch.git.current_branch",
+        lambda root: "feat/add-login",
+    )
+
+    args = argparse.Namespace(
+        type=None,
+        scope="auth",
+        no_scope=False,
+        description=[],
+        dry_run=True,
+    )
+    result = cmd_rename(args)
+
+    assert result == 0
+    out = capsys.readouterr().out
+    assert "feat/auth-add-login" in out
+
+
+def test_cmd_rename_full_rebuild_dry_run(monkeypatch, capsys) -> None:
+    """Providing description words triggers a full BranchName rebuild."""
+    from repo_release_tools.commands.branch import cmd_rename
+
+    monkeypatch.setattr(
+        "repo_release_tools.commands.branch.git.current_branch",
+        lambda root: "build/introduce-v1",
+    )
+
+    args = argparse.Namespace(
+        type="feat",
+        scope=None,
+        no_scope=False,
+        description=["introduce", "v2"],
+        dry_run=True,
+    )
+    result = cmd_rename(args)
+
+    assert result == 0
+    out = capsys.readouterr().out
+    assert "feat/introduce-v2" in out
+
+
+def test_cmd_rename_no_change_returns_error(monkeypatch, capsys) -> None:
+    """No change requested should return 1 with a helpful message."""
+    from repo_release_tools.commands.branch import cmd_rename
+
+    monkeypatch.setattr(
+        "repo_release_tools.commands.branch.git.current_branch",
+        lambda root: "feat/my-feature",
+    )
+
+    args = argparse.Namespace(
+        type=None,
+        scope=None,
+        no_scope=False,
+        description=[],
+        dry_run=True,
+    )
+    result = cmd_rename(args)
+
+    assert result == 1
+
+
+def test_cmd_rename_no_scope_without_description_errors(monkeypatch) -> None:
+    """--no-scope without description words is rejected."""
+    from repo_release_tools.commands.branch import cmd_rename
+
+    monkeypatch.setattr(
+        "repo_release_tools.commands.branch.git.current_branch",
+        lambda root: "feat/auth-add-login",
+    )
+
+    args = argparse.Namespace(
+        type=None,
+        scope=None,
+        no_scope=True,
+        description=[],
+        dry_run=True,
+    )
+    result = cmd_rename(args)
+
+    assert result == 1
+
+
+def test_cmd_rename_type_and_description_no_scope(monkeypatch, capsys) -> None:
+    """--no-scope with description rebuilds without scope."""
+    from repo_release_tools.commands.branch import cmd_rename
+
+    monkeypatch.setattr(
+        "repo_release_tools.commands.branch.git.current_branch",
+        lambda root: "feat/auth-add-login",
+    )
+
+    args = argparse.Namespace(
+        type="fix",
+        scope=None,
+        no_scope=True,
+        description=["patch", "login"],
+        dry_run=True,
+    )
+    result = cmd_rename(args)
+
+    assert result == 0
+    out = capsys.readouterr().out
+    assert "fix/patch-login" in out
+
+
+def test_cmd_rename_non_conventional_branch_errors(monkeypatch, capsys) -> None:
+    """A branch name without '/' produces a clear error."""
+    from repo_release_tools.commands.branch import cmd_rename
+
+    monkeypatch.setattr(
+        "repo_release_tools.commands.branch.git.current_branch",
+        lambda root: "main",
+    )
+
+    args = argparse.Namespace(
+        type="feat",
+        scope=None,
+        no_scope=False,
+        description=[],
+        dry_run=True,
+    )
+    result = cmd_rename(args)
+
+    assert result == 1
+    err = capsys.readouterr().err
+    assert "convention" in err
+
+
+def test_cmd_rename_branch_already_exists_returns_error(monkeypatch, capsys) -> None:
+    """When the target branch name already exists, return 1."""
+    from repo_release_tools.commands.branch import cmd_rename
+
+    monkeypatch.setattr(
+        "repo_release_tools.commands.branch.git.current_branch",
+        lambda root: "build/introduce-v1",
+    )
+    monkeypatch.setattr(
+        "repo_release_tools.commands.branch.git.branch_exists",
+        lambda root, name: True,
+    )
+
+    args = argparse.Namespace(
+        type="feat",
+        scope=None,
+        no_scope=False,
+        description=[],
+        dry_run=False,
+    )
+    result = cmd_rename(args)
+
+    assert result == 1
+
+
+def test_cmd_rename_executes_git_branch_m(monkeypatch, capsys) -> None:
+    """Successful non-dry-run rename calls git branch -m."""
+    from repo_release_tools.commands.branch import cmd_rename
+
+    monkeypatch.setattr(
+        "repo_release_tools.commands.branch.git.current_branch",
+        lambda root: "build/introduce-v1",
+    )
+    monkeypatch.setattr(
+        "repo_release_tools.commands.branch.git.branch_exists",
+        lambda root, name: False,
+    )
+    ran: list[list[str]] = []
+    monkeypatch.setattr(
+        "repo_release_tools.commands.branch.git.run",
+        lambda cmd, root, *, dry_run, label: ran.append(cmd),
+    )
+
+    args = argparse.Namespace(
+        type="feat",
+        scope=None,
+        no_scope=False,
+        description=[],
+        dry_run=False,
+    )
+    result = cmd_rename(args)
+
+    assert result == 0
+    assert ran == [["git", "branch", "-m", "build/introduce-v1", "feat/introduce-v1"]]

--- a/tests/test_branch.py
+++ b/tests/test_branch.py
@@ -34,6 +34,55 @@ def test_cmd_new_dry_run_uses_summary_panel(capsys) -> None:
     assert "[dry-run] complete" in captured.out
 
 
+def test_cmd_new_existing_branch_returns_error(monkeypatch, capsys) -> None:
+    args = argparse.Namespace(
+        type="feat",
+        description=["add", "parser"],
+        scope=None,
+        dry_run=False,
+    )
+    monkeypatch.setattr(
+        "repo_release_tools.commands.branch.git.current_branch", lambda root: "main"
+    )
+    monkeypatch.setattr(
+        "repo_release_tools.commands.branch.git.branch_exists", lambda root, name: True
+    )
+
+    result = cmd_new(args)
+
+    assert result == 1
+    assert "already exists" in capsys.readouterr().err
+
+
+def test_cmd_new_reports_uncommitted_changes(monkeypatch, capsys) -> None:
+    args = argparse.Namespace(
+        type="feat",
+        description=["add", "parser"],
+        scope=None,
+        dry_run=False,
+    )
+    ran: list[list[str]] = []
+    monkeypatch.setattr(
+        "repo_release_tools.commands.branch.git.current_branch", lambda root: "main"
+    )
+    monkeypatch.setattr(
+        "repo_release_tools.commands.branch.git.branch_exists", lambda root, name: False
+    )
+    monkeypatch.setattr(
+        "repo_release_tools.commands.branch.git.working_tree_clean", lambda root: False
+    )
+    monkeypatch.setattr(
+        "repo_release_tools.commands.branch.git.run",
+        lambda cmd, root, *, dry_run, label: ran.append(cmd),
+    )
+
+    result = cmd_new(args)
+
+    assert result == 0
+    assert ran == [["git", "checkout", "-b", "feat/add-parser"]]
+    assert "Uncommitted changes moved to the new branch" in capsys.readouterr().out
+
+
 def test_branch_validation_accepts_magic_ai_types() -> None:
     assert validate_branch_name("codex/add-parser") is None
 
@@ -115,6 +164,60 @@ def test_cmd_rescue_dry_run_with_since(capsys) -> None:
     assert result == 0
     captured = capsys.readouterr()
     assert "abc123" in captured.out
+
+
+def test_cmd_rescue_no_commits_returns_error(monkeypatch, capsys) -> None:
+    """Non-dry-run rescue fails when there are no commits ahead to rescue."""
+    from repo_release_tools.commands.branch import cmd_rescue
+
+    monkeypatch.setattr(
+        "repo_release_tools.commands.branch.git.current_branch", lambda root: "feat/existing-work"
+    )
+    monkeypatch.setattr(
+        "repo_release_tools.commands.branch.git.commits_ahead", lambda root, ref: []
+    )
+
+    args = argparse.Namespace(
+        type="fix",
+        description=["extract", "helper"],
+        scope=None,
+        dry_run=False,
+        since=None,
+    )
+
+    result = cmd_rescue(args)
+
+    assert result == 1
+    assert "Nothing to rescue" in capsys.readouterr().err
+
+
+def test_cmd_rescue_existing_target_branch_returns_error(monkeypatch, capsys) -> None:
+    """Rescue fails when the destination branch already exists."""
+    from repo_release_tools.commands.branch import cmd_rescue
+
+    monkeypatch.setattr(
+        "repo_release_tools.commands.branch.git.current_branch", lambda root: "main"
+    )
+    monkeypatch.setattr(
+        "repo_release_tools.commands.branch.git.commits_ahead",
+        lambda root, ref: ["abc123 fix: keep this change"],
+    )
+    monkeypatch.setattr(
+        "repo_release_tools.commands.branch.git.branch_exists", lambda root, name: True
+    )
+
+    args = argparse.Namespace(
+        type="fix",
+        description=["extract", "helper"],
+        scope=None,
+        dry_run=False,
+        since=None,
+    )
+
+    result = cmd_rescue(args)
+
+    assert result == 1
+    assert "already exists" in capsys.readouterr().err
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_bump.py
+++ b/tests/test_bump.py
@@ -4,7 +4,9 @@ from pathlib import Path
 
 import pytest
 
+from repo_release_tools.config import PinTarget, RrtConfig, VersionGroup, VersionTarget
 from repo_release_tools.commands.bump import cmd_bump
+from repo_release_tools.versioning import Version
 
 
 def test_cmd_bump_dry_run_from_pep621_config(tmp_path, capsys) -> None:
@@ -1182,3 +1184,90 @@ def test_cmd_bump_no_pin_sync_skips_pin_targets(
     assert result == 0
     # Doc file must be untouched when --no-pin-sync is set
     assert doc.read_text(encoding="utf-8") == original_doc
+
+
+def test_cmd_bump_deduplicates_pin_updates_and_stage_entries(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Duplicate group/global pins should only update and stage once."""
+    version_file = tmp_path / "pyproject.toml"
+    version_file.write_text('[project]\nname = "example"\nversion = "1.0.0"\n', encoding="utf-8")
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text("# Changelog\n", encoding="utf-8")
+    pin_file = tmp_path / "docs" / "action.md"
+    pin_file.parent.mkdir(parents=True)
+    pin_file.write_text("uses: Anselmoo/repo-release-tools@v1.0.0\n", encoding="utf-8")
+
+    target = VersionTarget(path=version_file, kind="pep621")
+    duplicate_pin = PinTarget(
+        path=pin_file,
+        pattern=r"(Anselmoo/repo-release-tools@v)(\d+\.\d+\.\d+)()",
+    )
+    group = VersionGroup(
+        name="default",
+        release_branch="release/v{version}",
+        changelog_file=changelog,
+        lock_command=[],
+        generated_files=[],
+        version_targets=[target],
+        pin_targets=[duplicate_pin],
+    )
+    config = RrtConfig(
+        root=tmp_path,
+        config_file=tmp_path / ".rrt.toml",
+        version_groups=[group],
+        default_group_name="default",
+        global_pin_targets=[duplicate_pin],
+    )
+
+    pin_updates: list[tuple[Path, str, bool]] = []
+    git_calls: list[list[str]] = []
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.load_or_autodetect_config", lambda root: config
+    )
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.read_group_current_version",
+        lambda grp: Version.parse("1.0.0"),
+    )
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.replace_version_in_file",
+        lambda target, version, dry_run: None,
+    )
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.replace_pin_in_file",
+        lambda pin, version, dry_run: pin_updates.append((pin.path, version, dry_run)),
+    )
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.working_tree_clean", lambda root: True
+    )
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.branch_exists", lambda root, branch: False
+    )
+    monkeypatch.setattr("repo_release_tools.commands.bump.git.current_branch", lambda root: "main")
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.run",
+        lambda cmd, root, *, dry_run, label: git_calls.append(cmd),
+    )
+
+    result = cmd_bump(
+        Namespace(
+            bump="patch",
+            dry_run=False,
+            force=False,
+            no_commit=True,
+            no_changelog=True,
+            no_update=True,
+            no_pin_sync=False,
+            include_maintenance=False,
+            base_branch=None,
+            group=None,
+        )
+    )
+
+    assert result == 0
+    assert pin_updates == [(pin_file, "1.0.1", False)]
+    add_calls = [cmd for cmd in git_calls if cmd[:2] == ["git", "add"]]
+    assert add_calls
+    assert add_calls[-1].count("docs/action.md") == 1

--- a/tests/test_bump.py
+++ b/tests/test_bump.py
@@ -1025,3 +1025,160 @@ def test_update_changelog_generates_txt_section(
     content = changelog.read_text(encoding="utf-8")
     assert "## [" not in content
     assert "txt fix" in content
+
+
+# ---------------------------------------------------------------------------
+# pin_targets — integration with cmd_bump
+# ---------------------------------------------------------------------------
+
+_BUMP_CONFIG_WITH_PINS = """\
+[tool.rrt]
+release_branch = "release/v{{version}}"
+changelog_file = "CHANGELOG.md"
+lock_command = []
+
+[[tool.rrt.version_targets]]
+path = "pyproject.toml"
+kind = "pep621"
+
+[[tool.rrt.pin_targets]]
+path = "docs/action.md"
+pattern = '(Anselmoo/repo-release-tools@v)(\\d+\\.\\d+\\.\\d+)()'
+
+[project]
+name = "example"
+version = "0.1.0"
+"""
+
+
+def _setup_pin_bump(tmp_path: Path) -> Path:
+    """Create a minimal project with a pin_targets doc file."""
+    (tmp_path / "pyproject.toml").write_text(_BUMP_CONFIG_WITH_PINS, encoding="utf-8")
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    doc = docs / "action.md"
+    doc.write_text("- uses: Anselmoo/repo-release-tools@v0.1.0\n", encoding="utf-8")
+    (tmp_path / "CHANGELOG.md").write_text(
+        "# Changelog\n\n## [Unreleased]\n\n### Added\n- new feature\n",
+        encoding="utf-8",
+    )
+    return doc
+
+
+def test_cmd_bump_updates_pin_targets(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """cmd_bump should update pin_targets files to the new version."""
+    doc = _setup_pin_bump(tmp_path)
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.working_tree_clean", lambda root: True
+    )
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.branch_exists", lambda root, branch: False
+    )
+    monkeypatch.setattr("repo_release_tools.commands.bump.git.current_branch", lambda root: "main")
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.run", lambda cmd, root, *, dry_run, label: ""
+    )
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git_log_since_latest_tag", lambda root: []
+    )
+
+    args = Namespace(
+        bump="minor",
+        dry_run=False,
+        no_commit=True,
+        no_changelog=True,
+        no_update=True,
+        no_pin_sync=False,
+        include_maintenance=False,
+        base_branch=None,
+        group=None,
+    )
+    result = cmd_bump(args)
+
+    assert result == 0
+    assert "v0.2.0" in doc.read_text(encoding="utf-8")
+
+
+def test_cmd_bump_dry_run_does_not_write_pin_targets(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """In dry-run mode, pin_targets files must not be modified."""
+    doc = _setup_pin_bump(tmp_path)
+    original_doc = doc.read_text(encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.working_tree_clean", lambda root: True
+    )
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.branch_exists", lambda root, branch: False
+    )
+    monkeypatch.setattr("repo_release_tools.commands.bump.git.current_branch", lambda root: "main")
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.run", lambda cmd, root, *, dry_run, label: ""
+    )
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git_log_since_latest_tag", lambda root: []
+    )
+
+    args = Namespace(
+        bump="minor",
+        dry_run=True,
+        no_commit=True,
+        no_changelog=True,
+        no_update=True,
+        no_pin_sync=False,
+        include_maintenance=False,
+        base_branch=None,
+        group=None,
+    )
+    result = cmd_bump(args)
+
+    assert result == 0
+    # File must be untouched in dry-run
+    assert doc.read_text(encoding="utf-8") == original_doc
+    assert "Would update" in capsys.readouterr().out
+
+
+def test_cmd_bump_no_pin_sync_skips_pin_targets(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """--no-pin-sync must skip all pin_targets updates."""
+    doc = _setup_pin_bump(tmp_path)
+    original_doc = doc.read_text(encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.working_tree_clean", lambda root: True
+    )
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.branch_exists", lambda root, branch: False
+    )
+    monkeypatch.setattr("repo_release_tools.commands.bump.git.current_branch", lambda root: "main")
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.run", lambda cmd, root, *, dry_run, label: ""
+    )
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git_log_since_latest_tag", lambda root: []
+    )
+
+    args = Namespace(
+        bump="minor",
+        dry_run=False,
+        no_commit=True,
+        no_changelog=True,
+        no_update=True,
+        no_pin_sync=True,
+        include_maintenance=False,
+        base_branch=None,
+        group=None,
+    )
+    result = cmd_bump(args)
+
+    assert result == 0
+    # Doc file must be untouched when --no-pin-sync is set
+    assert doc.read_text(encoding="utf-8") == original_doc

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -574,3 +574,79 @@ def test_insert_generated_section_rst_preserves_title() -> None:
     result = insert_generated_section(_RST_EMPTY, section, ChangelogFormat.RST)
     assert result.startswith("Changelog\n=========")
     assert has_unreleased_section(result, ChangelogFormat.RST)
+
+
+# ---------------------------------------------------------------------------
+# append_to_unreleased – blank-line correctness (regression)
+# ---------------------------------------------------------------------------
+
+_VERSIONED_AFTER_TITLE = """\
+# Changelog
+
+## [1.0.0] - 2025-01-01
+
+### Added
+- initial release
+"""
+
+_UNRELEASED_WITH_FIXED_AND_VERSION = """\
+# Changelog
+
+## [Unreleased]
+
+### Fixed
+- fix connection timeout
+
+## [1.0.0] - 2025-01-01
+
+### Added
+- initial release
+"""
+
+_UNRELEASED_EMPTY_WITH_VERSION = """\
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0] - 2025-01-01
+
+### Added
+- initial release
+"""
+
+
+def test_append_new_section_preserves_blank_line_before_versioned_section() -> None:
+    """Adding a new subsection must keep exactly one blank line before ## [version]."""
+    result = append_to_unreleased(_UNRELEASED_WITH_FIXED_AND_VERSION, "feat: add dark mode")
+    # The blank line separator between the new bullet and the version header must exist.
+    assert "- add dark mode\n\n## [1.0.0]" in result
+
+
+def test_append_to_empty_unreleased_preserves_blank_line_before_versioned_section() -> None:
+    """Filling an empty [Unreleased] must keep exactly one blank line before ## [version]."""
+    result = append_to_unreleased(_UNRELEASED_EMPTY_WITH_VERSION, "feat: new feature")
+    assert "- new feature\n\n## [1.0.0]" in result
+
+
+def test_fresh_unreleased_section_no_double_blank_line_before_versioned_section() -> None:
+    """Creating [Unreleased] from scratch must not produce two blank lines before ## [version]."""
+    result = append_to_unreleased(_VERSIONED_AFTER_TITLE, "fix: correct null pointer")
+    # Exactly one blank line between bullet and next version header.
+    assert "- correct null pointer\n\n## [1.0.0]" in result
+    assert "- correct null pointer\n\n\n## [1.0.0]" not in result
+
+
+def test_append_multiple_sections_no_extra_blank_lines() -> None:
+    """Three successive commits must not accumulate extra blank lines."""
+    content = _VERSIONED_AFTER_TITLE
+    content = append_to_unreleased(content, "feat: add widget")
+    content = append_to_unreleased(content, "fix: fix typo")
+    content = append_to_unreleased(content, "feat: add pagination")
+
+    # No run of three or more consecutive newlines anywhere.
+    assert "\n\n\n" not in content
+    # Version header still present and preceded by exactly one blank line.
+    assert "## [1.0.0]" in content
+    # Both subsections present.
+    assert "### Added" in content
+    assert "### Fixed" in content

--- a/tests/test_ci_version.py
+++ b/tests/test_ci_version.py
@@ -734,3 +734,162 @@ ci_format = "pep440"
     assert result == 0
     assert 'version = "0.2.0"' in (tmp_path / "pyproject.toml").read_text(encoding="utf-8")
     assert '"version": "1.6.0.dev1201"' in (tmp_path / "package.json").read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# cmd_ci_version_apply – error paths
+# ---------------------------------------------------------------------------
+
+
+def test_cmd_ci_version_apply_no_ci_format_targets(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """apply should fail when no version targets have ci_format configured."""
+    (tmp_path / "pyproject.toml").write_text(
+        """\
+[tool.rrt]
+
+[[tool.rrt.version_targets]]
+path = "pyproject.toml"
+kind = "pep621"
+
+[project]
+name = "example"
+version = "1.0.0"
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    result = cmd_ci_version_apply(
+        argparse.Namespace(version="1.0.0.dev100", dry_run=False, group=None)
+    )
+
+    assert result == 1
+
+
+def test_cmd_ci_version_apply_semver_pre_non_dev_version_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """apply should fail when semver_pre conversion cannot handle the version."""
+    (tmp_path / "Cargo.toml").write_text('[package]\nname = "eg"\nversion = "0.1.0"\n')
+    (tmp_path / "pyproject.toml").write_text(
+        """\
+[tool.rrt]
+
+[[tool.rrt.version_targets]]
+path = "Cargo.toml"
+kind = "pep621"
+ci_format = "semver_pre"
+
+[project]
+name = "example"
+version = "1.0.0"
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    # ".dev" in version but to_semver() leaves it unchanged → should fail
+    result = cmd_ci_version_apply(
+        argparse.Namespace(version="1.0.0.devABC", dry_run=False, group=None)
+    )
+
+    assert result == 1
+
+
+# ---------------------------------------------------------------------------
+# cmd_ci_version_compute – error paths
+# ---------------------------------------------------------------------------
+
+
+def test_cmd_ci_version_compute_no_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """compute should return 1 when no config is available."""
+    monkeypatch.chdir(tmp_path)
+
+    result = cmd_ci_version_compute(_ns(ref="refs/heads/main", run_id="999", run_attempt="1"))
+
+    assert result == 1
+
+
+def test_cmd_ci_version_compute_with_base(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """compute --base should print the computed version."""
+    monkeypatch.chdir(tmp_path)
+
+    args = argparse.Namespace(
+        base="2.0.0",
+        ref="refs/tags/v2.0.0",
+        ref_name="v2.0.0",
+        run_id="0",
+        run_attempt="1",
+        dry_run=False,
+        group=None,
+    )
+    result = cmd_ci_version_compute(args)
+
+    assert result == 0
+    assert "2.0.0" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# cmd_ci_version_sync
+# ---------------------------------------------------------------------------
+
+
+def test_cmd_ci_version_sync_with_base_tag(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """sync should compute the version and call apply."""
+    (tmp_path / "pyproject.toml").write_text(
+        """\
+[tool.rrt]
+
+[[tool.rrt.version_targets]]
+path = "pyproject.toml"
+kind = "pep621"
+ci_format = "pep440"
+
+[project]
+name = "example"
+version = "0.9.0"
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    args = argparse.Namespace(
+        base="1.0.0",
+        ref="refs/tags/v1.0.0",
+        ref_name="v1.0.0",
+        run_id="0",
+        run_attempt="1",
+        dry_run=True,
+        group=None,
+    )
+    result = cmd_ci_version_sync(args)
+
+    assert result == 0
+    out = capsys.readouterr().out
+    assert "1.0.0" in out
+
+
+def test_cmd_ci_version_sync_invalid_run_attempt(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """sync should return 1 when run_attempt is not an integer on main."""
+    monkeypatch.chdir(tmp_path)
+
+    args = argparse.Namespace(
+        base="1.0.0",
+        ref="refs/heads/main",
+        ref_name="main",
+        run_id="12345",
+        run_attempt="not-a-number",
+        dry_run=False,
+        group=None,
+    )
+    result = cmd_ci_version_sync(args)
+
+    assert result == 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,13 @@
 from __future__ import annotations
 
+import argparse
 import subprocess
 import sys
+
+import pytest
+
+
+from repo_release_tools import cli
 
 
 def test_module_help_smoke() -> None:
@@ -18,3 +24,25 @@ def test_module_help_smoke() -> None:
     assert "bump" in result.stdout
     assert "git" in result.stdout
     assert "init" in result.stdout
+
+
+def test_build_parser_registers_doctor_command() -> None:
+    parser = cli.build_parser()
+
+    args = parser.parse_args(["doctor"])
+
+    assert args.command == "doctor"
+    assert args.handler.__name__ == "cmd_doctor"
+
+
+def test_main_dispatches_to_selected_handler(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _FakeParser:
+        def parse_args(self) -> argparse.Namespace:
+            return argparse.Namespace(handler=lambda args: 7)
+
+    monkeypatch.setattr(cli, "build_parser", lambda: _FakeParser())
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+
+    assert exc.value.code == 7

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -711,3 +711,88 @@ def test_autodetect_config_picks_up_rst_changelog(tmp_path: Path) -> None:
     config = autodetect_config(tmp_path)
     assert config is not None
     assert config.changelog_file.name == "CHANGELOG.rst"
+
+
+# ---------------------------------------------------------------------------
+# PinTarget — config parsing
+# ---------------------------------------------------------------------------
+
+
+def test_load_config_parses_global_pin_targets(tmp_path: Path) -> None:
+    """Global [[tool.rrt.pin_targets]] are loaded onto RrtConfig.global_pin_targets."""
+    from repo_release_tools.config import load_config_from_path
+
+    doc = tmp_path / "docs.md"
+    doc.write_text("rev: v0.1.0\n", encoding="utf-8")
+
+    cfg_file = tmp_path / "pyproject.toml"
+    cfg_file.write_text(
+        """[tool.rrt]
+
+[[tool.rrt.version_targets]]
+path = "pyproject.toml"
+kind = "pep621"
+
+[[tool.rrt.pin_targets]]
+path = "docs.md"
+pattern = '(rev: v)(\\d+\\.\\d+\\.\\d+)()'
+
+[project]
+name = "example"
+version = "0.1.0"
+""",
+        encoding="utf-8",
+    )
+
+    config = load_config_from_path(tmp_path, cfg_file)
+
+    assert len(config.global_pin_targets) == 1
+    assert config.global_pin_targets[0].path == tmp_path / "docs.md"
+    assert "rev" in config.global_pin_targets[0].pattern
+
+
+def test_load_config_parses_per_group_pin_targets(tmp_path: Path) -> None:
+    """Per-group [[tool.rrt.version_groups.*.pin_targets]] end up on the group."""
+    from repo_release_tools.config import load_config_from_path
+
+    cfg_file = tmp_path / ".rrt.toml"
+    cfg_file.write_text(
+        """\
+[[tool.rrt.version_groups]]
+name = "frontend"
+release_branch = "release/v{version}"
+
+[[tool.rrt.version_groups.version_targets]]
+path = "package.json"
+kind = "package_json"
+
+[[tool.rrt.version_groups.pin_targets]]
+path = "README.md"
+pattern = '(badge/v)(\\d+\\.\\d+\\.\\d+)()'
+""",
+        encoding="utf-8",
+    )
+
+    config = load_config_from_path(tmp_path, cfg_file)
+
+    group = config.resolve_group("frontend")
+    assert len(group.pin_targets) == 1
+    assert group.pin_targets[0].path == tmp_path / "README.md"
+
+
+def test_pin_target_validate_rejects_pattern_with_fewer_than_3_groups(tmp_path: Path) -> None:
+    """validate() raises if the pattern has < 3 capture groups."""
+    from repo_release_tools.config import PinTarget
+
+    pin = PinTarget(path=tmp_path / "file.md", pattern=r"(prefix)(\d+\.\d+\.\d+)")
+    with pytest.raises(ValueError, match="3 capture groups"):
+        pin.validate()
+
+
+def test_pin_target_validate_rejects_invalid_regex(tmp_path: Path) -> None:
+    """validate() raises on invalid regex."""
+    from repo_release_tools.config import PinTarget
+
+    pin = PinTarget(path=tmp_path / "file.md", pattern=r"(unclosed[")
+    with pytest.raises(ValueError, match="not a valid regex"):
+        pin.validate()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -789,6 +789,15 @@ def test_pin_target_validate_rejects_pattern_with_fewer_than_3_groups(tmp_path: 
         pin.validate()
 
 
+def test_pin_target_validate_rejects_pattern_with_more_than_3_groups(tmp_path: Path) -> None:
+    """validate() raises if the pattern has > 3 capture groups."""
+    from repo_release_tools.config import PinTarget
+
+    pin = PinTarget(path=tmp_path / "file.md", pattern=r"(a)(b)(\d+\.\d+\.\d+)(suffix)")
+    with pytest.raises(ValueError, match="3 capture groups"):
+        pin.validate()
+
+
 def test_pin_target_validate_rejects_invalid_regex(tmp_path: Path) -> None:
     """validate() raises on invalid regex."""
     from repo_release_tools.config import PinTarget

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -796,3 +796,101 @@ def test_pin_target_validate_rejects_invalid_regex(tmp_path: Path) -> None:
     pin = PinTarget(path=tmp_path / "file.md", pattern=r"(unclosed[")
     with pytest.raises(ValueError, match="not a valid regex"):
         pin.validate()
+
+
+def test_load_config_rejects_non_list_pin_targets(tmp_path: Path) -> None:
+    from repo_release_tools.config import load_config_from_path
+
+    cfg_file = tmp_path / "pyproject.toml"
+    cfg_file.write_text(
+        """[tool.rrt]
+pin_targets = {}
+
+[[tool.rrt.version_targets]]
+path = "pyproject.toml"
+kind = "pep621"
+
+[project]
+name = "example"
+version = "0.1.0"
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="pin_targets must be an array of tables"):
+        load_config_from_path(tmp_path, cfg_file)
+
+
+def test_load_config_rejects_non_table_pin_target_entry(tmp_path: Path) -> None:
+    from repo_release_tools.config import load_config_from_path
+
+    cfg_file = tmp_path / "pyproject.toml"
+    cfg_file.write_text(
+        """[tool.rrt]
+pin_targets = ["docs.md"]
+
+[[tool.rrt.version_targets]]
+path = "pyproject.toml"
+kind = "pep621"
+
+[project]
+name = "example"
+version = "0.1.0"
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Each pin_targets entry must be a table"):
+        load_config_from_path(tmp_path, cfg_file)
+
+
+def test_load_config_rejects_pin_target_without_path(tmp_path: Path) -> None:
+    from repo_release_tools.config import load_config_from_path
+
+    cfg_file = tmp_path / "pyproject.toml"
+    cfg_file.write_text(
+        """[tool.rrt]
+
+[[tool.rrt.version_targets]]
+path = "pyproject.toml"
+kind = "pep621"
+
+[[tool.rrt.pin_targets]]
+path = ""
+pattern = '(rev: v)(\\d+\\.\\d+\\.\\d+)()'
+
+[project]
+name = "example"
+version = "0.1.0"
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="non-empty 'path' string"):
+        load_config_from_path(tmp_path, cfg_file)
+
+
+def test_load_config_rejects_pin_target_without_pattern(tmp_path: Path) -> None:
+    from repo_release_tools.config import load_config_from_path
+
+    cfg_file = tmp_path / "pyproject.toml"
+    cfg_file.write_text(
+        """[tool.rrt]
+
+[[tool.rrt.version_targets]]
+path = "pyproject.toml"
+kind = "pep621"
+
+[[tool.rrt.pin_targets]]
+path = "docs.md"
+pattern = ""
+
+[project]
+name = "example"
+version = "0.1.0"
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="non-empty 'pattern' string"):
+        load_config_from_path(tmp_path, cfg_file)

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -173,6 +173,23 @@ def test_doctor_changelog_exists(tmp_path: Path, monkeypatch, capsys) -> None:
     assert "exists" in out
 
 
+def test_doctor_changelog_missing_returns_1(tmp_path: Path, monkeypatch, capsys) -> None:
+    """Returns 1 when the changelog file does not exist."""
+    monkeypatch.chdir(tmp_path)
+    conf = _make_config(tmp_path)
+    _write_version_file(conf.version_groups[0].version_targets[0].path)
+    # Do NOT create CHANGELOG.md
+    monkeypatch.setattr(doctor, "load_or_autodetect_config", lambda _: conf)
+
+    rc = doctor.cmd_doctor(_ARGS)
+
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "CHANGELOG.md" in out
+    assert "not found" in out
+    assert "One or more health checks failed" in out
+
+
 def test_doctor_autodetected_warns(tmp_path: Path, monkeypatch, capsys) -> None:
     """Autodetected config prints a warning to stderr."""
     monkeypatch.chdir(tmp_path)
@@ -213,6 +230,7 @@ def test_doctor_unreadable_version_returns_0(tmp_path: Path, monkeypatch, capsys
     target_path.parent.mkdir(parents=True, exist_ok=True)
     # Write a file without the expected __version__ line
     target_path.write_text("# nothing here\n", encoding="utf-8")
+    (tmp_path / "CHANGELOG.md").write_text("# Changelog\n", encoding="utf-8")
     monkeypatch.setattr(doctor, "load_or_autodetect_config", lambda _: conf)
 
     rc = doctor.cmd_doctor(_ARGS)
@@ -269,6 +287,7 @@ def test_doctor_pin_no_match_warns_not_errors(tmp_path: Path, monkeypatch, capsy
     pin = PinTarget(path=pin_file, pattern=_VALID_PIN_PATTERN)
     conf = _make_config(tmp_path, pin_targets=[pin])
     _write_version_file(conf.version_groups[0].version_targets[0].path)
+    (tmp_path / "CHANGELOG.md").write_text("# Changelog\n", encoding="utf-8")
     monkeypatch.setattr(doctor, "load_or_autodetect_config", lambda _: conf)
 
     rc = doctor.cmd_doctor(_ARGS)
@@ -287,6 +306,7 @@ def test_doctor_pin_match_shows_healthy(tmp_path: Path, monkeypatch, capsys) -> 
     pin = PinTarget(path=pin_file, pattern=_VALID_PIN_PATTERN)
     conf = _make_config(tmp_path, pin_targets=[pin])
     _write_version_file(conf.version_groups[0].version_targets[0].path)
+    (tmp_path / "CHANGELOG.md").write_text("# Changelog\n", encoding="utf-8")
     monkeypatch.setattr(doctor, "load_or_autodetect_config", lambda _: conf)
 
     rc = doctor.cmd_doctor(_ARGS)

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,284 @@
+"""Tests for rrt doctor command."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from repo_release_tools.commands import doctor
+from repo_release_tools.config import (
+    PinTarget,
+    RrtConfig,
+    VersionGroup,
+    VersionTarget,
+)
+
+
+_ARGS = argparse.Namespace()
+
+_VALID_PIN_PATTERN = r"(Anselmoo/repo-release-tools@v)(\d+\.\d+\.\d+)()"
+
+
+def _make_config(
+    tmp_path: Path,
+    *,
+    autodetected: bool = False,
+    pin_targets: list[PinTarget] | None = None,
+    global_pins: list[PinTarget] | None = None,
+) -> RrtConfig:
+    target = VersionTarget(
+        path=tmp_path / "src" / "pkg" / "__init__.py",
+        kind="python_version",
+    )
+    group = VersionGroup(
+        name="default",
+        release_branch="release/v{version}",
+        changelog_file=tmp_path / "CHANGELOG.md",
+        lock_command=[],
+        generated_files=[],
+        version_targets=[target],
+        pin_targets=pin_targets or [],
+    )
+    return RrtConfig(
+        root=tmp_path,
+        config_file=tmp_path / "pyproject.toml",
+        version_groups=[group],
+        default_group_name="default",
+        autodetected=autodetected,
+        global_pin_targets=global_pins or [],
+    )
+
+
+def _write_version_file(path: Path, version: str = "1.2.3") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f'__version__ = "{version}"\n', encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Config loading errors
+# ---------------------------------------------------------------------------
+
+
+def test_doctor_no_config_file(tmp_path: Path, monkeypatch, capsys) -> None:
+    """Returns 1 and prints guidance when no config file is found."""
+    monkeypatch.chdir(tmp_path)
+
+    rc = doctor.cmd_doctor(_ARGS)
+
+    assert rc == 1
+    assert capsys.readouterr().err
+
+
+def test_doctor_no_rrt_section(tmp_path: Path, monkeypatch, capsys) -> None:
+    """Returns 1 when config exists but has no [tool.rrt] section."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "pyproject.toml").write_text("[tool.something]\nfoo = 1\n", encoding="utf-8")
+
+    rc = doctor.cmd_doctor(_ARGS)
+
+    assert rc == 1
+    assert capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_doctor_all_healthy(tmp_path: Path, monkeypatch, capsys) -> None:
+    """Returns 0 and shows the tree when all targets are healthy."""
+    monkeypatch.chdir(tmp_path)
+    conf = _make_config(tmp_path)
+    _write_version_file(conf.version_groups[0].version_targets[0].path)
+    (tmp_path / "CHANGELOG.md").write_text("# Changelog\n", encoding="utf-8")
+    monkeypatch.setattr(doctor, "load_or_autodetect_config", lambda _: conf)
+
+    rc = doctor.cmd_doctor(_ARGS)
+
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "rrt doctor" in out
+    assert "1.2.3" in out
+    assert "All health checks passed" in out
+
+
+def test_doctor_panel_shows_config_file(tmp_path: Path, monkeypatch, capsys) -> None:
+    """Panel header shows the config file path."""
+    monkeypatch.chdir(tmp_path)
+    conf = _make_config(tmp_path)
+    _write_version_file(conf.version_groups[0].version_targets[0].path)
+    monkeypatch.setattr(doctor, "load_or_autodetect_config", lambda _: conf)
+
+    doctor.cmd_doctor(_ARGS)
+
+    out = capsys.readouterr().out
+    assert "pyproject.toml" in out
+
+
+def test_doctor_panel_shows_group_count(tmp_path: Path, monkeypatch, capsys) -> None:
+    """Panel header shows version group count."""
+    monkeypatch.chdir(tmp_path)
+    conf = _make_config(tmp_path)
+    _write_version_file(conf.version_groups[0].version_targets[0].path)
+    monkeypatch.setattr(doctor, "load_or_autodetect_config", lambda _: conf)
+
+    doctor.cmd_doctor(_ARGS)
+
+    out = capsys.readouterr().out
+    assert "1 group" in out
+
+
+def test_doctor_changelog_exists(tmp_path: Path, monkeypatch, capsys) -> None:
+    """Tree shows changelog file as exists."""
+    monkeypatch.chdir(tmp_path)
+    conf = _make_config(tmp_path)
+    _write_version_file(conf.version_groups[0].version_targets[0].path)
+    (tmp_path / "CHANGELOG.md").write_text("## [Unreleased]\n", encoding="utf-8")
+    monkeypatch.setattr(doctor, "load_or_autodetect_config", lambda _: conf)
+
+    doctor.cmd_doctor(_ARGS)
+
+    out = capsys.readouterr().out
+    assert "CHANGELOG.md" in out
+    assert "exists" in out
+
+
+def test_doctor_autodetected_warns(tmp_path: Path, monkeypatch, capsys) -> None:
+    """Autodetected config prints a warning to stderr."""
+    monkeypatch.chdir(tmp_path)
+    conf = _make_config(tmp_path, autodetected=True)
+    _write_version_file(conf.version_groups[0].version_targets[0].path)
+    monkeypatch.setattr(doctor, "load_or_autodetect_config", lambda _: conf)
+
+    doctor.cmd_doctor(_ARGS)
+
+    assert capsys.readouterr().err  # auto-detect warning
+
+
+# ---------------------------------------------------------------------------
+# Version target failures
+# ---------------------------------------------------------------------------
+
+
+def test_doctor_missing_version_file_returns_1(tmp_path: Path, monkeypatch, capsys) -> None:
+    """Returns 1 when a version target file is missing."""
+    monkeypatch.chdir(tmp_path)
+    conf = _make_config(tmp_path)
+    # Do NOT write the version file
+    monkeypatch.setattr(doctor, "load_or_autodetect_config", lambda _: conf)
+
+    rc = doctor.cmd_doctor(_ARGS)
+
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "not found" in out
+    assert "One or more health checks failed" in out
+
+
+def test_doctor_unreadable_version_returns_0(tmp_path: Path, monkeypatch, capsys) -> None:
+    """Unreadable version (bad content) shows warning but returns 0 (non-fatal)."""
+    monkeypatch.chdir(tmp_path)
+    conf = _make_config(tmp_path)
+    target_path = conf.version_groups[0].version_targets[0].path
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    # Write a file without the expected __version__ line
+    target_path.write_text("# nothing here\n", encoding="utf-8")
+    monkeypatch.setattr(doctor, "load_or_autodetect_config", lambda _: conf)
+
+    rc = doctor.cmd_doctor(_ARGS)
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "unreadable" in out
+
+
+# ---------------------------------------------------------------------------
+# Pin target checks
+# ---------------------------------------------------------------------------
+
+
+def test_doctor_missing_pin_file_returns_1(tmp_path: Path, monkeypatch, capsys) -> None:
+    """Returns 1 when a pin target file is missing."""
+    monkeypatch.chdir(tmp_path)
+    pin = PinTarget(path=tmp_path / "docs" / "missing.md", pattern=_VALID_PIN_PATTERN)
+    conf = _make_config(tmp_path, pin_targets=[pin])
+    _write_version_file(conf.version_groups[0].version_targets[0].path)
+    monkeypatch.setattr(doctor, "load_or_autodetect_config", lambda _: conf)
+
+    rc = doctor.cmd_doctor(_ARGS)
+
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "not found" in out
+
+
+def test_doctor_pin_bad_pattern_returns_1(tmp_path: Path, monkeypatch, capsys) -> None:
+    """Returns 1 when a pin target has an invalid regex pattern."""
+    monkeypatch.chdir(tmp_path)
+    pin_file = tmp_path / "docs" / "page.md"
+    pin_file.parent.mkdir(parents=True)
+    pin_file.write_text("some content\n", encoding="utf-8")
+    pin = PinTarget(path=pin_file, pattern="([bad(regex")
+    conf = _make_config(tmp_path, pin_targets=[pin])
+    _write_version_file(conf.version_groups[0].version_targets[0].path)
+    monkeypatch.setattr(doctor, "load_or_autodetect_config", lambda _: conf)
+
+    rc = doctor.cmd_doctor(_ARGS)
+
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "bad pattern" in out
+
+
+def test_doctor_pin_no_match_warns_not_errors(tmp_path: Path, monkeypatch, capsys) -> None:
+    """Pin with no match in file shows warning but returns 0."""
+    monkeypatch.chdir(tmp_path)
+    pin_file = tmp_path / "docs" / "page.md"
+    pin_file.parent.mkdir(parents=True)
+    pin_file.write_text("no version pin here\n", encoding="utf-8")
+    pin = PinTarget(path=pin_file, pattern=_VALID_PIN_PATTERN)
+    conf = _make_config(tmp_path, pin_targets=[pin])
+    _write_version_file(conf.version_groups[0].version_targets[0].path)
+    monkeypatch.setattr(doctor, "load_or_autodetect_config", lambda _: conf)
+
+    rc = doctor.cmd_doctor(_ARGS)
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "no match" in out
+
+
+def test_doctor_pin_match_shows_healthy(tmp_path: Path, monkeypatch, capsys) -> None:
+    """Pin with a match in file shows healthy indicator."""
+    monkeypatch.chdir(tmp_path)
+    pin_file = tmp_path / "docs" / "page.md"
+    pin_file.parent.mkdir(parents=True)
+    pin_file.write_text("uses: Anselmoo/repo-release-tools@v1.2.3\n", encoding="utf-8")
+    pin = PinTarget(path=pin_file, pattern=_VALID_PIN_PATTERN)
+    conf = _make_config(tmp_path, pin_targets=[pin])
+    _write_version_file(conf.version_groups[0].version_targets[0].path)
+    monkeypatch.setattr(doctor, "load_or_autodetect_config", lambda _: conf)
+
+    rc = doctor.cmd_doctor(_ARGS)
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "match" in out
+
+
+def test_doctor_global_pins_deduplicated(tmp_path: Path, monkeypatch, capsys) -> None:
+    """Same pin in group_pins + global_pins is checked only once."""
+    monkeypatch.chdir(tmp_path)
+    pin_file = tmp_path / "docs" / "page.md"
+    pin_file.parent.mkdir(parents=True)
+    pin_file.write_text("uses: Anselmoo/repo-release-tools@v1.2.3\n", encoding="utf-8")
+    pin = PinTarget(path=pin_file, pattern=_VALID_PIN_PATTERN)
+    conf = _make_config(tmp_path, pin_targets=[pin], global_pins=[pin])
+    _write_version_file(conf.version_groups[0].version_targets[0].path)
+    monkeypatch.setattr(doctor, "load_or_autodetect_config", lambda _: conf)
+
+    doctor.cmd_doctor(_ARGS)
+
+    out = capsys.readouterr().out
+    # Pin should appear exactly once in tree output
+    assert out.count("page.md") == 1

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -80,6 +80,36 @@ def test_doctor_no_rrt_section(tmp_path: Path, monkeypatch, capsys) -> None:
     assert capsys.readouterr().err
 
 
+def test_doctor_generic_value_error_returns_1(tmp_path: Path, monkeypatch, capsys) -> None:
+    """Unexpected ValueError is surfaced to stderr."""
+    monkeypatch.chdir(tmp_path)
+
+    def _boom(_: Path) -> RrtConfig:
+        raise ValueError("bad config")
+
+    monkeypatch.setattr(doctor, "load_or_autodetect_config", _boom)
+
+    rc = doctor.cmd_doctor(_ARGS)
+
+    assert rc == 1
+    assert "bad config" in capsys.readouterr().err
+
+
+def test_doctor_runtime_error_returns_1(tmp_path: Path, monkeypatch, capsys) -> None:
+    """Runtime errors while loading config are surfaced to stderr."""
+    monkeypatch.chdir(tmp_path)
+
+    def _boom(_: Path) -> RrtConfig:
+        raise RuntimeError("broken runtime")
+
+    monkeypatch.setattr(doctor, "load_or_autodetect_config", _boom)
+
+    rc = doctor.cmd_doctor(_ARGS)
+
+    assert rc == 1
+    assert "broken runtime" in capsys.readouterr().err
+
+
 # ---------------------------------------------------------------------------
 # Happy path
 # ---------------------------------------------------------------------------

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -13,6 +13,7 @@ from repo_release_tools.hooks import run_changelog_check
 from repo_release_tools.hooks import run_pre_commit_changelog
 from repo_release_tools.hooks import run_update_unreleased
 from repo_release_tools.hooks import validate_branch_name
+from repo_release_tools.hooks import is_changelog_meta_commit
 from repo_release_tools.hooks import validate_commit_subject
 from repo_release_tools.hooks import _entries_cancel_out
 from repo_release_tools.hooks import dedup_changelog_entries
@@ -1060,3 +1061,79 @@ def test_main_update_unreleased_message_file_unreadable(tmp_path: Path) -> None:
         os.chdir(old_cwd)
 
     assert result == 1
+
+
+# ---------------------------------------------------------------------------
+# is_changelog_meta_commit
+# ---------------------------------------------------------------------------
+
+
+def test_is_changelog_meta_commit_true_for_fix_update_changelog() -> None:
+    assert is_changelog_meta_commit("fix: update changelog entries") is True
+
+
+def test_is_changelog_meta_commit_true_for_feat_with_changelog_word() -> None:
+    assert is_changelog_meta_commit("feat: update changelog to reflect new api") is True
+
+
+def test_is_changelog_meta_commit_true_case_insensitive() -> None:
+    assert is_changelog_meta_commit("fix: correct CHANGELOG formatting") is True
+
+
+def test_is_changelog_meta_commit_false_for_normal_feat() -> None:
+    assert is_changelog_meta_commit("feat: add dark mode") is False
+
+
+def test_is_changelog_meta_commit_false_for_normal_fix() -> None:
+    assert is_changelog_meta_commit("fix: resolve login timeout") is False
+
+
+def test_is_changelog_meta_commit_false_for_unparseable_subject() -> None:
+    assert is_changelog_meta_commit("not a conventional commit at all") is False
+
+
+# ---------------------------------------------------------------------------
+# run_update_unreleased – changelog-meta-commit skip guard
+# ---------------------------------------------------------------------------
+
+
+def test_run_update_unreleased_skips_changelog_meta_commit(
+    tmp_path: Path,
+) -> None:
+    """A commit whose description mentions 'changelog' must not add a bullet."""
+    changelog = tmp_path / "CHANGELOG.md"
+    original = "# Changelog\n"
+    changelog.write_text(original, encoding="utf-8")
+
+    result = run_update_unreleased(tmp_path, subject="fix: update changelog entries")
+
+    assert result == 0
+    assert changelog.read_text(encoding="utf-8") == original
+
+
+def test_run_update_unreleased_skips_changelog_meta_commit_case_insensitive(
+    tmp_path: Path,
+) -> None:
+    """The guard is case-insensitive on 'changelog'."""
+    changelog = tmp_path / "CHANGELOG.md"
+    original = "# Changelog\n"
+    changelog.write_text(original, encoding="utf-8")
+
+    result = run_update_unreleased(tmp_path, subject="feat: correct CHANGELOG formatting")
+
+    assert result == 0
+    assert changelog.read_text(encoding="utf-8") == original
+
+
+def test_run_update_unreleased_does_not_skip_unrelated_feat(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A normal feat commit (no 'changelog' in description) still writes a bullet."""
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text("# Changelog\n", encoding="utf-8")
+    monkeypatch.setattr(hooks.git, "run", lambda *a, **kw: None)
+
+    result = run_update_unreleased(tmp_path, subject="feat: add pagination")
+
+    assert result == 0
+    assert "add pagination" in changelog.read_text(encoding="utf-8")

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1137,3 +1137,9 @@ def test_run_update_unreleased_does_not_skip_unrelated_feat(
 
     assert result == 0
     assert "add pagination" in changelog.read_text(encoding="utf-8")
+
+
+def test_main_doctor_dispatches_to_cmd_doctor(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(hooks, "cmd_doctor", lambda parsed: 7)
+
+    assert hooks.main(["doctor"]) == 7

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1092,6 +1092,16 @@ def test_is_changelog_meta_commit_false_for_unparseable_subject() -> None:
     assert is_changelog_meta_commit("not a conventional commit at all") is False
 
 
+def test_is_changelog_meta_commit_false_for_changelog_product_feature() -> None:
+    """A commit adding a product feature named 'changelog' must NOT be skipped."""
+    assert is_changelog_meta_commit("feat: add changelog parser") is False
+
+
+def test_is_changelog_meta_commit_false_for_changelog_bug_fix() -> None:
+    """A bug fix for a product component named 'changelog' must NOT be skipped."""
+    assert is_changelog_meta_commit("fix: changelog parsing regression") is False
+
+
 # ---------------------------------------------------------------------------
 # run_update_unreleased – changelog-meta-commit skip guard
 # ---------------------------------------------------------------------------

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -105,6 +105,12 @@ def test_spinner_lines_noop_on_non_tty(capsys) -> None:
     assert non_tty.getvalue() == ""
 
 
+def test_panel_empty_rows_returns_title_only() -> None:
+    """panel() with no rows must return just the title string."""
+    result = output.panel("Just a title", [])
+    assert result == "Just a title"
+
+
 def test_spinner_lines_noop_on_legacy_terminal(monkeypatch, capsys) -> None:
     """spinner_lines must skip threading when IS_LEGACY_TERMINAL is True."""
     import io

--- a/tests/test_version_targets.py
+++ b/tests/test_version_targets.py
@@ -302,3 +302,29 @@ def test_replace_pin_in_file_no_match_warns(tmp_path: Path, capsys: pytest.Captu
 
     captured = capsys.readouterr()
     assert "did not match" in captured.out.lower() or "skipping" in captured.out.lower()
+
+
+def test_replace_pin_in_file_replaces_all_occurrences(
+    tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """replace_pin_in_file updates every occurrence, not just the first."""
+    from repo_release_tools.config import PinTarget
+    from repo_release_tools.version_targets import replace_pin_in_file
+
+    f = tmp_path / "action.md"
+    content = (
+        "- uses: Anselmoo/repo-release-tools@v0.1.7\n"
+        "# also: Anselmoo/repo-release-tools@v0.1.7\n"
+        "- uses: Anselmoo/repo-release-tools@v0.1.7\n"
+    )
+    f.write_text(content, encoding="utf-8")
+    pin = PinTarget(
+        path=f,
+        pattern=r"(Anselmoo/repo-release-tools@v)(\d+\.\d+\.\d+)()",
+    )
+
+    replace_pin_in_file(pin, "2.0.0", dry_run=False)
+
+    updated = f.read_text(encoding="utf-8")
+    assert updated.count("v2.0.0") == 3
+    assert "v0.1.7" not in updated

--- a/tests/test_version_targets.py
+++ b/tests/test_version_targets.py
@@ -7,7 +7,6 @@ import pytest
 from repo_release_tools.config import VersionTarget
 from repo_release_tools.version_targets import read_version_string, replace_version_in_file
 
-
 # ---------------------------------------------------------------------------
 # python_version – read
 # ---------------------------------------------------------------------------
@@ -223,3 +222,83 @@ def test_validate_unknown_kind_raises() -> None:
     target = VersionTarget(path=Path("file.py"), kind="ruby_version")
     with pytest.raises(ValueError, match="kind must be one of"):
         target.validate()
+
+
+# ---------------------------------------------------------------------------
+# replace_pin_in_file
+# ---------------------------------------------------------------------------
+
+
+def test_replace_pin_in_file_updates_version(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+    from repo_release_tools.config import PinTarget
+    from repo_release_tools.version_targets import replace_pin_in_file
+
+    f = tmp_path / "action.md"
+    f.write_text("- uses: Anselmoo/repo-release-tools@v0.1.7\n", encoding="utf-8")
+    pin = PinTarget(
+        path=f,
+        pattern=r"(Anselmoo/repo-release-tools@v)(\d+\.\d+\.\d+)()",
+    )
+
+    replace_pin_in_file(pin, "1.0.0", dry_run=False)
+
+    assert "v1.0.0" in f.read_text(encoding="utf-8")
+    assert "v0.1.7" not in f.read_text(encoding="utf-8")
+
+
+def test_replace_pin_in_file_dry_run_does_not_write(
+    tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    from repo_release_tools.config import PinTarget
+    from repo_release_tools.version_targets import replace_pin_in_file
+
+    f = tmp_path / "action.md"
+    original = "- uses: Anselmoo/repo-release-tools@v0.1.7\n"
+    f.write_text(original, encoding="utf-8")
+    pin = PinTarget(
+        path=f,
+        pattern=r"(Anselmoo/repo-release-tools@v)(\d+\.\d+\.\d+)()",
+    )
+
+    replace_pin_in_file(pin, "1.0.0", dry_run=True)
+
+    # File must be unchanged in dry-run mode
+    assert f.read_text(encoding="utf-8") == original
+    out = capsys.readouterr().out
+    assert "Would update" in out
+
+
+def test_replace_pin_in_file_already_current_skips(
+    tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    from repo_release_tools.config import PinTarget
+    from repo_release_tools.version_targets import replace_pin_in_file
+
+    f = tmp_path / "action.md"
+    f.write_text("- uses: Anselmoo/repo-release-tools@v1.0.0\n", encoding="utf-8")
+    pin = PinTarget(
+        path=f,
+        pattern=r"(Anselmoo/repo-release-tools@v)(\d+\.\d+\.\d+)()",
+    )
+
+    replace_pin_in_file(pin, "1.0.0", dry_run=False)
+
+    out = capsys.readouterr().out
+    assert "already" in out.lower() or "up to date" in out.lower() or "pin" in out.lower()
+
+
+def test_replace_pin_in_file_no_match_warns(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+    from repo_release_tools.config import PinTarget
+    from repo_release_tools.version_targets import replace_pin_in_file
+
+    f = tmp_path / "notes.md"
+    f.write_text("# Just some notes\n", encoding="utf-8")
+    pin = PinTarget(
+        path=f,
+        pattern=r"(Anselmoo/repo-release-tools@v)(\d+\.\d+\.\d+)()",
+    )
+
+    replace_pin_in_file(pin, "1.0.0", dry_run=False)
+
+    captured = capsys.readouterr()
+    assert "did not match" in captured.out.lower() or "skipping" in captured.out.lower()

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -16,3 +16,17 @@ def test_bump_minor() -> None:
 
 def test_bump_major() -> None:
     assert str(Version.parse("1.2.3").bump("major")) == "2.0.0"
+
+
+def test_parse_invalid_semver_raises() -> None:
+    import pytest
+
+    with pytest.raises(ValueError, match="Invalid semver"):
+        Version.parse("not-a-version")
+
+
+def test_bump_unknown_kind_raises() -> None:
+    import pytest
+
+    with pytest.raises(ValueError, match="Unknown bump kind"):
+        Version.parse("1.2.3").bump("hotfix")


### PR DESCRIPTION
- Implement tests for branch name validation and commit type normalization.
- Add tests for the `cmd_rescue` command in dry-run mode, ensuring it behaves correctly without modifying git state.
- Enhance tests for the `cmd_rename` command, covering various scenarios including type-only renames, scope handling, and error cases.
- Introduce tests for the `cmd_bump` command, focusing on pin target updates and ensuring dry-run mode does not alter files.
- Add tests for changelog management, ensuring correct handling of blank lines and section appending.
- Implement tests for CI versioning commands, covering error paths and successful execution scenarios.
- Introduce tests for configuration loading, ensuring proper parsing of pin targets and validation of patterns.
- Add a new test suite for the `doctor` command, verifying health checks and configuration integrity.
- Enhance hook tests to ensure changelog meta commits are correctly identified and handled.
- Add tests for output formatting, ensuring panels behave correctly with empty rows.
- Implement tests for version target functionality, including pin replacement logic and error handling.
- Add tests for versioning logic, ensuring proper handling of semver parsing and bumping.