### PR TITLE
fix: changelog squash

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@ drifts from your release policy.
 
 ```yaml
 - uses: actions/checkout@v6
-	with:
-		fetch-depth: 0
+  with:
+    fetch-depth: 0
 
 - uses: Anselmoo/repo-release-tools@v0.1.10
-	with:
-		check-branch-name: "true"
-		check-commit-subject: "true"
-		check-changelog: "true"
+  with:
+    check-branch-name: "true"
+    check-commit-subject: "true"
+    check-changelog: "true"
 ```
 
 See the full action guide:

--- a/README.md
+++ b/README.md
@@ -1,17 +1,46 @@
 # repo-release-tools
 
-`repo-release-tools` is a small product for conventional branches, changelog
-policy, version bumps, and opinionated Git workflows across local development,
-CI, and Copilot workflows.
+`repo-release-tools` keeps release policy boring in the best possible way.
 
-## Product surfaces
+Use it from **GitHub Marketplace** when you want CI to validate branch names,
+commit subjects, and changelog policy. Install it from **PyPI** when you want a
+local CLI, hook integration, version bumps, and release-branch automation.
 
-- `rrt` CLI for branch and release commands
-- [GitHub Action](https://github.com/features/actions) for policy checks in CI
-- [pre-commit](https://pre-commit.com) hooks for local enforcement
-- [Copilot CLI](https://github.com/features/copilot/cli) skill for zero-install guidance
+- GitHub Marketplace action: <https://github.com/marketplace/actions/repo-release-tools-policy-checks>
+- PyPI package: <https://pypi.org/project/repo-release-tools/>
 
-## Minimal quickstart
+## Choose your entry point
+
+### Use the GitHub Action for CI policy checks
+
+Choose the action if you want pull requests and pushes to fail fast when a repo
+drifts from your release policy.
+
+- validates branch names such as `feat/add-parser`
+- validates Conventional Commit subjects
+- validates changelog policy in CI
+- optionally checks that the working tree stays clean
+- can run `rrt doctor` as a pre-release health gate
+
+```yaml
+- uses: actions/checkout@v6
+	with:
+		fetch-depth: 0
+
+- uses: Anselmoo/repo-release-tools@v0.1.10
+	with:
+		check-branch-name: "true"
+		check-commit-subject: "true"
+		check-changelog: "true"
+```
+
+See the full action guide:
+<https://github.com/Anselmoo/repo-release-tools/blob/main/docs/github-action.md>
+
+### Use the Python package for local workflow automation
+
+Choose the package if you want the developer-side tools: branch helpers,
+version bumps, config inspection, pre-commit hooks, and release automation.
 
 ```bash
 pip install repo-release-tools
@@ -22,7 +51,7 @@ rrt git doctor
 rrt bump patch
 ```
 
-Or:
+Or run the CLI without installing it permanently:
 
 ```bash
 uvx repo-release-tools branch new feat "add parser"
@@ -30,11 +59,19 @@ uvx repo-release-tools branch new feat "add parser"
 
 For basic versioning, `bump` and `ci-version` can run without `[tool.rrt]` by
 auto-detecting root-level `pyproject.toml`, `package.json`, and `Cargo.toml`.
-If multiple version files are found they are updated together, and explicit
-config becomes optional fine-tuning for groups, release branches, changelog
-paths, lock commands, generated files, or custom patterns. Go repos still need
-explicit config for file updates because Go has no standard in-file project
-version. Run `rrt init` to capture the current recommendation in `.rrt.toml`.
+If multiple version files are found, they are updated together. Explicit config
+is for the nice extras: grouped releases, changelog paths, release branches,
+lock commands, generated files, and custom patterns.
+
+## Changelog workflows
+
+The same project can be used in two release styles. Pick the one that matches
+how your repository actually lands changes.
+
+| Workflow | Best for | Hook behavior | Action `changelog-strategy: auto` | `rrt bump` default |
+|---|---|---|---|---|
+| `incremental` *(default)* | teams that maintain changelog entries during development | `rrt-update-unreleased` and `rrt-changelog` stay active | resolves to `per-commit` | `auto` |
+| `squash` | repositories that squash many commits into one PR merge | changelog write/check hooks skip changelog enforcement | resolves to `release-only` | `generate` |
 
 Minimal config:
 
@@ -42,6 +79,7 @@ Minimal config:
 [tool.rrt]
 release_branch = "release/v{version}"
 changelog_file = "CHANGELOG.md"
+changelog_workflow = "incremental"  # or "squash"
 
 [[tool.rrt.version_targets]]
 path = "pyproject.toml"
@@ -52,33 +90,22 @@ Native config is also supported in `package.json` (`"rrt": { ... }`) and
 `Cargo.toml` (`[package.metadata.rrt]` / `[workspace.metadata.rrt]`). Go repos
 should use `.rrt.toml` or `.config/rrt.toml`.
 
-## Conventional Branching
+## What the project includes
 
-`repo-release-tools` uses conventional branches as the next step after
-trunk-based publishing. The idea is simple: keep branches short-lived, encode
-intent in the branch name, and let release automation stay predictable.
+- `rrt` CLI for branches, bumps, config inspection, and Git helpers
+- `rrt-hooks` for `pre-commit`, `lefthook`, and CI validation
+- a reusable GitHub Action in `action.yml`
+- docs for branch policy, hook setup, and release workflows
 
-The default pattern is `type/kebab-case-description`, for example
-`feat/add-config-discovery` or `fix/handle-tag-workflows`.
+## Start with the doc that matches your task
 
-This works well with conventional commits and changelog automation:
-
-- branch type tells reviewers and automation what kind of change is coming
-- commit subjects stay conventional for changelog generation
-- release branches stay explicit, such as `release/v1.2.3`
-
-See [Conventional branches](docs/semantic-branches.md) for the full branch model
-and supported branch types.
-
-## Documentation
-
-- [Docs index](docs/index.md)
-- [RRT CLI](docs/rrt-cli.md)
-- [GitHub Action](docs/github-action.md)
-- [pre-commit](docs/pre-commit.md)
-- [Skill](docs/skill.md)
-- [Conventional branches](docs/semantic-branches.md)
-- [Git magic](docs/git-magic.md)
+- Docs index: <https://github.com/Anselmoo/repo-release-tools/blob/main/docs/index.md>
+- GitHub Action: <https://github.com/Anselmoo/repo-release-tools/blob/main/docs/github-action.md>
+- CLI reference: <https://github.com/Anselmoo/repo-release-tools/blob/main/docs/rrt-cli.md>
+- Hook setup: <https://github.com/Anselmoo/repo-release-tools/blob/main/docs/pre-commit.md>
+- Conventional branches: <https://github.com/Anselmoo/repo-release-tools/blob/main/docs/semantic-branches.md>
+- Git workflow helpers: <https://github.com/Anselmoo/repo-release-tools/blob/main/docs/git-magic.md>
+- Copilot skill: <https://github.com/Anselmoo/repo-release-tools/blob/main/docs/skill.md>
 
 ## License
 

--- a/action.yml
+++ b/action.yml
@@ -35,10 +35,11 @@ inputs:
   changelog-strategy:
     description: |
       Changelog enforcement strategy:
+        auto         – (default) derive from changelog_workflow in repo config.
         per-commit   – (default) the changelog file must appear in the commit's changed-file list.
         unreleased   – a non-empty [Unreleased] section must exist in the changelog.
         release-only – the check is skipped (changelog is updated only at release time).
-    default: "per-commit"
+    default: "auto"
   check-dirty-tree:
     description: Whether to fail when the checked-out work tree is dirty
     default: "false"
@@ -108,7 +109,7 @@ runs:
         rrt-hooks check-changelog \
           --subject "$commit_subject" \
           --changelog-file "$INPUT_CHANGELOG_FILE" \
-          --strategy "${INPUT_CHANGELOG_STRATEGY:-per-commit}" \
+          --strategy "${INPUT_CHANGELOG_STRATEGY:-auto}" \
           --branch "$branch_name" \
           --ref HEAD
 

--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,7 @@ inputs:
     description: |
       Changelog enforcement strategy:
         auto         – (default) derive from changelog_workflow in repo config.
-        per-commit   – (default) the changelog file must appear in the commit's changed-file list.
+        per-commit   – the changelog file must appear in the commit's changed-file list.
         unreleased   – a non-empty [Unreleased] section must exist in the changelog.
         release-only – the check is skipped (changelog is updated only at release time).
     default: "auto"

--- a/docs/agent-instructions.md
+++ b/docs/agent-instructions.md
@@ -74,7 +74,7 @@ lefthook install                      # registers git hooks
 DO NOT use `uvx --from repo-release-tools rrt-hooks …` in `lefthook.yml` — `rrt-hooks` is an installed binary, not a uvx shortcut.
 ````
 
-### .pre-commit-config.yaml — minimal (auto-write changelog)
+### .pre-commit-config.yaml — incremental workflow (auto-write changelog)
 
 > Use the following prompt to configure pre-commit with auto-write changelog.
 
@@ -93,7 +93,7 @@ default_install_hook_types: [pre-commit, commit-msg]
 
 repos:
   - repo: https://github.com/Anselmoo/repo-release-tools
-    rev: v0.1.9
+    rev: v0.1.10
     hooks:
       - id: rrt-branch-name
       - id: rrt-update-unreleased
@@ -106,8 +106,41 @@ Hook reference:
 - `rrt-commit-subject`    commit-msg stage  — validates Conventional Commits subject
 
 Constraints:
-- `rrt-changelog` and `rrt-update-unreleased` are mutually exclusive — use one or the other, never both
+- `rrt-changelog` and `rrt-update-unreleased` are usually alternatives — use one or the other for incremental repos
 - `default_install_hook_types` must include `commit-msg` for `rrt-update-unreleased` and `rrt-commit-subject` to run
+
+If the repo config sets `changelog_workflow = "squash"`, prefer the squash example below instead of auto-writing `[Unreleased]`.
+````
+
+### .pre-commit-config.yaml — squash workflow
+
+> Use the following prompt to configure pre-commit for a squash-merge repo.
+
+````prompt
+<context>
+Repo: https://github.com/Anselmoo/repo-release-tools
+Entry point: rrt-hooks (installed binary — repo_release_tools.hooks:main)
+Python ≥ 3.12 | uv_build | Conventional Commits | Keep-a-Changelog
+Assume pre-commit is already installed.
+</context>
+
+Create `.pre-commit-config.yaml` at the repo root with this content:
+
+```yaml
+default_install_hook_types: [pre-commit, commit-msg]
+
+repos:
+  - repo: https://github.com/Anselmoo/repo-release-tools
+    rev: v0.1.10
+    hooks:
+      - id: rrt-branch-name
+      - id: rrt-commit-subject
+```
+
+Notes:
+- Use this when the repository squash-merges many commits into one merge commit.
+- Pair it with `changelog_workflow = "squash"` in repo config.
+- In squash workflow, changelog-writing and changelog-check hooks intentionally skip changelog enforcement.
 ````
 
 ### .pre-commit-config.yaml — full (all hooks)
@@ -129,7 +162,7 @@ default_install_hook_types: [pre-commit, commit-msg, pre-push, manual]
 
 repos:
   - repo: https://github.com/Anselmoo/repo-release-tools
-    rev: v0.1.9
+    rev: v0.1.10
     hooks:
       - id: rrt-branch-name        # pre-commit:       validate <type>/<slug> branch name
       - id: rrt-update-unreleased  # commit-msg:       auto-write [Unreleased] section
@@ -139,7 +172,7 @@ repos:
 ```
 
 Constraints:
-- `rrt-changelog` and `rrt-update-unreleased` are mutually exclusive — enable only one
+- `rrt-changelog` and `rrt-update-unreleased` are usually alternatives — enable only one for incremental repos
 - Do NOT add `default_install_hook_types: [pre-push]` in isolation — include `pre-commit` and `commit-msg` too
 ````
 
@@ -254,7 +287,7 @@ uvx pre-commit run --all-files
 ````prompt
 <context>
 Repo: https://github.com/Anselmoo/repo-release-tools
-Action: Anselmoo/repo-release-tools@v0.1.9 (composite action, defined in action.yml)
+Action: Anselmoo/repo-release-tools@v0.1.10 (composite action, defined in action.yml)
 Wraps rrt-hooks subcommands; runs on ubuntu-latest; requires fetch-depth: 0 for git log access.
 </context>
 
@@ -268,10 +301,14 @@ jobs:
   policy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0        # required — rrt-hooks uses git log; shallow clone breaks it
-      - uses: Anselmoo/repo-release-tools@v0.1.9
+      - uses: Anselmoo/repo-release-tools@v0.1.10
+        with:
+          check-branch-name: "true"
+          check-commit-subject: "true"
+          check-changelog: "true"
 ```
 ````
 
@@ -282,7 +319,7 @@ jobs:
 ````prompt
 <context>
 Repo: https://github.com/Anselmoo/repo-release-tools
-Action: Anselmoo/repo-release-tools@v0.1.9 (composite action, defined in action.yml)
+Action: Anselmoo/repo-release-tools@v0.1.10 (composite action, defined in action.yml)
 Wraps rrt-hooks subcommands; requires fetch-depth: 0.
 </context>
 
@@ -296,15 +333,15 @@ jobs:
   policy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0        # required — rrt-hooks uses git log; shallow clone breaks it
-      - uses: Anselmoo/repo-release-tools@v0.1.9
+      - uses: Anselmoo/repo-release-tools@v0.1.10
         with:
           check-branch-name: "true"
           check-commit-subject: "true"
           check-changelog: "true"
-          changelog-strategy: "per-commit"  # per-commit | unreleased | release-only
+          changelog-strategy: "auto"  # auto | per-commit | unreleased | release-only
           changelog-file: "CHANGELOG.md"
           check-dirty-tree: "false"
 ```
@@ -319,7 +356,7 @@ All available inputs (action.yml):
 - `commit-subject`:      `""`            — override commit subject
 - `check-changelog`:     `"true"`        — validate changelog updates
 - `changelog-file`:      `"CHANGELOG.md"`
-- `changelog-strategy`:  `"per-commit"`  — `per-commit` | `unreleased` | `release-only`
+- `changelog-strategy`:  `"auto"`        — `auto` | `per-commit` | `unreleased` | `release-only`
 - `check-dirty-tree`:    `"false"`       — fail on dirty working tree
 ````
 
@@ -330,7 +367,7 @@ All available inputs (action.yml):
 ````prompt
 <context>
 Repo: https://github.com/Anselmoo/repo-release-tools
-Action: Anselmoo/repo-release-tools@v0.1.9
+Action: Anselmoo/repo-release-tools@v0.1.10
 changelog-strategy input controls how the action validates CHANGELOG.md.
 </context>
 
@@ -338,21 +375,22 @@ Choose the right changelog strategy based on your workflow:
 
 | Strategy | When to use | Requirement |
 |---|---|---|
+| `auto` | Recommended default | Follows `changelog_workflow` from repo config |
 | `per-commit` | CHANGELOG.md must be in the commit's changed-file list | Commit author must manually update changelog before each commit |
 | `unreleased` | `[Unreleased]` section must be non-empty | Pair with `rrt-update-unreleased` (pre-commit or lefthook) to auto-write entries |
 | `release-only` | Skip changelog check on PRs/pushes; enforce only at release | Changelog is validated only on tagged releases |
 
-**per-commit** (default):
+**auto** (default):
 ```yaml
-- uses: Anselmoo/repo-release-tools@v0.1.9
+- uses: Anselmoo/repo-release-tools@v0.1.10
   with:
     check-changelog: "true"
-    changelog-strategy: "per-commit"
+    changelog-strategy: "auto"
 ```
 
 **unreleased** (pair with auto-write hooks):
 ```yaml
-- uses: Anselmoo/repo-release-tools@v0.1.9
+- uses: Anselmoo/repo-release-tools@v0.1.10
   with:
     check-changelog: "true"
     changelog-strategy: "unreleased"
@@ -361,14 +399,15 @@ Choose the right changelog strategy based on your workflow:
 **Dynamic — unreleased on branches, release-only on tags:**
 (`check-branch-name` auto-skips on tag refs — no extra condition needed)
 ```yaml
-- uses: Anselmoo/repo-release-tools@v0.1.9
+- uses: Anselmoo/repo-release-tools@v0.1.10
   with:
     check-branch-name: "true"
     changelog-strategy: ${{ startsWith(github.ref, 'refs/tags/') && 'release-only' || 'unreleased' }}
 ```
 
 Constraints:
-- `per-commit` fails on squash-merge workflows — prefer `unreleased` for PR-based flows
+- `auto` resolves to `per-commit` for `incremental` repos and `release-only` for `squash` repos
+- `per-commit` is strict and usually a poor fit for squash-merge workflows
 - `fetch-depth: 0` is always required; without it, `git log` returns nothing and checks may silently pass or fail unexpectedly
 ````
 
@@ -379,7 +418,7 @@ Constraints:
 ````prompt
 <context>
 Repo: https://github.com/Anselmoo/repo-release-tools
-Action: Anselmoo/repo-release-tools@v0.1.9 (composite action, defined in action.yml)
+Action: Anselmoo/repo-release-tools@v0.1.10 (composite action, defined in action.yml)
 Entry point: rrt-hooks (installed binary — repo_release_tools.hooks:main)
 </context>
 
@@ -396,7 +435,7 @@ rrt-hooks check-commit-subject --subject "$(git log -1 --pretty=%s)"
 rrt-hooks check-changelog \
   --subject "$(git log -1 --pretty=%s)" \
   --changelog-file CHANGELOG.md \
-  --strategy per-commit \
+  --strategy auto \
   --branch "$BRANCH_NAME" \
   --ref HEAD
 

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -1,66 +1,113 @@
 # GitHub Action
 
-`repo-release-tools` ships a reusable composite action in `action.yml`.
+Use the GitHub Action when you want CI to enforce the same policy that
+`rrt-hooks` can enforce locally.
 
-## Minimal usage
+## Minimal workflow
 
 ```yaml
 - uses: actions/checkout@v6
+  with:
+    fetch-depth: 0
 
 - uses: Anselmoo/repo-release-tools@v0.1.10
   with:
     check-branch-name: "true"
-    check-changelog: "true"
     check-commit-subject: "true"
-    check-dirty-tree: "false"
+    check-changelog: "true"
 ```
+
+`fetch-depth: 0` is required because changelog and commit-subject checks use
+`git log` and commit metadata. A shallow checkout makes those checks flaky at
+best and misleading at worst — tiny chaos gremlin, large confusion.
 
 ## What it checks
 
 - branch naming
-- changelog updates for feature/fix/breaking work
-- conventional commit subjects
+- Conventional Commit subjects
+- changelog policy
 - optional clean-worktree enforcement
-- optional `rrt doctor` config health checks
+- optional `rrt doctor` health checks
 
 ## Important behavior
 
 - Tag-triggered workflows skip branch-name validation automatically.
 - The action installs `repo-release-tools` from the action checkout, not from
   the consumer repository.
+- `changelog-strategy` defaults to `auto`, so CI can follow repository config
+  instead of forcing one changelog policy everywhere.
+
+## Changelog strategy: use `auto` unless you have a reason not to
+
+`changelog-strategy` controls how CI decides whether a changelog is valid.
+
+| Strategy | When to use it | What passes |
+|---|---|---|
+| `auto` *(default)* | most repositories | follows `changelog_workflow` from repo config |
+| `per-commit` | every changelog-relevant commit must touch `CHANGELOG.md` | `CHANGELOG.md` appears in the commit's changed files |
+| `unreleased` | you maintain `[Unreleased]` continuously, often via hooks | `## [Unreleased]` is non-empty |
+| `release-only` | changelog is generated or reviewed only when cutting a release | check is skipped during normal CI |
+
+### How `auto` resolves
+
+| `changelog_workflow` | Action behavior when `changelog-strategy: auto` |
+|---|---|
+| `incremental` *(default)* | resolves to `per-commit` |
+| `squash` | resolves to `release-only` |
+| not configured | resolves to `per-commit` |
+
+Use an explicit override only when you want CI to be stricter or looser than
+the repo default. A common example is pairing local `rrt-update-unreleased`
+hooks with CI `changelog-strategy: "unreleased"`.
+
+## Common examples
+
+### Default CI setup
+
+```yaml
+- uses: Anselmoo/repo-release-tools@v0.1.10
+  with:
+    check-changelog: "true"
+    changelog-strategy: "auto"
+```
+
+### Hook-managed `[Unreleased]` workflow
+
+```yaml
+- uses: Anselmoo/repo-release-tools@v0.1.10
+  with:
+    check-changelog: "true"
+    changelog-strategy: "unreleased"
+```
+
+### Release-time changelog workflow
+
+```yaml
+- uses: Anselmoo/repo-release-tools@v0.1.10
+  with:
+    check-changelog: "true"
+    changelog-strategy: "release-only"
+```
 
 ## Inputs
 
 | Input | Default | Description |
 |---|---|---|
 | `check-branch-name` | `"true"` | Validate branch naming convention |
-| `check-commit-subject` | `"true"` | Validate conventional commit subject |
-| `check-changelog` | `"true"` | Require changelog update for feat/fix/breaking commits |
-| `changelog-strategy` | `"per-commit"` | `per-commit` / `unreleased` / `release-only` |
-| `check-dirty-tree` | `"false"` | Fail when work tree has uncommitted changes after checks |
-| `check-doctor` | `"false"` | Run `rrt doctor` health checks (exits 1 on any failure) |
+| `check-commit-subject` | `"true"` | Validate Conventional Commit subject |
+| `check-changelog` | `"true"` | Validate changelog policy for changelog-relevant commits |
+| `changelog-strategy` | `"auto"` | `auto` / `per-commit` / `unreleased` / `release-only` |
+| `changelog-file` | `"CHANGELOG.md"` | Path to changelog file |
+| `check-dirty-tree` | `"false"` | Fail when generated files leave the work tree dirty |
+| `check-doctor` | `"false"` | Run `rrt doctor` health checks |
 | `branch-name` | — | Override the branch name to validate |
 | `branch-ref-type` | — | Override branch ref type detection |
 | `commit-subject` | — | Override the commit subject to validate |
-| `changelog-file` | `"CHANGELOG.md"` | Path to changelog file |
 
-### Changelog strategies
+`check-dirty-tree` defaults to `"false"` because GitHub Actions checkouts are
+normally clean already. Turn it on when a workflow generates files and you want
+the job to assert that nothing was left uncommitted.
 
-| Strategy | When the check passes |
-|---|---|
-| `per-commit` (default) | `CHANGELOG.md` appears in the commit's changed files |
-| `unreleased` | `## [Unreleased]` section is non-empty |
-| `release-only` | Check always skipped (changelog updated only at release time) |
-
-`check-dirty-tree` defaults to `"false"` because a GitHub Actions checkout is
-usually clean already. It is still useful for workflows that generate files and
-want to assert that the job did not leave uncommitted changes behind.
-
-`check-doctor` runs `rrt doctor`, which verifies that every version target and
-pin target in `[tool.rrt]` is reachable and well-formed. Recommended as a
-pre-release gate.
-
-## Docs publishing
-
-This repository also ships a minimal Pages workflow that publishes `docs/`
-directly. No extra docs framework is required for the current interface.
+`check-doctor` runs `rrt doctor`, which verifies that version targets and pin
+targets in repo config are reachable and well-formed. It is a good release gate
+when your repository relies on config-driven version updates.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,26 +1,40 @@
 # repo-release-tools docs
 
-`repo-release-tools` provides one release workflow across local CLI usage, CI,
-pre-commit, and Copilot skill entrypoints.
+`repo-release-tools` has two main entry points:
 
-## Start here
+- **GitHub Action** for CI policy checks
+- **Python CLI + hooks** for local release automation
 
-- [RRT CLI](rrt-cli.md) — branch helpers, version bumps, and config-driven targets
-- [GitHub Action](github-action.md) — CI enforcement for branch, changelog, and commit policy
-- [pre-commit](pre-commit.md) — local hooks for branch, changelog, and commit checks
-- [Skill](skill.md) — Copilot CLI skill usage via `uvx`
-- [Conventional branches](semantic-branches.md) — branch naming model for trunk-based publishing
-- [Git magic](git-magic.md) — opinionated commit workflows and reusable Git safety checks
+This docs set is organized around those entry points first, then around the
+workflow details behind them.
 
-## What This Docs Set Covers
+## Start by platform
 
-The docs are intentionally split so the landing page stays short:
+- [GitHub Action](github-action.md) — CI checks for branch names, commit
+	subjects, changelog policy, and optional doctor/dirty-tree gates
+- [RRT CLI](rrt-cli.md) — installable or `uvx`-driven local commands for
+	branches, bumps, config inspection, and Git helpers
+- [pre-commit / lefthook](pre-commit.md) — local hook setup for incremental or
+	squash-based changelog workflows
 
-- the CLI and config model live in `rrt-cli.md`
-- branch policy and release naming live in `semantic-branches.md`
-- workflow design and Git safety checks live in `git-magic.md`
-- CI and local enforcement live in `github-action.md` and `pre-commit.md`
-- zero-install guidance lives in `skill.md`
+## Start by workflow
 
-That keeps the homepage readable while still giving each workflow a complete
-leaf page.
+- [Conventional branches](semantic-branches.md) — naming model and allowed
+	branch types
+- [Git magic](git-magic.md) — opinionated Git helpers and workflow shortcuts
+- [Skill](skill.md) — Copilot CLI usage via `uvx`
+
+## Choose your changelog workflow
+
+`repo-release-tools` supports two changelog styles:
+
+- `incremental` *(default)* — maintain changelog state during development
+- `squash` — skip per-commit changelog enforcement and generate or correct
+	changelog entries when changes are squashed together
+
+If you are unsure where to start:
+
+1. Read [`rrt-cli.md`](rrt-cli.md) to configure `changelog_workflow`
+2. Read [`pre-commit.md`](pre-commit.md) for the matching local hook setup
+3. Read [`github-action.md`](github-action.md) to see how
+	 `changelog-strategy: auto` follows that workflow in CI

--- a/docs/pre-commit.md
+++ b/docs/pre-commit.md
@@ -2,7 +2,22 @@
 
 `repo-release-tools` publishes reusable hooks in `.pre-commit-hooks.yaml`.
 
-## Minimal config
+The first decision is not *which hook do I add?* — it is *which changelog
+workflow does this repo follow?*
+
+## Choose the workflow first
+
+| Workflow | Recommended hooks | Best for |
+|---|---|---|
+| `incremental` *(default)* | `rrt-branch-name`, `rrt-commit-subject`, plus `rrt-update-unreleased` **or** `rrt-changelog` | teams that maintain changelog state while developing |
+| `squash` | `rrt-branch-name`, `rrt-commit-subject`, optional `rrt-dirty-tree` / `rrt-doctor` | repos that squash many commits and do changelog work at release time |
+
+With `changelog_workflow = "squash"`, the changelog-writing and changelog-check
+hooks intentionally skip changelog enforcement. You can leave them configured
+during migration, but the cleaner setup is to remove them and keep only the
+non-changelog policy hooks.
+
+## Incremental workflow: keep `[Unreleased]` current
 
 ```yaml
 default_install_hook_types: [pre-commit, commit-msg]
@@ -11,10 +26,9 @@ repos:
   - repo: https://github.com/Anselmoo/repo-release-tools
     rev: v0.1.10
     hooks:
-      - id: rrt-branch-name        # pre-commit: validate branch name
-      - id: rrt-update-unreleased  # commit-msg: auto-write changelog bullet
-      - id: rrt-changelog          # pre-commit: require changelog for feat/fix
-      - id: rrt-commit-subject     # commit-msg: validate conventional commit
+      - id: rrt-branch-name
+      - id: rrt-update-unreleased
+      - id: rrt-commit-subject
 ```
 
 Install both hook types:
@@ -23,20 +37,53 @@ Install both hook types:
 pre-commit install --hook-type pre-commit --hook-type commit-msg
 ```
 
+This setup keeps `CHANGELOG.md` moving with development. `rrt-update-unreleased`
+auto-writes changelog bullets for changelog-relevant commit types, while
+`rrt-commit-subject` enforces Conventional Commits.
+
+If you prefer manual changelog edits instead of auto-writing them, replace
+`rrt-update-unreleased` with `rrt-changelog`.
+
+## Squash workflow: keep local policy, skip per-commit changelog noise
+
+```yaml
+default_install_hook_types: [pre-commit, commit-msg]
+
+repos:
+  - repo: https://github.com/Anselmoo/repo-release-tools
+    rev: v0.1.10
+    hooks:
+      - id: rrt-branch-name
+      - id: rrt-commit-subject
+```
+
+Use this when pull requests are squash-merged and you do not want ten tiny
+commit-level changelog bullets to become one giant release footnote monster.
+Pair it with:
+
+- `changelog_workflow = "squash"` in repo config
+- GitHub Action `changelog-strategy: "auto"` or `"release-only"`
+- `rrt bump` to generate release-time changelog content
+
 ## Hook overview
 
 | Hook | Stage | Description |
 |---|---|---|
 | `rrt-branch-name` | pre-commit | Validate branch naming convention |
-| `rrt-update-unreleased` | commit-msg | Auto-write bullet under `[Unreleased]` for feat/fix commits |
-| `rrt-changelog` | pre-commit | Require a staged changelog update for feat/fix/breaking work |
-| `rrt-commit-subject` | commit-msg | Validate conventional commit subjects |
+| `rrt-update-unreleased` | commit-msg | Auto-write a bullet under `[Unreleased]` for changelog-relevant commits |
+| `rrt-changelog` | pre-commit | Require a staged changelog update for changelog-relevant work |
+| `rrt-commit-subject` | commit-msg | Validate Conventional Commit subjects |
 | `rrt-dirty-tree` | pre-push / manual | Fail on uncommitted changes |
-| `rrt-doctor` | manual | Run `rrt doctor` health checks on rrt config |
+| `rrt-doctor` | manual | Run `rrt doctor` health checks on `rrt` config |
 
-## Dirty tree check
+`rrt-update-unreleased` and `rrt-changelog` are alternatives for the
+incremental workflow. You usually want one or the other, not both.
 
-`rrt-dirty-tree` is not enabled in the minimal config because a normal
+## Optional guards
+
+### Dirty tree check
+
+`rrt-dirty-tree` is not enabled in the minimal configs because a normal
 `pre-commit` run happens while the working tree is intentionally dirty. It is
 better suited for `pre-push` or manual execution when you want to enforce a
 clean repository before publishing work:
@@ -50,7 +97,7 @@ repos:
         stages: [pre-push]
 ```
 
-## Doctor check
+### Doctor check
 
 `rrt-doctor` runs `rrt doctor` health checks against every version target and
 pin target in `[tool.rrt]`. It is registered at the `manual` stage so it does
@@ -62,7 +109,7 @@ pre-commit run rrt-doctor --hook-stage manual
 rrt doctor
 ```
 
-You can also run the same logic directly:
+You can also run the same dirty-tree logic directly:
 
 ```bash
 rrt-hooks check-dirty-tree
@@ -119,34 +166,13 @@ rrt-hooks changelog post-correct --commit
 
 ## Lefthook setup
 
-[Lefthook](https://github.com/evilmartians/lefthook) is a fast, language-agnostic
-hook runner. Unlike pre-commit it does not require a Python environment, but the
-reference `lefthook.yml` for `repo-release-tools` uses an installed `rrt-hooks`
-binary provided by `uv tool install repo-release-tools`.
+[Lefthook](https://github.com/evilmartians/lefthook) can run the same local
+policy with an installed `rrt-hooks` binary.
 
-`repo-release-tools` ships a reference `lefthook.yml` at the repo root.
+Install `repo-release-tools` so `rrt-hooks` is on `PATH`, then add the commands
+that match your workflow.
 
-### Install
-
-```bash
-# install lefthook
-# macOS
-brew install lefthook
-
-# or via npm / npx
-npm install --save-dev lefthook
-
-# install uv if needed
-# macOS
-brew install uv
-
-# install repo-release-tools so `rrt-hooks` is available to lefthook
-uv tool install repo-release-tools
-
-lefthook install
-```
-
-### Reference config
+### Incremental workflow example
 
 ```yaml
 # lefthook.yml
@@ -168,34 +194,26 @@ pre-push:
       run: rrt-hooks check-changelog --subject "$(git log -1 --format=%s)" --strategy unreleased
 ```
 
-### How the auto-write flow works
+### Squash workflow example
 
-When you commit, lefthook runs two `commit-msg` commands:
+```yaml
+# lefthook.yml
+commit-msg:
+  commands:
+    rrt-commit-subject:
+      run: rrt-hooks commit-msg {1}
 
-1. **`rrt-update-unreleased`** — parses the commit subject, appends a bullet under
-   `## [Unreleased]` in `CHANGELOG.md`, and stages the file automatically.
-   This is the changelog equivalent of `ruff --fix`: `feat`, `fix`, `refactor`,
-   and `perf` commits are written automatically; `chore`, `ci`, `test`, and `build`
-   commits are silently skipped (they map to the Maintenance section which does not
-   require an entry). The `--message-file {1}` argument tells `rrt-hooks` to read
-   the subject from the file lefthook provides rather than `.git/COMMIT_EDITMSG`.
-2. **`rrt-commit-subject`** — validates the subject follows Conventional Commits.
-   If this fails the commit is aborted and the changelog write has no effect.
-
-The `pre-push` guard (`rrt-hooks check-changelog --strategy unreleased`) catches the rare case
-where someone committed with `--no-verify`: it checks that `## [Unreleased]` is
-non-empty before the push is allowed.
-
-**Changelog-meta commit guard**: commits whose description contains the word
-`changelog` (e.g. `fix: update changelog entries`) are automatically skipped by
-`rrt-update-unreleased`. This prevents recursive bullets where a changelog
-correction commit would itself appear in `[Unreleased]`.
+pre-commit:
+  commands:
+    rrt-branch-name:
+      run: rrt-hooks pre-commit
+```
 
 ### Comparison: pre-commit vs. lefthook
 
-| Hook | pre-commit | lefthook |
+| Policy | pre-commit | lefthook |
 |---|---|---|
 | Auto-write changelog | `rrt-update-unreleased` (commit-msg) | `rrt-update-unreleased --message-file {1}` |
 | Validate commit subject | `rrt-commit-subject` (commit-msg) | `rrt-commit-subject {1}` |
-| Validate branch name | `rrt-branch-name` (pre-commit) | `rrt-branch-name` |
-| Pre-push guard | `rrt-dirty-tree` (pre-push) | `rrt-hooks check-changelog --strategy unreleased` |
+| Validate branch name | `rrt-branch-name` (pre-commit) | `rrt-hooks pre-commit` |
+| Pre-push unreleased guard | `rrt-changelog` or `rrt-dirty-tree` | `rrt-hooks check-changelog --strategy unreleased` |

--- a/docs/rrt-cli.md
+++ b/docs/rrt-cli.md
@@ -2,6 +2,9 @@
 
 The installed command is `rrt`.
 
+Use the CLI when you want the local developer workflow: branch helpers, version
+bumps, config inspection, Git shortcuts, and release automation.
+
 ## Install
 
 ```bash
@@ -13,6 +16,22 @@ Or run it without installing:
 ```bash
 uvx repo-release-tools branch new feat "add parser"
 ```
+
+## Quickstart
+
+```bash
+rrt init
+rrt config
+rrt branch new feat "add parser"
+rrt git commit "add parser"
+rrt git doctor
+rrt bump patch
+```
+
+If your repo already has a simple `pyproject.toml`, `package.json`, or
+`Cargo.toml`, `rrt bump` and `rrt ci-version` can often work without explicit
+config. Run `rrt init` when you want `rrt` to write the current recommendation
+into `.rrt.toml` or a native manifest file.
 
 ## Core commands
 
@@ -233,10 +252,41 @@ Go does not have a standard extensible manifest section like `package.json` or
 [tool.rrt]
 release_branch = "release/v{version}"
 changelog_file = "CHANGELOG.md"
+changelog_workflow = "incremental"  # or "squash"
 
 [[tool.rrt.version_targets]]
 path = "pyproject.toml"
 kind = "pep621"
+```
+
+## Changelog workflows
+
+`rrt` supports two changelog workflows so the CLI can match how a repository
+actually merges work.
+
+### `incremental` (default)
+
+Use `incremental` when the repository maintains changelog state during regular
+development.
+
+- works well with `rrt-update-unreleased` or `rrt-changelog`
+- keeps `[Unreleased]` current as changes land
+- makes `rrt bump` default to the normal `auto` changelog behavior
+
+### `squash`
+
+Use `squash` when pull requests are squash-merged and per-commit changelog
+updates would create noisy or misleading release notes.
+
+- local changelog hooks skip changelog enforcement
+- GitHub Action `changelog-strategy: auto` resolves to `release-only`
+- `rrt bump` defaults to `generate` so release notes are built at release time
+
+Set it in repo config:
+
+```toml
+[tool.rrt]
+changelog_workflow = "squash"
 ```
 
 ## Custom branch types

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ pattern = '(Anselmoo/repo-release-tools@v|rev: v)(\d+\.\d+\.\d+)()'
 
 [[tool.rrt.pin_targets]]
 path = "README.md"
-pattern = '(rev: v)(\d+\.\d+\.\d+)()'
+pattern = '(Anselmoo/repo-release-tools@v)(\d+\.\d+\.\d+)()'
 
 [tool.ruff]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,10 @@ pattern = '(rev: v)(\d+\.\d+\.\d+)()'
 path = "docs/agent-instructions.md"
 pattern = '(Anselmoo/repo-release-tools@v|rev: v)(\d+\.\d+\.\d+)()'
 
+[[tool.rrt.pin_targets]]
+path = "README.md"
+pattern = '(rev: v)(\d+\.\d+\.\d+)()'
+
 [tool.ruff]
 line-length = 100
 target-version = "py312"

--- a/src/repo_release_tools/commands/bump.py
+++ b/src/repo_release_tools/commands/bump.py
@@ -35,6 +35,13 @@ from repo_release_tools.versioning import Version
 PREVIEW_LINES = 8
 
 
+def resolve_changelog_mode(config: RrtConfig, requested_mode: str | None) -> str:
+    """Resolve the changelog update mode from CLI input and workflow defaults."""
+    if requested_mode is not None:
+        return requested_mode
+    return "generate" if config.changelog_workflow == "squash" else "auto"
+
+
 def git_log_since_latest_tag(root: Path) -> list[str]:
     """Collect commit subjects since the latest tag."""
     tags_raw = git.capture(["git", "tag", "--sort=-v:refname"], root)
@@ -254,6 +261,9 @@ def cmd_bump(args: argparse.Namespace) -> int:
 
     if not args.no_changelog:
         print(f"\n{output.section('Updating changelog')}")
+        effective_changelog_mode = resolve_changelog_mode(
+            config, getattr(args, "changelog_mode", None)
+        )
         update_changelog(
             RrtConfig(
                 root=config.root,
@@ -264,7 +274,7 @@ def cmd_bump(args: argparse.Namespace) -> int:
             str(new),
             include_maintenance=args.include_maintenance,
             dry_run=args.dry_run,
-            changelog_mode=getattr(args, "changelog_mode", "auto"),
+            changelog_mode=effective_changelog_mode,
         )
 
     if group.lock_command and not args.no_update:
@@ -349,11 +359,13 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
     parser.add_argument(
         "--changelog-mode",
         choices=["auto", "promote", "generate"],
-        default="auto",
+        default=None,
         metavar="MODE",
         help=(
             "How to update the changelog: "
-            "'auto' (default) promotes [Unreleased] when it has entries, "
+            "when omitted, the default follows changelog_workflow "
+            "(incremental -> 'auto', squash -> 'generate'); "
+            "'auto' promotes [Unreleased] when it has entries, "
             "otherwise generates from the git log; "
             "'promote' requires a non-empty [Unreleased] section and renames it; "
             "'generate' always writes a new section from the git log "

--- a/src/repo_release_tools/config.py
+++ b/src/repo_release_tools/config.py
@@ -9,12 +9,15 @@ import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
 from textwrap import dedent
+from typing import cast
 
 
 DEFAULT_RELEASE_BRANCH = "release/v{version}"
 DEFAULT_CHANGELOG = "CHANGELOG.md"
+DEFAULT_CHANGELOG_WORKFLOW = "incremental"
 DEFAULT_LOCK_COMMAND = ["uv", "lock", "-U"]
 DEFAULT_GENERIC_LOCK_COMMAND: list[str] = []
+VALID_CHANGELOG_WORKFLOWS = frozenset({"incremental", "squash"})
 
 # Well-known changelog filenames probed in order when autodetecting.
 CHANGELOG_CANDIDATES = (
@@ -212,6 +215,7 @@ class VersionTarget:
             )
 
         if has_pattern:
+            assert self.pattern is not None
             re.compile(self.pattern)
         if self.ci_format is not None:
             if not isinstance(self.ci_format, str):
@@ -268,6 +272,7 @@ class VersionGroup:
     version_targets: list[VersionTarget]
     version_source: Path | None = None
     pin_targets: list[PinTarget] = field(default_factory=list)
+    changelog_workflow: str = DEFAULT_CHANGELOG_WORKFLOW
 
     def primary_target(self) -> VersionTarget:
         """Return the target used as the canonical version source."""
@@ -340,6 +345,11 @@ class RrtConfig:
     def version_targets(self) -> list[VersionTarget]:
         """Backward-compatible access to the default group's version targets."""
         return self.resolve_group().version_targets
+
+    @property
+    def changelog_workflow(self) -> str:
+        """Backward-compatible access to the default group's changelog workflow."""
+        return self.resolve_group().changelog_workflow
 
 
 class MissingRrtConfigError(ValueError):
@@ -899,9 +909,10 @@ def load_config_from_path(root: Path, config_file: Path) -> RrtConfig:
         isinstance(item, str) for item in raw_extra_branch_types
     ):
         raise ValueError("tool.rrt.extra_branch_types must be a list of strings")
+    typed_extra_branch_types = cast(list[str], raw_extra_branch_types)
     seen_extra: set[str] = set()
     extra_branch_types_list: list[str] = []
-    for raw_item in raw_extra_branch_types:
+    for raw_item in typed_extra_branch_types:
         normalized = raw_item.strip().lower()
         if not normalized:
             raise ValueError("tool.rrt.extra_branch_types entries must be non-empty identifiers")
@@ -920,9 +931,10 @@ def load_config_from_path(root: Path, config_file: Path) -> RrtConfig:
             extra_branch_types_list.append(normalized)
     extra_branch_types = tuple(extra_branch_types_list)
 
-    group_defaults = {
+    group_defaults: dict[str, object] = {
         "release_branch": raw.get("release_branch", DEFAULT_RELEASE_BRANCH),
         "changelog_file": raw.get("changelog_file", DEFAULT_CHANGELOG),
+        "changelog_workflow": raw.get("changelog_workflow", DEFAULT_CHANGELOG_WORKFLOW),
         "lock_command": raw.get("lock_command", _default_lock_command(config_file)),
         "generated_files": raw.get("generated_files", _default_generated_files(config_file)),
     }
@@ -946,7 +958,8 @@ def load_config_from_path(root: Path, config_file: Path) -> RrtConfig:
         for item in raw_groups:
             if not isinstance(item, dict):
                 raise ValueError("Each tool.rrt.version_groups entry must be a table")
-            name = item.get("name")
+            typed_item = cast(dict[str, object], item)
+            name = typed_item.get("name")
             if not isinstance(name, str) or not name:
                 raise ValueError("Each tool.rrt.version_groups entry needs a non-empty name")
             if name in seen_names:
@@ -957,7 +970,7 @@ def load_config_from_path(root: Path, config_file: Path) -> RrtConfig:
                     root,
                     config_file=config_file,
                     group_name=name,
-                    raw_group=item,
+                    raw_group=typed_item,
                     defaults=group_defaults,
                 )
             )
@@ -1225,8 +1238,9 @@ def _load_pin_targets(root: Path, raw_pins: object) -> list[PinTarget]:
     for item in raw_pins:
         if not isinstance(item, dict):
             raise ValueError("Each pin_targets entry must be a table")
-        raw_path = item.get("path")
-        raw_pattern = item.get("pattern")
+        typed_item = cast(dict[str, object], item)
+        raw_path = typed_item.get("path")
+        raw_pattern = typed_item.get("pattern")
         if not isinstance(raw_path, str) or not raw_path:
             raise ValueError("Each pin_targets entry must have a non-empty 'path' string")
         if not isinstance(raw_pattern, str) or not raw_pattern:
@@ -1254,13 +1268,32 @@ def _load_version_group(
     for item in raw_targets:
         if not isinstance(item, dict):
             raise ValueError("Each version target must be a table")
+        typed_item = cast(dict[str, object], item)
+        raw_path = typed_item.get("path")
+        if not isinstance(raw_path, str) or not raw_path:
+            raise ValueError("Each version target must have a non-empty 'path' string")
+        raw_kind = typed_item.get("kind")
+        raw_pattern = typed_item.get("pattern")
+        raw_section = typed_item.get("section")
+        raw_field = typed_item.get("field")
+        raw_ci_format = typed_item.get("ci_format")
+        if raw_kind is not None and not isinstance(raw_kind, str):
+            raise ValueError("kind must be a string when provided")
+        if raw_pattern is not None and not isinstance(raw_pattern, str):
+            raise ValueError("pattern must be a string when provided")
+        if raw_section is not None and not isinstance(raw_section, str):
+            raise ValueError("section must be a string when provided")
+        if raw_field is not None and not isinstance(raw_field, str):
+            raise ValueError("field must be a string when provided")
+        if raw_ci_format is not None and not isinstance(raw_ci_format, str):
+            raise ValueError("ci_format must be a string when provided")
         target = VersionTarget(
-            path=root / item["path"],
-            kind=item.get("kind"),
-            pattern=item.get("pattern"),
-            section=item.get("section"),
-            field=item.get("field"),
-            ci_format=item.get("ci_format"),
+            path=root / raw_path,
+            kind=raw_kind,
+            pattern=raw_pattern,
+            section=raw_section,
+            field=raw_field,
+            ci_format=raw_ci_format,
         )
         target.validate()
         targets.append(target)
@@ -1273,6 +1306,13 @@ def _load_version_group(
     if not isinstance(changelog_value, str):
         raise ValueError("changelog_file must be a string")
 
+    changelog_workflow = raw_group.get("changelog_workflow", defaults["changelog_workflow"])
+    if not isinstance(changelog_workflow, str):
+        raise ValueError("changelog_workflow must be a string")
+    if changelog_workflow not in VALID_CHANGELOG_WORKFLOWS:
+        allowed = ", ".join(sorted(VALID_CHANGELOG_WORKFLOWS))
+        raise ValueError(f"changelog_workflow must be one of {allowed}, got {changelog_workflow!r}")
+
     lock_command_raw = raw_group.get("lock_command", defaults["lock_command"])
     auto_gen: list[str] = []
     if lock_command_raw is None:
@@ -1284,7 +1324,7 @@ def _load_version_group(
     ):
         raise ValueError("lock_command must be a list of strings")
     else:
-        lock_command = lock_command_raw
+        lock_command = cast(list[str], lock_command_raw)
 
     generated_files_raw = raw_group.get("generated_files", defaults["generated_files"])
     if generated_files_raw is None:
@@ -1295,7 +1335,7 @@ def _load_version_group(
     ):
         raise ValueError("generated_files must be a list of strings")
     else:
-        generated_files = generated_files_raw
+        generated_files = cast(list[str], generated_files_raw)
 
     raw_version_source = raw_group.get("version_source")
     if raw_version_source is not None and not isinstance(raw_version_source, str):
@@ -1315,4 +1355,5 @@ def _load_version_group(
         version_targets=targets,
         version_source=version_source,
         pin_targets=_load_pin_targets(root, raw_group.get("pin_targets", [])),
+        changelog_workflow=changelog_workflow,
     )

--- a/src/repo_release_tools/hooks.py
+++ b/src/repo_release_tools/hooks.py
@@ -17,7 +17,13 @@ from repo_release_tools.changelog import (
     get_unreleased_entries,
     parse_conventional_commit,
 )
-from repo_release_tools.config import DEFAULT_CHANGELOG, load_extra_branch_types
+from repo_release_tools.config import (
+    DEFAULT_CHANGELOG,
+    DEFAULT_CHANGELOG_WORKFLOW,
+    is_missing_tool_rrt_error,
+    load_extra_branch_types,
+    load_or_autodetect_config,
+)
 from repo_release_tools.commands.branch import (
     BRANCH_SLUG_RE,
     CONVENTIONAL_TYPES,
@@ -220,6 +226,26 @@ def changelog_is_updated(changed_files: list[str], *, changelog_file: str, cwd: 
     """Return whether the changelog file is included in the changed files."""
     target = _normalize_repo_path(changelog_file, cwd=cwd)
     return any(_normalize_repo_path(path, cwd=cwd) == target for path in changed_files)
+
+
+def _detect_changelog_workflow(cwd: Path) -> str:
+    """Return the configured changelog workflow, defaulting to incremental."""
+    try:
+        return load_or_autodetect_config(cwd).changelog_workflow
+    except FileNotFoundError:
+        return DEFAULT_CHANGELOG_WORKFLOW
+    except ValueError as exc:
+        if is_missing_tool_rrt_error(exc):
+            return DEFAULT_CHANGELOG_WORKFLOW
+        raise RuntimeError(f"Failed to load changelog_workflow configuration: {exc}") from exc
+
+
+def _resolve_changelog_strategy(cwd: Path, strategy: str) -> str:
+    """Resolve an explicit or workflow-derived changelog enforcement strategy."""
+    if strategy != "auto":
+        return strategy
+    workflow = _detect_changelog_workflow(cwd)
+    return "release-only" if workflow == "squash" else "per-commit"
 
 
 # ---------------------------------------------------------------------------
@@ -531,6 +557,12 @@ def run_pre_commit(cwd: Path) -> int:
 
 def run_pre_commit_changelog(cwd: Path, *, changelog_file: str = DEFAULT_CHANGELOG) -> int:
     """Validate staged changelog updates during pre-commit."""
+    try:
+        if _detect_changelog_workflow(cwd) == "squash":
+            return 0
+    except RuntimeError as exc:
+        return emit_failure("Commit blocked by changelog policy.", [str(exc)])
+
     branch_name = git.current_branch(cwd)
     if not branch_requires_changelog(branch_name):
         return 0
@@ -573,6 +605,12 @@ def run_update_unreleased(
     updates, but returns ``emit_failure(...)`` if the changelog file is
     missing.
     """
+    try:
+        if _detect_changelog_workflow(cwd) == "squash":
+            return 0
+    except RuntimeError as exc:
+        return emit_failure("Changelog update failed.", [str(exc)])
+
     if not commit_subject_requires_changelog(subject):
         return 0
     if is_changelog_meta_commit(subject):
@@ -606,14 +644,17 @@ def run_changelog_check(
     changed_files: list[str] | None = None,
     ref: str = "HEAD",
     title: str,
-    strategy: str = "per-commit",
+    strategy: str = "auto",
     branch: str = "",
 ) -> int:
     """Validate that changelog-relevant commits update the changelog file.
 
     *strategy* controls what constitutes a valid changelog update:
 
-    ``per-commit`` (default)
+    ``auto`` (default)
+        Derives the strategy from ``changelog_workflow``. ``incremental`` maps
+        to ``per-commit`` and ``squash`` maps to ``release-only``.
+    ``per-commit``
         The changelog file must appear in the commit's changed file list.
     ``unreleased``
         The changelog file must contain a non-empty ``[Unreleased]`` section.
@@ -632,12 +673,17 @@ def run_changelog_check(
         if branch_prefix in BOT_BRANCH_TYPES:
             return 0
 
-    if strategy == "release-only":
+    try:
+        effective_strategy = _resolve_changelog_strategy(cwd, strategy)
+    except RuntimeError as exc:
+        return emit_failure(title, [str(exc)])
+
+    if effective_strategy == "release-only":
         return 0
 
     normalized_path = _normalize_repo_path(changelog_file, cwd=cwd)
 
-    if strategy == "unreleased":
+    if effective_strategy == "unreleased":
         changelog_path = cwd / changelog_file
         if changelog_path.exists():
             content = changelog_path.read_text(encoding="utf-8")
@@ -653,7 +699,7 @@ def run_changelog_check(
             ],
         )
 
-    # strategy == "per-commit" (default)
+    # effective_strategy == "per-commit"
     effective_changed_files = (
         changed_files if changed_files is not None else changed_files_for_ref(cwd, ref)
     )
@@ -816,11 +862,12 @@ def main(argv: list[str] | None = None) -> int:
     )
     changelog_check_parser.add_argument(
         "--strategy",
-        default="per-commit",
-        choices=["per-commit", "unreleased", "release-only"],
+        default="auto",
+        choices=["auto", "per-commit", "unreleased", "release-only"],
         help=(
             "Changelog enforcement strategy: "
-            "'per-commit' (default) requires the changelog in the changed-file list; "
+            "'auto' (default) derives from changelog_workflow; "
+            "'per-commit' requires the changelog in the changed-file list; "
             "'unreleased' requires a non-empty [Unreleased] section; "
             "'release-only' skips the check entirely."
         ),

--- a/tests/test_bump.py
+++ b/tests/test_bump.py
@@ -6,7 +6,148 @@ import pytest
 
 from repo_release_tools.config import PinTarget, RrtConfig, VersionGroup, VersionTarget
 from repo_release_tools.commands.bump import cmd_bump
+from repo_release_tools.commands.bump import git_log_since_latest_tag
+from repo_release_tools.commands.bump import resolve_changelog_mode
+from repo_release_tools.commands.bump import update_changelog
 from repo_release_tools.versioning import Version
+
+
+def test_resolve_changelog_mode_prefers_requested_mode(tmp_path: Path) -> None:
+    target = VersionTarget(path=tmp_path / "pyproject.toml", kind="pep621")
+    group = VersionGroup(
+        name="default",
+        release_branch="release/v{version}",
+        changelog_file=tmp_path / "CHANGELOG.md",
+        lock_command=[],
+        generated_files=[],
+        version_targets=[target],
+        changelog_workflow="incremental",
+    )
+    config = RrtConfig(
+        root=tmp_path,
+        config_file=tmp_path / ".rrt.toml",
+        version_groups=[group],
+        default_group_name="default",
+    )
+
+    assert resolve_changelog_mode(config, "promote") == "promote"
+
+
+def test_resolve_changelog_mode_defaults_to_auto_for_incremental(tmp_path: Path) -> None:
+    target = VersionTarget(path=tmp_path / "pyproject.toml", kind="pep621")
+    group = VersionGroup(
+        name="default",
+        release_branch="release/v{version}",
+        changelog_file=tmp_path / "CHANGELOG.md",
+        lock_command=[],
+        generated_files=[],
+        version_targets=[target],
+        changelog_workflow="incremental",
+    )
+    config = RrtConfig(
+        root=tmp_path,
+        config_file=tmp_path / ".rrt.toml",
+        version_groups=[group],
+        default_group_name="default",
+    )
+
+    assert resolve_changelog_mode(config, None) == "auto"
+
+
+def test_git_log_since_latest_tag_uses_latest_tag_range(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: list[list[str]] = []
+
+    def fake_capture(cmd: list[str], root: Path) -> str:
+        calls.append(cmd)
+        if cmd[:2] == ["git", "tag"]:
+            return "v1.2.0\nv1.1.0\n"
+        return "feat: add parser\nfix: tighten validation\n"
+
+    monkeypatch.setattr("repo_release_tools.commands.bump.git.capture", fake_capture)
+
+    assert git_log_since_latest_tag(tmp_path) == ["feat: add parser", "fix: tighten validation"]
+    assert calls[1] == ["git", "log", "v1.2.0..HEAD", "--pretty=format:%s"]
+
+
+def test_git_log_since_latest_tag_uses_head_when_no_tags(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: list[list[str]] = []
+
+    def fake_capture(cmd: list[str], root: Path) -> str:
+        calls.append(cmd)
+        if cmd[:2] == ["git", "tag"]:
+            return ""
+        return "feat: add parser\n"
+
+    monkeypatch.setattr("repo_release_tools.commands.bump.git.capture", fake_capture)
+
+    assert git_log_since_latest_tag(tmp_path) == ["feat: add parser"]
+    assert calls[1] == ["git", "log", "HEAD", "--pretty=format:%s"]
+
+
+def test_update_changelog_skips_missing_file(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    target = VersionTarget(path=tmp_path / "pyproject.toml", kind="pep621")
+    group = VersionGroup(
+        name="default",
+        release_branch="release/v{version}",
+        changelog_file=tmp_path / "MISSING.md",
+        lock_command=[],
+        generated_files=[],
+        version_targets=[target],
+    )
+    config = RrtConfig(
+        root=tmp_path,
+        config_file=tmp_path / ".rrt.toml",
+        version_groups=[group],
+        default_group_name="default",
+    )
+
+    update_changelog(config, "1.2.3", include_maintenance=False, dry_run=False)
+
+    assert "MISSING.md not found" in capsys.readouterr().out
+
+
+def test_update_changelog_promote_dry_run_shows_preview(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(
+        "# Changelog\n\n## [Unreleased]\n\n### Added\n- parser\n\n## [1.0.0] - 2025-01-01\n",
+        encoding="utf-8",
+    )
+    config = _make_config(tmp_path, changelog)
+
+    update_changelog(
+        config, "1.1.0", include_maintenance=False, dry_run=True, changelog_mode="promote"
+    )
+
+    output = capsys.readouterr().out
+    assert "Would promote [Unreleased] to [1.1.0]" in output
+
+
+def test_update_changelog_generate_dry_run_shows_ellipsis_for_long_preview(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git_log_since_latest_tag",
+        lambda root: [f"feat: item {i}" for i in range(12)],
+    )
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text("# Changelog\n\n## [Unreleased]\n\n", encoding="utf-8")
+    config = _make_config(tmp_path, changelog)
+
+    update_changelog(
+        config, "1.1.0", include_maintenance=True, dry_run=True, changelog_mode="generate"
+    )
+
+    output = capsys.readouterr().out
+    assert "Would prepend to" in output
+    assert "…" in output or "..." in output
 
 
 def test_cmd_bump_dry_run_from_pep621_config(tmp_path, capsys) -> None:
@@ -352,6 +493,226 @@ version = "0.1.0"
     captured = capsys.readouterr()
     assert result == 1
     assert "Multiple version groups configured" in captured.err
+
+
+def test_cmd_bump_reports_missing_config_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.load_or_autodetect_config",
+        lambda root: (_ for _ in ()).throw(FileNotFoundError("missing")),
+    )
+
+    result = cmd_bump(
+        Namespace(
+            bump="patch",
+            dry_run=False,
+            no_commit=True,
+            no_changelog=True,
+            no_update=True,
+            no_pin_sync=True,
+            include_maintenance=False,
+            base_branch=None,
+            group=None,
+        )
+    )
+
+    assert result == 1
+    assert "No supported rrt config file found" in capsys.readouterr().err
+
+
+def test_cmd_bump_reports_missing_tool_rrt_guidance(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.load_or_autodetect_config",
+        lambda root: (_ for _ in ()).throw(
+            ValueError("Missing rrt configuration in supported config files: pyproject.toml")
+        ),
+    )
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.iter_config_files",
+        lambda root: [tmp_path / "pyproject.toml"],
+    )
+
+    result = cmd_bump(
+        Namespace(
+            bump="patch",
+            dry_run=False,
+            no_commit=True,
+            no_changelog=True,
+            no_update=True,
+            no_pin_sync=True,
+            include_maintenance=False,
+            base_branch=None,
+            group=None,
+        )
+    )
+
+    assert result == 1
+    assert "No [tool.rrt] configuration found" in capsys.readouterr().err
+
+
+def test_cmd_bump_reports_runtime_error_loading_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.load_or_autodetect_config",
+        lambda root: (_ for _ in ()).throw(RuntimeError("broken environment")),
+    )
+
+    result = cmd_bump(
+        Namespace(
+            bump="patch",
+            dry_run=False,
+            no_commit=True,
+            no_changelog=True,
+            no_update=True,
+            no_pin_sync=True,
+            include_maintenance=False,
+            base_branch=None,
+            group=None,
+        )
+    )
+
+    assert result == 1
+    assert "broken environment" in capsys.readouterr().err
+
+
+def test_cmd_bump_rejects_invalid_explicit_version(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    (tmp_path / ".rrt.toml").write_text(
+        """\
+[tool.rrt]
+lock_command = []
+
+[[tool.rrt.version_targets]]
+path = "package.json"
+kind = "package_json"
+""",
+        encoding="utf-8",
+    )
+    (tmp_path / "package.json").write_text(
+        '{"name": "example", "version": "1.0.0"}', encoding="utf-8"
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    result = cmd_bump(
+        Namespace(
+            bump="not-a-version",
+            dry_run=True,
+            no_commit=True,
+            no_changelog=True,
+            no_update=True,
+            no_pin_sync=True,
+            include_maintenance=False,
+            base_branch=None,
+            group=None,
+        )
+    )
+
+    assert result == 1
+    assert "Invalid semver" in capsys.readouterr().err
+
+
+def test_cmd_bump_refuses_dirty_working_tree(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    (tmp_path / ".rrt.toml").write_text(
+        """\
+[tool.rrt]
+lock_command = []
+
+[[tool.rrt.version_targets]]
+path = "package.json"
+kind = "package_json"
+""",
+        encoding="utf-8",
+    )
+    (tmp_path / "package.json").write_text(
+        '{"name": "example", "version": "1.0.0"}', encoding="utf-8"
+    )
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.working_tree_clean", lambda root: False
+    )
+
+    result = cmd_bump(
+        Namespace(
+            bump="patch",
+            dry_run=False,
+            no_commit=True,
+            no_changelog=True,
+            no_update=True,
+            no_pin_sync=True,
+            include_maintenance=False,
+            base_branch=None,
+            group=None,
+        )
+    )
+
+    assert result == 1
+    assert "Working tree has uncommitted changes" in capsys.readouterr().err
+
+
+def test_cmd_bump_checks_out_base_branch_before_release_branch(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    (tmp_path / ".rrt.toml").write_text(
+        """\
+[tool.rrt]
+lock_command = []
+
+[[tool.rrt.version_targets]]
+path = "package.json"
+kind = "package_json"
+""",
+        encoding="utf-8",
+    )
+    (tmp_path / "package.json").write_text(
+        '{"name": "example", "version": "1.0.0"}', encoding="utf-8"
+    )
+
+    calls: list[list[str]] = []
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.working_tree_clean", lambda root: True
+    )
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.branch_exists", lambda root, branch: False
+    )
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.current_branch", lambda root: "feature/current"
+    )
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.run",
+        lambda cmd, root, *, dry_run, label: calls.append(cmd),
+    )
+
+    result = cmd_bump(
+        Namespace(
+            bump="patch",
+            dry_run=False,
+            force=False,
+            no_commit=True,
+            no_changelog=True,
+            no_update=True,
+            no_pin_sync=True,
+            include_maintenance=False,
+            base_branch="main",
+            group=None,
+        )
+    )
+
+    assert result == 0
+    assert ["git", "checkout", "main"] in calls
 
 
 def test_cmd_bump_updates_selected_group_only(tmp_path: Path, capsys) -> None:

--- a/tests/test_bump.py
+++ b/tests/test_bump.py
@@ -867,7 +867,7 @@ def test_update_changelog_adds_unreleased_placeholder_when_absent(
 # ---------------------------------------------------------------------------
 
 
-def _make_config(tmp_path: Path, changelog: Path) -> "object":
+def _make_config(tmp_path: Path, changelog: Path) -> RrtConfig:
     from repo_release_tools.config import RrtConfig, VersionGroup, VersionTarget
 
     target = VersionTarget(path=tmp_path / "pyproject.toml", kind="pep621")
@@ -970,6 +970,75 @@ def test_update_changelog_mode_generate_ignores_unreleased(
     content = changelog.read_text(encoding="utf-8")
     assert "from git log" in content
     assert "## [1.1.0]" in content
+
+
+def test_cmd_bump_defaults_to_generate_for_squash_workflow(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    target = VersionTarget(path=tmp_path / "pyproject.toml", kind="pep621")
+    group = VersionGroup(
+        name="default",
+        release_branch="release/v{version}",
+        changelog_file=tmp_path / "CHANGELOG.md",
+        lock_command=[],
+        generated_files=[],
+        version_targets=[target],
+        changelog_workflow="squash",
+    )
+    config = RrtConfig(
+        root=tmp_path,
+        config_file=tmp_path / ".rrt.toml",
+        version_groups=[group],
+        default_group_name="default",
+    )
+    changelog_modes: list[str] = []
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.load_or_autodetect_config", lambda root: config
+    )
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.read_group_current_version",
+        lambda grp: Version.parse("1.0.0"),
+    )
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.replace_version_in_file",
+        lambda target, version, dry_run: None,
+    )
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.update_changelog",
+        lambda config, version, *, include_maintenance, dry_run, changelog_mode: (
+            changelog_modes.append(changelog_mode)
+        ),
+    )
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.working_tree_clean", lambda root: True
+    )
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.branch_exists", lambda root, branch: False
+    )
+    monkeypatch.setattr("repo_release_tools.commands.bump.git.current_branch", lambda root: "main")
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.run", lambda cmd, root, *, dry_run, label: ""
+    )
+
+    result = cmd_bump(
+        Namespace(
+            bump="patch",
+            dry_run=False,
+            force=False,
+            no_commit=True,
+            no_changelog=False,
+            no_update=True,
+            no_pin_sync=True,
+            include_maintenance=False,
+            base_branch=None,
+            group=None,
+        )
+    )
+
+    assert result == 0
+    assert changelog_modes == ["generate"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import runpy
 import subprocess
 import sys
 
@@ -46,3 +47,25 @@ def test_main_dispatches_to_selected_handler(monkeypatch: pytest.MonkeyPatch) ->
         cli.main()
 
     assert exc.value.code == 7
+
+
+def test_package_module_executes_main(monkeypatch: pytest.MonkeyPatch) -> None:
+    called: list[str] = []
+    monkeypatch.setattr("repo_release_tools.cli.main", lambda: called.append("ran"))
+
+    runpy.run_module("repo_release_tools", run_name="__main__")
+
+    assert called == ["ran"]
+
+
+def test_cli_module_main_block_exits_with_handler_code(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        argparse.ArgumentParser,
+        "parse_args",
+        lambda self: argparse.Namespace(handler=lambda args: 9),
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        runpy.run_module("repo_release_tools.cli", run_name="__main__")
+
+    assert exc.value.code == 9

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -279,6 +279,16 @@ kind = "package_json"
         load_config(tmp_path)
 
 
+def test_load_config_rejects_non_table_tool_rrt(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        'tool = { rrt = "oops" }\n[project]\nname = "example"\nversion = "0.1.0"\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match=r"\[tool\.rrt\].*must be a table"):
+        load_config(tmp_path)
+
+
 def test_load_config_supports_package_json_rrt(tmp_path: Path) -> None:
     (tmp_path / "package.json").write_text(
         """{
@@ -305,6 +315,23 @@ def test_load_config_supports_package_json_rrt(tmp_path: Path) -> None:
     assert config.release_branch == "release/web/v{version}"
     assert config.lock_command == ["npm", "install"]
     assert config.generated_files == [tmp_path / "package-lock.json"]
+
+
+def test_load_config_rejects_package_json_top_level_non_object(tmp_path: Path) -> None:
+    (tmp_path / "package.json").write_text("[]", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="top-level object"):
+        load_config(tmp_path)
+
+
+def test_load_config_rejects_package_json_rrt_non_object(tmp_path: Path) -> None:
+    (tmp_path / "package.json").write_text(
+        '{"name": "example", "version": "1.0.0", "rrt": "oops"}',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="rrt in package.json must be an object"):
+        load_config(tmp_path)
 
 
 def test_load_config_supports_cargo_package_metadata_rrt(tmp_path: Path) -> None:
@@ -362,6 +389,131 @@ field = "version"
 
     assert config.config_file == tmp_path / "Cargo.toml"
     assert config.resolve_group().primary_target().section == "workspace.package"
+
+
+def test_load_config_rejects_non_table_cargo_rrt_metadata(tmp_path: Path) -> None:
+    (tmp_path / "Cargo.toml").write_text(
+        """\
+[package]
+name = \"example\"
+version = \"1.0.0\"
+
+[package.metadata]
+rrt = \"oops\"
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="must be a table"):
+        load_config(tmp_path)
+
+
+@pytest.mark.parametrize(
+    ("body", "message"),
+    [
+        ("release_branch = 1", "release_branch must be a string"),
+        ("changelog_file = 1", "changelog_file must be a string"),
+        ("changelog_workflow = 1", "changelog_workflow must be a string"),
+        ('lock_command = "uv lock"', "lock_command must be a list of strings"),
+        ('generated_files = "uv.lock"', "generated_files must be a list of strings"),
+        ("version_source = 1", "version_source must be a string when provided"),
+    ],
+)
+def test_load_config_rejects_invalid_group_scalar_types(
+    tmp_path: Path, body: str, message: str
+) -> None:
+    (tmp_path / ".rrt.toml").write_text(
+        f"""\
+[tool.rrt]
+{body}
+
+[[tool.rrt.version_targets]]
+path = \"package.json\"
+kind = \"package_json\"
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match=message):
+        load_config(tmp_path)
+
+
+@pytest.mark.parametrize(
+    ("target_body", "message"),
+    [
+        ('path = "package.json"\nkind = 1', "kind must be a string when provided"),
+        ('path = "package.json"\npattern = 1', "pattern must be a string when provided"),
+        (
+            'path = "package.json"\nsection = 1\nfield = "version"',
+            "section must be a string when provided",
+        ),
+        (
+            'path = "package.json"\nsection = "package"\nfield = 1',
+            "field must be a string when provided",
+        ),
+        ('path = "package.json"\nci_format = 1', "ci_format must be a string when provided"),
+    ],
+)
+def test_load_config_rejects_invalid_target_field_types(
+    tmp_path: Path, target_body: str, message: str
+) -> None:
+    (tmp_path / ".rrt.toml").write_text(
+        f"""\
+[tool.rrt]
+
+[[tool.rrt.version_targets]]
+{target_body}
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match=message):
+        load_config(tmp_path)
+
+
+def test_load_config_rejects_missing_version_targets_in_group(tmp_path: Path) -> None:
+    (tmp_path / ".rrt.toml").write_text("[tool.rrt]\nversion_targets = []\n", encoding="utf-8")
+
+    with pytest.raises(
+        ValueError, match=r"Missing \[\[tool\.rrt\.version_targets\]\] configuration"
+    ):
+        load_config(tmp_path)
+
+
+def test_load_config_rejects_non_table_target_entry(tmp_path: Path) -> None:
+    (tmp_path / ".rrt.toml").write_text(
+        '[tool.rrt]\nversion_targets = ["package.json"]\n', encoding="utf-8"
+    )
+
+    with pytest.raises(ValueError, match="Each version target must be a table"):
+        load_config(tmp_path)
+
+
+def test_load_config_rejects_target_without_non_empty_path(tmp_path: Path) -> None:
+    (tmp_path / ".rrt.toml").write_text(
+        '[tool.rrt]\n\n[[tool.rrt.version_targets]]\npath = ""\nkind = "package_json"\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="non-empty 'path' string"):
+        load_config(tmp_path)
+
+
+def test_load_config_rejects_version_source_not_matching_any_target(tmp_path: Path) -> None:
+    (tmp_path / ".rrt.toml").write_text(
+        """\
+[tool.rrt]
+version_source = "other.json"
+
+[[tool.rrt.version_targets]]
+path = "package.json"
+kind = "package_json"
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="does not match any target path"):
+        load_config(tmp_path)
 
 
 def test_load_config_rejects_mixing_flat_targets_and_groups(tmp_path: Path) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,6 +6,7 @@ import pytest
 
 from repo_release_tools.config import (
     DEFAULT_CHANGELOG,
+    DEFAULT_CHANGELOG_WORKFLOW,
     VersionTarget,
     autodetect_config,
     find_changelog_file,
@@ -201,6 +202,81 @@ kind = "package_json"
     assert config.resolve_group().name == "python"
     assert config.resolve_group("web").generated_files == [tmp_path / "pnpm-lock.yaml"]
     assert config.resolve_group("web").primary_target().path == tmp_path / "package.json"
+
+
+def test_load_config_parses_changelog_workflow(tmp_path: Path) -> None:
+    (tmp_path / ".rrt.toml").write_text(
+        """\
+[tool.rrt]
+changelog_workflow = "squash"
+
+[[tool.rrt.version_targets]]
+path = "package.json"
+kind = "package_json"
+""",
+        encoding="utf-8",
+    )
+
+    config = load_config(tmp_path)
+
+    assert config.changelog_workflow == "squash"
+    assert config.resolve_group().changelog_workflow == "squash"
+
+
+def test_group_inherits_default_changelog_workflow(tmp_path: Path) -> None:
+    (tmp_path / ".rrt.toml").write_text(
+        """\
+[tool.rrt]
+changelog_workflow = "squash"
+default_group = "python"
+
+[[tool.rrt.version_groups]]
+name = "python"
+
+[[tool.rrt.version_groups.version_targets]]
+path = "pyproject.toml"
+kind = "pep621"
+
+[[tool.rrt.version_groups]]
+name = "web"
+changelog_workflow = "incremental"
+
+[[tool.rrt.version_groups.version_targets]]
+path = "package.json"
+kind = "package_json"
+""",
+        encoding="utf-8",
+    )
+
+    config = load_config(tmp_path)
+
+    assert config.resolve_group("python").changelog_workflow == "squash"
+    assert config.resolve_group("web").changelog_workflow == "incremental"
+
+
+def test_load_config_defaults_changelog_workflow_incremental(tmp_path: Path) -> None:
+    (tmp_path / ".rrt.toml").write_text(_RRT_CONFIG, encoding="utf-8")
+
+    config = load_config(tmp_path)
+
+    assert config.changelog_workflow == DEFAULT_CHANGELOG_WORKFLOW
+
+
+def test_load_config_rejects_invalid_changelog_workflow(tmp_path: Path) -> None:
+    (tmp_path / ".rrt.toml").write_text(
+        """\
+[tool.rrt]
+changelog_workflow = "mystery"
+
+[[tool.rrt.version_targets]]
+path = "package.json"
+kind = "package_json"
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="changelog_workflow must be one of"):
+        load_config(tmp_path)
 
 
 def test_load_config_supports_package_json_rrt(tmp_path: Path) -> None:

--- a/tests/test_git_cmd.py
+++ b/tests/test_git_cmd.py
@@ -1,4 +1,7 @@
 import argparse
+import contextlib
+
+import pytest
 
 from repo_release_tools.commands import git_cmd
 
@@ -623,3 +626,643 @@ def test_cmd_diff_handles_deleted_file_headers(monkeypatch, capsys) -> None:
     captured = capsys.readouterr().out
     assert "deleted.txt" in captured
     assert "removed line" in captured
+
+
+def test_commit_subject_render_includes_scope_and_breaking_marker() -> None:
+    subject = git_cmd.CommitSubject(
+        type="feat", description="ship parser", scope="cli", breaking=True
+    )
+
+    assert subject.render() == "feat(cli)!: ship parser"
+
+
+def test_normalize_commit_subject_type_accepts_and_rejects_values() -> None:
+    assert git_cmd.normalize_commit_subject_type("FIX") == "fix"
+    assert git_cmd.infer_commit_type("wizard/add-parser") is None
+
+    with pytest.raises(argparse.ArgumentTypeError, match="invalid commit type"):
+        git_cmd.normalize_commit_subject_type("wizard")
+
+
+def test_resolve_commit_subject_requires_explicit_type_for_uninferable_branch(
+    monkeypatch, tmp_path
+) -> None:
+    monkeypatch.setattr(git_cmd.git, "current_branch", lambda cwd: "main")
+    args = argparse.Namespace(description=["ship", "it"], type=None, scope=None, breaking=False)
+
+    with pytest.raises(ValueError, match="Use --type explicitly"):
+        git_cmd.resolve_commit_subject(args, tmp_path)
+
+
+def test_classify_status_line_covers_all_status_kinds() -> None:
+    assert git_cmd.classify_status_line("?? docs/new.md") == ("untracked", "docs/new.md")
+    assert git_cmd.classify_status_line("UU src/conflict.py") == ("conflict", "src/conflict.py")
+    assert git_cmd.classify_status_line("R  old.py -> new.py") == ("renamed", "old.py -> new.py")
+    assert git_cmd.classify_status_line("A  src/new.py") == ("added", "src/new.py")
+    assert git_cmd.classify_status_line("D  src/old.py") == ("removed", "src/old.py")
+
+
+def test_describe_sync_relation_and_sync_problem_cover_remaining_states() -> None:
+    assert (
+        git_cmd.describe_sync_relation(ahead=0, behind=2, base_ref="origin/main") == "behind base"
+    )
+    assert git_cmd.describe_sync_relation(ahead=1, behind=2, base_ref="origin/main") == "diverged"
+    assert (
+        git_cmd.sync_problem("feat/add-parser", base_ref="origin/main", ahead=0, behind=2)
+        == "Branch 'feat/add-parser' is behind origin/main by 2 commit(s). Sync is needed."
+    )
+
+
+def test_cmd_status_requires_git_repository(monkeypatch, tmp_path, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(git_cmd.git, "is_git_repository", lambda cwd: False)
+
+    assert git_cmd.cmd_status(argparse.Namespace()) == 1
+    assert "is not inside a Git work tree" in capsys.readouterr().err
+
+
+def test_cmd_log_requires_git_repository(monkeypatch, tmp_path, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(git_cmd.git, "is_git_repository", lambda cwd: False)
+
+    assert git_cmd.cmd_log(argparse.Namespace(limit=5)) == 1
+    assert "is not inside a Git work tree" in capsys.readouterr().err
+
+
+def test_cmd_log_handles_empty_history(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(git_cmd.git, "is_git_repository", lambda cwd: True)
+    monkeypatch.setattr(git_cmd.git, "capture", lambda cmd, cwd: "")
+
+    assert git_cmd.cmd_log(argparse.Namespace(limit=5)) == 0
+    assert "No commits found." in capsys.readouterr().out
+
+
+def test_cmd_doctor_requires_git_repository(monkeypatch, tmp_path, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(git_cmd.git, "is_git_repository", lambda cwd: False)
+
+    assert git_cmd.cmd_doctor(argparse.Namespace(changelog_file="CHANGELOG.md")) == 1
+    assert "is not inside a Git work tree" in capsys.readouterr().err
+
+
+def test_cmd_doctor_reports_status_failure(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(git_cmd.git, "is_git_repository", lambda cwd: True)
+    monkeypatch.setattr(git_cmd.git, "current_branch", lambda cwd: "main")
+    monkeypatch.setattr(git_cmd.git, "upstream_branch", lambda cwd: "origin/main")
+    monkeypatch.setattr(
+        git_cmd.git,
+        "status_porcelain",
+        lambda cwd: (_ for _ in ()).throw(RuntimeError("git status --short failed (exit 128)")),
+    )
+
+    assert git_cmd.cmd_doctor(argparse.Namespace(changelog_file="CHANGELOG.md")) == 1
+    assert "git status --short failed" in capsys.readouterr().err
+
+
+def test_cmd_doctor_reports_missing_changelog_entry(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(git_cmd.git, "is_git_repository", lambda cwd: True)
+    monkeypatch.setattr(git_cmd.git, "current_branch", lambda cwd: "feat/add-parser")
+    monkeypatch.setattr(git_cmd.git, "upstream_branch", lambda cwd: "origin/feat/add-parser")
+    monkeypatch.setattr(git_cmd.git, "in_progress_operation", lambda cwd: None)
+    monkeypatch.setattr(git_cmd.git, "status_porcelain", lambda cwd: [])
+    monkeypatch.setattr(git_cmd.git, "ahead_behind", lambda cwd, ref: (0, 0))
+    monkeypatch.setattr(git_cmd, "load_extra_branch_types", lambda cwd: ())
+
+    def fake_capture(cmd, cwd):
+        if cmd[:4] == ["git", "log", "-1", "--pretty=%s"]:
+            return "feat: add parser"
+        if cmd[:5] == ["git", "diff-tree", "--no-commit-id", "--name-only", "--root"]:
+            return "src/repo_release_tools/cli.py"
+        raise AssertionError(cmd)
+
+    monkeypatch.setattr(git_cmd.git, "capture", fake_capture)
+
+    assert git_cmd.cmd_doctor(argparse.Namespace(changelog_file="CHANGELOG.md")) == 1
+    assert "is not part of HEAD" in capsys.readouterr().out
+
+
+def test_cmd_check_dirty_tree_requires_git_repository(monkeypatch, tmp_path, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(git_cmd.git, "is_git_repository", lambda cwd: False)
+
+    assert git_cmd.cmd_check_dirty_tree(argparse.Namespace()) == 1
+    assert "is not inside a Git work tree" in capsys.readouterr().err
+
+
+def test_cmd_check_dirty_tree_reports_clean_tree(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(git_cmd.git, "is_git_repository", lambda cwd: True)
+    monkeypatch.setattr(git_cmd.git, "working_tree_clean", lambda cwd: True)
+    monkeypatch.setattr(git_cmd.git, "current_branch", lambda cwd: "main")
+    monkeypatch.setattr(git_cmd.git, "upstream_branch", lambda cwd: "origin/main")
+    monkeypatch.setattr(git_cmd.git, "ahead_behind", lambda cwd, ref: (0, 0))
+
+    assert git_cmd.cmd_check_dirty_tree(argparse.Namespace()) == 0
+    assert "Working tree is clean." in capsys.readouterr().out
+
+
+def test_cmd_sync_status_requires_git_repository(monkeypatch, tmp_path, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(git_cmd.git, "is_git_repository", lambda cwd: False)
+
+    assert git_cmd.cmd_sync_status(argparse.Namespace(base_ref=None)) == 1
+    assert "is not inside a Git work tree" in capsys.readouterr().err
+
+
+def test_cmd_sync_status_reports_status_failure(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(git_cmd.git, "is_git_repository", lambda cwd: True)
+    monkeypatch.setattr(git_cmd.git, "current_branch", lambda cwd: "feat/add-parser")
+    monkeypatch.setattr(git_cmd.git, "upstream_branch", lambda cwd: "origin/feat/add-parser")
+    monkeypatch.setattr(git_cmd.git, "ref_exists", lambda cwd, ref: True)
+    monkeypatch.setattr(git_cmd.git, "in_progress_operation", lambda cwd: None)
+    monkeypatch.setattr(
+        git_cmd.git,
+        "status_porcelain",
+        lambda cwd: (_ for _ in ()).throw(RuntimeError("git status --short failed (exit 128)")),
+    )
+
+    assert git_cmd.cmd_sync_status(argparse.Namespace(base_ref=None)) == 1
+    assert "git status --short failed" in capsys.readouterr().err
+
+
+def test_cmd_sync_status_reports_branch_ahead(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(git_cmd.git, "is_git_repository", lambda cwd: True)
+    monkeypatch.setattr(git_cmd.git, "current_branch", lambda cwd: "feat/add-parser")
+    monkeypatch.setattr(git_cmd.git, "upstream_branch", lambda cwd: "origin/feat/add-parser")
+    monkeypatch.setattr(git_cmd.git, "ref_exists", lambda cwd, ref: True)
+    monkeypatch.setattr(git_cmd.git, "in_progress_operation", lambda cwd: None)
+    monkeypatch.setattr(git_cmd.git, "status_porcelain", lambda cwd: [])
+    monkeypatch.setattr(git_cmd.git, "ahead_behind", lambda cwd, ref: (2, 0))
+
+    assert git_cmd.cmd_sync_status(argparse.Namespace(base_ref=None)) == 0
+    assert "is ahead of origin/feat/add-parser by 2 commit(s)." in capsys.readouterr().out
+
+
+def test_cmd_commit_requires_explicit_type_when_branch_not_inferable(
+    monkeypatch, tmp_path, capsys
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(git_cmd.git, "current_branch", lambda cwd: "main")
+    args = argparse.Namespace(
+        description=["ship", "parser"],
+        type=None,
+        scope=None,
+        breaking=False,
+        dry_run=False,
+    )
+
+    assert git_cmd.cmd_commit(args) == 1
+    assert "Use --type explicitly" in capsys.readouterr().err
+
+
+def test_cmd_commit_all_stages_and_commits(monkeypatch, tmp_path) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(git_cmd.git, "current_branch", lambda cwd: "feat/add-parser")
+    commands: list[list[str]] = []
+    monkeypatch.setattr(
+        git_cmd.git,
+        "run",
+        lambda cmd, cwd, *, dry_run, label: commands.append(cmd) or "",
+    )
+    args = argparse.Namespace(
+        description=["ship", "parser"],
+        type=None,
+        scope=None,
+        breaking=False,
+        dry_run=False,
+    )
+
+    assert git_cmd.cmd_commit_all(args) == 0
+    assert commands == [["git", "add", "."], ["git", "commit", "-m", "feat: ship parser"]]
+
+
+def test_cmd_sync_requires_upstream_branch(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(git_cmd.git, "is_git_repository", lambda cwd: True)
+    monkeypatch.setattr(git_cmd.git, "current_branch", lambda cwd: "feat/add-parser")
+    monkeypatch.setattr(git_cmd.git, "upstream_branch", lambda cwd: None)
+
+    assert git_cmd.cmd_sync(argparse.Namespace(merge=False, dry_run=False)) == 1
+    assert "No upstream branch is configured" in capsys.readouterr().err
+
+
+def test_cmd_sync_reports_status_failure(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(git_cmd.git, "is_git_repository", lambda cwd: True)
+    monkeypatch.setattr(git_cmd.git, "current_branch", lambda cwd: "feat/add-parser")
+    monkeypatch.setattr(git_cmd.git, "upstream_branch", lambda cwd: "origin/feat/add-parser")
+    monkeypatch.setattr(git_cmd.git, "working_tree_clean", lambda cwd: True)
+    monkeypatch.setattr(
+        git_cmd.git,
+        "status_porcelain",
+        lambda cwd: (_ for _ in ()).throw(RuntimeError("git status --short failed (exit 128)")),
+    )
+
+    assert git_cmd.cmd_sync(argparse.Namespace(merge=False, dry_run=False)) == 1
+    assert "git status --short failed" in capsys.readouterr().err
+
+
+def test_cmd_sync_rejects_in_progress_operation(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(git_cmd.git, "is_git_repository", lambda cwd: True)
+    monkeypatch.setattr(git_cmd.git, "current_branch", lambda cwd: "feat/add-parser")
+    monkeypatch.setattr(git_cmd.git, "upstream_branch", lambda cwd: "origin/feat/add-parser")
+    monkeypatch.setattr(git_cmd.git, "working_tree_clean", lambda cwd: True)
+    monkeypatch.setattr(git_cmd.git, "status_porcelain", lambda cwd: [])
+    monkeypatch.setattr(git_cmd.git, "in_progress_operation", lambda cwd: "merge")
+
+    assert git_cmd.cmd_sync(argparse.Namespace(merge=False, dry_run=False)) == 1
+    assert "Cannot sync while a merge is in progress" in capsys.readouterr().err
+
+
+def test_cmd_sync_warns_when_pull_fails_after_auto_stash(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(git_cmd.git, "is_git_repository", lambda cwd: True)
+    monkeypatch.setattr(git_cmd.git, "current_branch", lambda cwd: "feat/add-parser")
+    monkeypatch.setattr(git_cmd.git, "upstream_branch", lambda cwd: "origin/feat/add-parser")
+    monkeypatch.setattr(git_cmd.git, "working_tree_clean", lambda cwd: False)
+    monkeypatch.setattr(git_cmd.git, "status_porcelain", lambda cwd: [" M src/file.py"])
+    monkeypatch.setattr(git_cmd.git, "in_progress_operation", lambda cwd: None)
+    monkeypatch.setattr(git_cmd.git, "ahead_behind", lambda cwd, ref: (1, 0))
+    monkeypatch.setattr(git_cmd.output, "spinner_lines", lambda *a, **k: contextlib.nullcontext())
+
+    def fake_run(cmd, cwd, *, dry_run, label):
+        if cmd[:2] == ["git", "pull"]:
+            raise RuntimeError("pull failed")
+        return ""
+
+    monkeypatch.setattr(git_cmd.git, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="pull failed"):
+        git_cmd.cmd_sync(argparse.Namespace(merge=True, dry_run=False))
+
+    assert "auto-stash remains on the stash stack" in capsys.readouterr().err
+
+
+def test_cmd_move_warns_when_checkout_fails_after_stash(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(git_cmd.git, "is_git_repository", lambda cwd: True)
+    monkeypatch.setattr(git_cmd.git, "current_branch", lambda cwd: "main")
+    monkeypatch.setattr(git_cmd.git, "working_tree_clean", lambda cwd: False)
+
+    def fake_run(cmd, cwd, *, dry_run, label):
+        if cmd[:2] == ["git", "checkout"]:
+            raise RuntimeError("checkout failed")
+        return ""
+
+    monkeypatch.setattr(git_cmd.git, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="checkout failed"):
+        git_cmd.cmd_move(argparse.Namespace(target="feat/add-parser", create=False, dry_run=False))
+
+    assert "auto-stash remains on the stash stack" in capsys.readouterr().err
+
+
+def test_cmd_squash_local_rejects_dirty_tree(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(git_cmd.git, "working_tree_clean", lambda cwd: False)
+
+    result = git_cmd.cmd_squash_local(
+        argparse.Namespace(
+            base_ref=None,
+            description=["squash"],
+            type="feat",
+            scope=None,
+            breaking=False,
+            dry_run=False,
+        )
+    )
+
+    assert result == 1
+    assert "Working tree has uncommitted changes" in capsys.readouterr().err
+
+
+def test_cmd_squash_local_requires_upstream_or_base(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(git_cmd.git, "working_tree_clean", lambda cwd: True)
+    monkeypatch.setattr(git_cmd.git, "upstream_branch", lambda cwd: None)
+
+    result = git_cmd.cmd_squash_local(
+        argparse.Namespace(
+            base_ref=None,
+            description=["squash"],
+            type="feat",
+            scope=None,
+            breaking=False,
+            dry_run=False,
+        )
+    )
+
+    assert result == 1
+    assert "No upstream branch is configured" in capsys.readouterr().err
+
+
+def test_cmd_squash_local_requires_commits_ahead(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(git_cmd.git, "working_tree_clean", lambda cwd: True)
+    monkeypatch.setattr(
+        git_cmd, "resolve_commit_subject", lambda args, root: ("feat/add", "feat: add")
+    )
+    monkeypatch.setattr(git_cmd.git, "commits_ahead", lambda cwd, base_ref: [])
+
+    result = git_cmd.cmd_squash_local(
+        argparse.Namespace(
+            base_ref="origin/main",
+            description=["squash"],
+            type="feat",
+            scope=None,
+            breaking=False,
+            dry_run=False,
+        )
+    )
+
+    assert result == 1
+    assert "Nothing to squash" in capsys.readouterr().err
+
+
+def test_cmd_squash_local_requires_merge_base(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(git_cmd.git, "working_tree_clean", lambda cwd: True)
+    monkeypatch.setattr(
+        git_cmd, "resolve_commit_subject", lambda args, root: ("feat/add", "feat: add")
+    )
+    monkeypatch.setattr(git_cmd.git, "commits_ahead", lambda cwd, base_ref: ["abc123 feat: add"])
+    monkeypatch.setattr(git_cmd.git, "merge_base", lambda cwd, base_ref: None)
+
+    result = git_cmd.cmd_squash_local(
+        argparse.Namespace(
+            base_ref="origin/main",
+            description=["squash"],
+            type="feat",
+            scope=None,
+            breaking=False,
+            dry_run=False,
+        )
+    )
+
+    assert result == 1
+    assert "Could not determine merge-base" in capsys.readouterr().err
+
+
+def test_cmd_squash_local_reports_commit_subject_resolution_error(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(git_cmd.git, "working_tree_clean", lambda cwd: True)
+    monkeypatch.setattr(
+        git_cmd,
+        "resolve_commit_subject",
+        lambda args, root: (_ for _ in ()).throw(ValueError("bad subject")),
+    )
+
+    result = git_cmd.cmd_squash_local(
+        argparse.Namespace(
+            base_ref="origin/main",
+            description=["squash"],
+            type="feat",
+            scope=None,
+            breaking=False,
+            dry_run=False,
+        )
+    )
+
+    assert result == 1
+    assert "bad subject" in capsys.readouterr().err
+
+
+def test_cmd_squash_local_dry_run_success(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        git_cmd, "resolve_commit_subject", lambda args, root: ("feat/add", "feat: add")
+    )
+    monkeypatch.setattr(
+        git_cmd.git, "commits_ahead", lambda cwd, base_ref: ["a1 feat: one", "b2 fix: two"]
+    )
+    monkeypatch.setattr(git_cmd.git, "merge_base", lambda cwd, base_ref: "abc123")
+    commands: list[list[str]] = []
+    monkeypatch.setattr(
+        git_cmd.git,
+        "run",
+        lambda cmd, cwd, *, dry_run, label: commands.append(cmd) or "",
+    )
+
+    result = git_cmd.cmd_squash_local(
+        argparse.Namespace(
+            base_ref="origin/main",
+            description=["squash"],
+            type="feat",
+            scope=None,
+            breaking=False,
+            dry_run=True,
+        )
+    )
+
+    assert result == 0
+    assert commands == [["git", "reset", "--soft", "abc123"], ["git", "commit", "-m", "feat: add"]]
+    assert "commit graph preserved" in capsys.readouterr().out
+
+
+def test_cmd_undo_safe_runs_soft_reset_in_dry_run(monkeypatch, capsys) -> None:
+    commands: list[list[str]] = []
+    monkeypatch.setattr(
+        git_cmd.git,
+        "run",
+        lambda cmd, cwd, *, dry_run, label: commands.append(cmd) or "",
+    )
+
+    result = git_cmd.cmd_undo_safe(
+        argparse.Namespace(target="HEAD~2", keep_staged=True, dry_run=True)
+    )
+
+    assert result == 0
+    assert commands == [["git", "reset", "--soft", "HEAD~2"]]
+    assert "HEAD unchanged" in capsys.readouterr().out
+
+
+def test_cmd_undo_safe_runs_mixed_reset(monkeypatch) -> None:
+    commands: list[list[str]] = []
+    monkeypatch.setattr(
+        git_cmd.git,
+        "run",
+        lambda cmd, cwd, *, dry_run, label: commands.append(cmd) or "",
+    )
+
+    assert (
+        git_cmd.cmd_undo_safe(argparse.Namespace(target="HEAD~1", keep_staged=False, dry_run=False))
+        == 0
+    )
+    assert commands == [["git", "reset", "--mixed", "HEAD~1"]]
+
+
+def test_cmd_rebootstrap_rejects_missing_git_dir(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(git_cmd.git, "git_dir", lambda cwd: None)
+    args = argparse.Namespace(yes_i_know_this_destroys_history=True)
+
+    assert git_cmd.cmd_rebootstrap(args) == 1
+    assert "does not look like a Git repository" in capsys.readouterr().err
+
+
+def test_cmd_rebootstrap_rejects_remote_guard(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".git").mkdir()
+    monkeypatch.setattr(git_cmd.git, "remote_names", lambda cwd: ["origin"])
+    args = argparse.Namespace(
+        yes_i_know_this_destroys_history=True,
+        allow_remote=False,
+        hard_init=False,
+        empty_first=False,
+        branch=None,
+        message=None,
+        empty_message=git_cmd.DEFAULT_REBOOTSTRAP_EMPTY_MESSAGE,
+        dry_run=True,
+    )
+
+    assert git_cmd.cmd_rebootstrap(args) == 1
+    assert "Refusing to rebootstrap a repository with configured remotes" in capsys.readouterr().err
+
+
+def test_cmd_rebootstrap_empty_first_dry_run(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".git").mkdir()
+    monkeypatch.setattr(git_cmd.git, "remote_names", lambda cwd: [])
+    monkeypatch.setattr(git_cmd.git, "current_branch", lambda cwd: "main")
+    commands: list[list[str]] = []
+    monkeypatch.setattr(
+        git_cmd.git,
+        "run",
+        lambda cmd, cwd, *, dry_run, label: commands.append(cmd) or "",
+    )
+    args = argparse.Namespace(
+        yes_i_know_this_destroys_history=True,
+        allow_remote=False,
+        hard_init=False,
+        empty_first=True,
+        branch=None,
+        message=None,
+        empty_message="chore: empty bootstrap",
+        dry_run=True,
+    )
+
+    assert git_cmd.cmd_rebootstrap(args) == 0
+    assert commands == [
+        ["git", "init", "-b", "main"],
+        ["git", "commit", "--allow-empty", "-m", "chore: empty bootstrap"],
+        ["git", "add", "."],
+        ["git", "commit", "-m", git_cmd.DEFAULT_REBOOTSTRAP_MESSAGE],
+    ]
+    assert "history preserved via preview only" in capsys.readouterr().out
+
+
+def test_cmd_rebootstrap_empty_first_non_dry_run(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".git").mkdir()
+    monkeypatch.setattr(git_cmd.git, "git_dir", lambda cwd: tmp_path / ".git")
+    monkeypatch.setattr(git_cmd.git, "remote_names", lambda cwd: [])
+    monkeypatch.setattr(git_cmd.git, "current_branch", lambda cwd: "main")
+    monkeypatch.setattr(git_cmd.shutil, "move", lambda src, dst: None)
+    commands: list[list[str]] = []
+    monkeypatch.setattr(
+        git_cmd.git,
+        "run",
+        lambda cmd, cwd, *, dry_run, label: commands.append(cmd) or "",
+    )
+    args = argparse.Namespace(
+        yes_i_know_this_destroys_history=True,
+        allow_remote=False,
+        hard_init=False,
+        empty_first=True,
+        branch=None,
+        message=None,
+        empty_message="chore: empty bootstrap",
+        dry_run=False,
+    )
+
+    assert git_cmd.cmd_rebootstrap(args) == 0
+    assert commands == [
+        ["git", "init", "-b", "main"],
+        ["git", "commit", "--allow-empty", "-m", "chore: empty bootstrap"],
+        ["git", "add", "."],
+        ["git", "commit", "-m", git_cmd.DEFAULT_REBOOTSTRAP_MESSAGE],
+    ]
+
+
+def test_cmd_rebootstrap_reinitializes_snapshot_history(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".git").mkdir()
+    monkeypatch.setattr(git_cmd.git, "git_dir", lambda cwd: tmp_path / ".git")
+    monkeypatch.setattr(git_cmd.git, "remote_names", lambda cwd: [])
+    monkeypatch.setattr(git_cmd.git, "current_branch", lambda cwd: "main")
+    moved: list[tuple[str, str]] = []
+    commands: list[list[str]] = []
+    monkeypatch.setattr(git_cmd.shutil, "move", lambda src, dst: moved.append((src, dst)))
+    monkeypatch.setattr(
+        git_cmd.git,
+        "run",
+        lambda cmd, cwd, *, dry_run, label: commands.append(cmd) or "",
+    )
+    args = argparse.Namespace(
+        yes_i_know_this_destroys_history=True,
+        allow_remote=False,
+        hard_init=False,
+        empty_first=False,
+        branch=None,
+        message=None,
+        empty_message=git_cmd.DEFAULT_REBOOTSTRAP_EMPTY_MESSAGE,
+        dry_run=False,
+    )
+
+    assert git_cmd.cmd_rebootstrap(args) == 0
+    assert moved
+    assert commands == [
+        ["git", "init", "-b", "main"],
+        ["git", "add", "."],
+        ["git", "commit", "-m", git_cmd.DEFAULT_REBOOTSTRAP_MESSAGE],
+    ]
+    assert "Repository history reinitialized" in capsys.readouterr().out
+
+
+def test_cmd_rebootstrap_reports_runtime_failure_and_backup(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".git").mkdir()
+    monkeypatch.setattr(git_cmd.git, "git_dir", lambda cwd: tmp_path / ".git")
+    monkeypatch.setattr(git_cmd.git, "remote_names", lambda cwd: [])
+    monkeypatch.setattr(git_cmd.git, "current_branch", lambda cwd: "main")
+    monkeypatch.setattr(git_cmd.shutil, "move", lambda src, dst: None)
+    monkeypatch.setattr(
+        git_cmd.git,
+        "run",
+        lambda cmd, cwd, *, dry_run, label: (_ for _ in ()).throw(RuntimeError("git init failed")),
+    )
+    args = argparse.Namespace(
+        yes_i_know_this_destroys_history=True,
+        allow_remote=False,
+        hard_init=False,
+        empty_first=False,
+        branch=None,
+        message=None,
+        empty_message=git_cmd.DEFAULT_REBOOTSTRAP_EMPTY_MESSAGE,
+        dry_run=False,
+    )
+
+    assert git_cmd.cmd_rebootstrap(args) == 1
+    assert "Original git data is backed up" in capsys.readouterr().err
+
+
+def test_parse_diff_line_handles_malformed_hunk_header() -> None:
+    kind, text, lineno = git_cmd._parse_diff_line("@@ nonsense +oops @@")
+    assert kind == "unchanged"
+    assert text == "@@ nonsense +oops @@"
+    assert lineno is None
+
+
+def test_cmd_diff_prints_malformed_hunk_headers(monkeypatch, capsys) -> None:
+    diff_output = "diff --git a/foo.py b/foo.py\n+++ b/foo.py\n@@ bad +12 @@\n+added line\n"
+    monkeypatch.setattr(git_cmd.git, "is_git_repository", lambda _: True)
+    monkeypatch.setattr(git_cmd.git, "capture_checked", lambda cmd, cwd: diff_output)
+
+    assert git_cmd.cmd_diff(argparse.Namespace(staged=False, against=None)) == 0
+    captured = capsys.readouterr().out
+    assert "@@ bad +12 @@" in captured
+    assert "added line" in captured
+
+
+def test_cmd_diff_uses_old_path_when_new_path_is_dev_null(monkeypatch, capsys) -> None:
+    diff_output = (
+        "diff --git a/deleted.txt /dev/null\n"
+        "--- a/deleted.txt\n"
+        "+++ /dev/null\n"
+        "@@ -1 +0,0 @@\n"
+        "-gone\n"
+    )
+    monkeypatch.setattr(git_cmd.git, "is_git_repository", lambda _: True)
+    monkeypatch.setattr(git_cmd.git, "capture_checked", lambda cmd, cwd: diff_output)
+
+    assert git_cmd.cmd_diff(argparse.Namespace(staged=False, against=None)) == 0
+    assert "deleted.txt" in capsys.readouterr().out

--- a/tests/test_git_helpers.py
+++ b/tests/test_git_helpers.py
@@ -4,7 +4,162 @@ import subprocess
 
 from pathlib import Path
 
+import pytest
+
 from repo_release_tools import git
+
+
+def test_run_dry_run_skips_subprocess(monkeypatch, tmp_path: Path, capsys) -> None:
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("subprocess should not run")),
+    )
+
+    result = git.run(["git", "status"], tmp_path, dry_run=True, label="git status")
+
+    assert result == ""
+    assert "Would run: git status" in capsys.readouterr().out
+
+
+def test_run_prints_stdout_on_success(monkeypatch, tmp_path: Path, capsys) -> None:
+    def fake_run(cmd, cwd, capture_output, text, check):
+        assert cmd == ["git", "status"]
+        return subprocess.CompletedProcess(cmd, 0, stdout="line one\nline two\n", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = git.run(["git", "status"], tmp_path, dry_run=False, label="git status")
+
+    captured = capsys.readouterr().out
+    assert result == "line one\nline two"
+    assert "git status" in captured
+    assert "line one" in captured
+    assert "line two" in captured
+
+
+def test_run_prints_stdout_and_stderr_before_raising(monkeypatch, tmp_path: Path, capsys) -> None:
+    def fake_run(cmd, cwd, capture_output, text, check):
+        return subprocess.CompletedProcess(cmd, 2, stdout="out line\n", stderr="err line\n")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match=r"git status failed \(exit 2\)"):
+        git.run(["git", "status"], tmp_path, dry_run=False, label="git status")
+
+    captured = capsys.readouterr().out
+    assert "out line" in captured
+    assert "err line" in captured
+
+
+def test_capture_and_capture_checked_strip_output(monkeypatch, tmp_path: Path) -> None:
+    def fake_run(cmd, cwd, capture_output, text, check):
+        return subprocess.CompletedProcess(cmd, 0, stdout="  value\n", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert git.capture(["git", "branch", "--show-current"], tmp_path) == "value"
+    assert git.capture_checked(["git", "rev-parse", "HEAD"], tmp_path) == "value"
+
+
+def test_capture_checked_raises_on_nonzero_exit(monkeypatch, tmp_path: Path) -> None:
+    def fake_run(cmd, cwd, capture_output, text, check):
+        return subprocess.CompletedProcess(cmd, 7, stdout="", stderr="fatal")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match=r"git rev-parse HEAD failed \(exit 7\)"):
+        git.capture_checked(["git", "rev-parse", "HEAD"], tmp_path)
+
+
+def test_current_branch_branch_exists_and_commits_ahead_delegate(
+    monkeypatch, tmp_path: Path
+) -> None:
+    def fake_capture(cmd: list[str], cwd: Path) -> str:
+        if cmd == ["git", "branch", "--show-current"]:
+            return "feature/current"
+        if cmd == ["git", "branch", "--list", "release/v1.2.3"]:
+            return "  release/v1.2.3"
+        if cmd == ["git", "log", "origin/main..HEAD", "--pretty=format:%h %s"]:
+            return "abc123 feat: add parser\n\nxyz789 fix: typo\n"
+        raise AssertionError(cmd)
+
+    monkeypatch.setattr(git, "capture", fake_capture)
+
+    assert git.current_branch(tmp_path) == "feature/current"
+    assert git.branch_exists(tmp_path, "release/v1.2.3") is True
+    assert git.commits_ahead(tmp_path, "origin/main") == [
+        "abc123 feat: add parser",
+        "xyz789 fix: typo",
+    ]
+
+
+def test_working_tree_clean_and_ahead_behind_handle_multiple_outcomes(
+    monkeypatch, tmp_path: Path
+) -> None:
+    responses = iter(
+        [
+            subprocess.CompletedProcess([], 0, stdout="", stderr=""),
+            subprocess.CompletedProcess([], 0, stdout=" M file.py\n", stderr=""),
+            subprocess.CompletedProcess([], 0, stdout="3 2\n", stderr=""),
+            subprocess.CompletedProcess([], 1, stdout="", stderr="fatal"),
+            subprocess.CompletedProcess([], 0, stdout="malformed\n", stderr=""),
+        ]
+    )
+
+    monkeypatch.setattr(subprocess, "run", lambda *args, **kwargs: next(responses))
+
+    assert git.working_tree_clean(tmp_path) is True
+    assert git.working_tree_clean(tmp_path) is False
+    assert git.ahead_behind(tmp_path, "origin/main") == (3, 2)
+    assert git.ahead_behind(tmp_path, "origin/main") == (0, 0)
+    assert git.ahead_behind(tmp_path, "origin/main") == (0, 0)
+
+
+def test_upstream_branch_returns_value_or_none(monkeypatch, tmp_path: Path) -> None:
+    responses = iter(
+        [
+            subprocess.CompletedProcess([], 0, stdout="origin/main\n", stderr=""),
+            subprocess.CompletedProcess([], 0, stdout="\n", stderr=""),
+            subprocess.CompletedProcess([], 128, stdout="", stderr="fatal"),
+        ]
+    )
+
+    monkeypatch.setattr(subprocess, "run", lambda *args, **kwargs: next(responses))
+
+    assert git.upstream_branch(tmp_path) == "origin/main"
+    assert git.upstream_branch(tmp_path) is None
+    assert git.upstream_branch(tmp_path) is None
+
+
+def test_git_dir_merge_base_remote_names_and_repository_detection(
+    monkeypatch, tmp_path: Path
+) -> None:
+    responses = iter(
+        [
+            subprocess.CompletedProcess([], 0, stdout=".git\n", stderr=""),
+            subprocess.CompletedProcess([], 0, stdout="\n", stderr=""),
+            subprocess.CompletedProcess([], 128, stdout="", stderr="fatal"),
+            subprocess.CompletedProcess([], 0, stdout="abc123\n", stderr=""),
+            subprocess.CompletedProcess([], 128, stdout="", stderr="fatal"),
+            subprocess.CompletedProcess([], 0, stdout="true\n", stderr=""),
+            subprocess.CompletedProcess([], 0, stdout="false\n", stderr=""),
+            subprocess.CompletedProcess([], 128, stdout="", stderr="fatal"),
+        ]
+    )
+
+    monkeypatch.setattr(subprocess, "run", lambda *args, **kwargs: next(responses))
+    monkeypatch.setattr(git, "capture", lambda cmd, cwd: "origin\n\nupstream\n")
+
+    assert git.git_dir(tmp_path) == (tmp_path / ".git").resolve()
+    assert git.git_dir(tmp_path) is None
+    assert git.git_dir(tmp_path) is None
+    assert git.merge_base(tmp_path, "origin/main") == "abc123"
+    assert git.merge_base(tmp_path, "origin/main") is None
+    assert git.remote_names(tmp_path) == ["origin", "upstream"]
+    assert git.is_git_repository(tmp_path) is True
+    assert git.is_git_repository(tmp_path) is False
+    assert git.is_git_repository(tmp_path) is False
 
 
 def test_status_porcelain_preserves_leading_spaces(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -242,6 +242,7 @@ def test_action_installs_from_action_path_and_runs_hooks() -> None:
     assert '--changelog-file "$INPUT_CHANGELOG_FILE"' in action_text
     assert "--ref HEAD" in action_text
     assert '--strategy "${INPUT_CHANGELOG_STRATEGY' in action_text
+    assert 'default: "auto"' in action_text
     assert "--branch" in action_text
 
 
@@ -791,6 +792,30 @@ def test_run_changelog_check_strategy_release_only_skips_check() -> None:
     )
 
 
+def test_run_changelog_check_auto_uses_squash_workflow(tmp_path: Path) -> None:
+    (tmp_path / ".rrt.toml").write_text(
+        """\
+[tool.rrt]
+changelog_workflow = "squash"
+
+[[tool.rrt.version_targets]]
+path = "package.json"
+kind = "package_json"
+""",
+        encoding="utf-8",
+    )
+
+    assert (
+        run_changelog_check(
+            "feat: brand new feature",
+            cwd=tmp_path,
+            changed_files=[],
+            title="Changelog validation failed.",
+        )
+        == 0
+    )
+
+
 def test_run_changelog_check_strategy_unreleased_passes_when_section_nonempty(
     tmp_path: Path,
 ) -> None:
@@ -878,6 +903,48 @@ def test_run_update_unreleased_skips_non_changelog_commits(
 
     assert result == 0
     assert changelog.read_text(encoding="utf-8") == original
+
+
+def test_run_update_unreleased_skips_for_squash_workflow(tmp_path: Path) -> None:
+    (tmp_path / ".rrt.toml").write_text(
+        """\
+[tool.rrt]
+changelog_workflow = "squash"
+
+[[tool.rrt.version_targets]]
+path = "package.json"
+kind = "package_json"
+""",
+        encoding="utf-8",
+    )
+    changelog = tmp_path / "CHANGELOG.md"
+    original = "# Changelog\n"
+    changelog.write_text(original, encoding="utf-8")
+
+    result = run_update_unreleased(tmp_path, subject="feat: new widget")
+
+    assert result == 0
+    assert changelog.read_text(encoding="utf-8") == original
+
+
+def test_run_pre_commit_changelog_skips_for_squash_workflow(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    (tmp_path / ".rrt.toml").write_text(
+        """\
+[tool.rrt]
+changelog_workflow = "squash"
+
+[[tool.rrt.version_targets]]
+path = "package.json"
+kind = "package_json"
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(hooks.git, "current_branch", lambda cwd: "feat/add-hook-checks")
+    monkeypatch.setattr(hooks, "staged_files", lambda cwd: ["src/repo_release_tools/hooks.py"])
+
+    assert run_pre_commit_changelog(tmp_path) == 0
 
 
 def test_run_update_unreleased_returns_one_when_changelog_missing(

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -20,6 +20,8 @@ from repo_release_tools.hooks import dedup_changelog_entries
 from repo_release_tools.hooks import apply_dedup_to_changelog
 from repo_release_tools.hooks import collect_squash_changelog_hunks
 from repo_release_tools.hooks import run_post_correct
+from repo_release_tools.hooks import _detect_changelog_workflow
+from repo_release_tools.hooks import _resolve_changelog_strategy
 
 
 def test_validate_branch_name_accepts_feature_branch() -> None:
@@ -28,6 +30,10 @@ def test_validate_branch_name_accepts_feature_branch() -> None:
 
 def test_validate_branch_name_accepts_release_branch() -> None:
     assert validate_branch_name("release/v1.2.3") is None
+
+
+def test_validate_branch_name_accepts_main_branch() -> None:
+    assert validate_branch_name("main") is None
 
 
 def test_validate_branch_name_accepts_magic_ai_branch() -> None:
@@ -39,6 +45,27 @@ def test_validate_branch_name_rejects_invalid_slug() -> None:
 
     assert problem is not None
     assert "lowercase letters, digits, and hyphens" in problem
+
+
+def test_validate_branch_name_rejects_invalid_release_version() -> None:
+    problem = validate_branch_name("release/vbanana")
+
+    assert problem is not None
+    assert "release/v<semver>" in problem
+
+
+def test_validate_branch_name_rejects_missing_separator() -> None:
+    problem = validate_branch_name("feat-add-parser")
+
+    assert problem is not None
+    assert "<type>/<kebab-case-description>" in problem
+
+
+def test_validate_branch_name_rejects_too_long_slug() -> None:
+    problem = validate_branch_name(f"feat/{'a' * 65}")
+
+    assert problem is not None
+    assert "too long" in problem
 
 
 def test_validate_branch_name_lists_magic_ai_types_in_error() -> None:
@@ -58,6 +85,14 @@ def test_validate_commit_subject_accepts_fixup_commit() -> None:
     assert validate_commit_subject("fixup! feat(cli): add hook checks") is None
 
 
+def test_validate_commit_subject_accepts_merge_commit() -> None:
+    assert validate_commit_subject("Merge branch 'feat/add-parser'") is None
+
+
+def test_validate_commit_subject_rejects_empty_subject() -> None:
+    assert validate_commit_subject("") == "Commit message is empty."
+
+
 def test_validate_commit_subject_rejects_invalid_commit() -> None:
     problem = validate_commit_subject("update stuff")
 
@@ -73,12 +108,20 @@ def test_branch_requires_changelog_skips_maintenance_branch() -> None:
     assert branch_requires_changelog("chore/update-tooling") is False
 
 
+def test_branch_requires_changelog_skips_invalid_branch_type() -> None:
+    assert branch_requires_changelog("wizard/update-tooling") is False
+
+
 def test_commit_subject_requires_changelog_for_breaking_change() -> None:
     assert commit_subject_requires_changelog("chore!: remove deprecated flow") is True
 
 
 def test_commit_subject_requires_changelog_skips_chore_commit() -> None:
     assert commit_subject_requires_changelog("chore: update tooling") is False
+
+
+def test_commit_subject_requires_changelog_skips_invalid_subject() -> None:
+    assert commit_subject_requires_changelog("just do the thing") is False
 
 
 def test_changelog_is_updated_accepts_relative_and_absolute_paths(tmp_path: Path) -> None:
@@ -117,6 +160,37 @@ def test_run_dirty_tree_check_accepts_clean_tree(monkeypatch) -> None:
     monkeypatch.setattr(hooks.git, "working_tree_clean", lambda cwd: True)
 
     assert hooks.run_dirty_tree_check(Path.cwd(), title="Dirty tree validation failed.") == 0
+
+
+def test_run_dirty_tree_check_rejects_non_git_directory(monkeypatch) -> None:
+    monkeypatch.setattr(hooks.git, "is_git_repository", lambda cwd: False)
+
+    assert hooks.run_dirty_tree_check(Path.cwd(), title="Dirty tree validation failed.") == 1
+
+
+def test_run_pre_commit_uses_current_branch_and_extra_types(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(hooks.git, "current_branch", lambda cwd: "snyk/fix-vuln")
+    monkeypatch.setattr(hooks, "load_extra_branch_types", lambda cwd: ("snyk",))
+
+    def fake_run_branch_name_check(
+        branch_name: str, *, title: str, extra_types: tuple[str, ...]
+    ) -> int:
+        captured["branch_name"] = branch_name
+        captured["title"] = title
+        captured["extra_types"] = extra_types
+        return 7
+
+    monkeypatch.setattr(hooks, "run_branch_name_check", fake_run_branch_name_check)
+
+    assert hooks.run_pre_commit(Path.cwd()) == 7
+    assert captured == {
+        "branch_name": "snyk/fix-vuln",
+        "title": "Commit blocked by branch naming policy.",
+        "extra_types": ("snyk",),
+    }
 
 
 def test_run_dirty_tree_check_rejects_dirty_tree(monkeypatch) -> None:
@@ -168,6 +242,29 @@ def test_run_pre_commit_changelog_accepts_staged_changelog(monkeypatch) -> None:
     assert run_pre_commit_changelog(Path.cwd()) == 0
 
 
+def test_run_pre_commit_changelog_skips_non_changelog_branch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(hooks.git, "current_branch", lambda cwd: "chore/update-guide")
+    monkeypatch.setattr(
+        hooks, "staged_files", lambda cwd: pytest.fail("staged_files should not run")
+    )
+
+    assert run_pre_commit_changelog(Path.cwd()) == 0
+
+
+def test_run_pre_commit_changelog_reports_workflow_load_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        hooks,
+        "_detect_changelog_workflow",
+        lambda cwd: (_ for _ in ()).throw(RuntimeError("bad config")),
+    )
+
+    assert run_pre_commit_changelog(Path.cwd()) == 1
+
+
 def test_run_changelog_check_accepts_commit_with_changelog_file() -> None:
     assert (
         run_changelog_check(
@@ -177,6 +274,38 @@ def test_run_changelog_check_accepts_commit_with_changelog_file() -> None:
             title="Changelog validation failed.",
         )
         == 0
+    )
+
+
+def test_run_changelog_check_skips_non_changelog_subject() -> None:
+    assert (
+        run_changelog_check(
+            "chore: rewrite docs",
+            cwd=Path.cwd(),
+            changed_files=[],
+            title="Changelog validation failed.",
+        )
+        == 0
+    )
+
+
+def test_run_changelog_check_reports_strategy_resolution_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        hooks,
+        "_resolve_changelog_strategy",
+        lambda cwd, strategy: (_ for _ in ()).throw(RuntimeError("bad workflow")),
+    )
+
+    assert (
+        run_changelog_check(
+            "feat: add parser",
+            cwd=Path.cwd(),
+            changed_files=[],
+            title="Changelog validation failed.",
+        )
+        == 1
     )
 
 
@@ -927,6 +1056,16 @@ kind = "package_json"
     assert changelog.read_text(encoding="utf-8") == original
 
 
+def test_run_update_unreleased_reports_workflow_load_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        hooks,
+        "_detect_changelog_workflow",
+        lambda cwd: (_ for _ in ()).throw(RuntimeError("bad config")),
+    )
+
+    assert run_update_unreleased(Path.cwd(), subject="feat: parser") == 1
+
+
 def test_run_pre_commit_changelog_skips_for_squash_workflow(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -1128,6 +1267,99 @@ def test_main_update_unreleased_message_file_unreadable(tmp_path: Path) -> None:
         os.chdir(old_cwd)
 
     assert result == 1
+
+
+def test_main_pre_commit_dispatch(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(hooks, "run_pre_commit", lambda cwd: 11)
+
+    assert hooks.main(["pre-commit"]) == 11
+
+
+def test_main_pre_commit_changelog_dispatch(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(hooks, "run_pre_commit_changelog", lambda cwd, *, changelog_file: 12)
+
+    assert hooks.main(["pre-commit-changelog", "--changelog-file", "NEWS.md"]) == 12
+
+
+def test_main_update_unreleased_falls_back_to_commit_editmsg(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text("# Changelog\n", encoding="utf-8")
+    git_dir = tmp_path / ".git"
+    git_dir.mkdir()
+    (git_dir / "COMMIT_EDITMSG").write_text("feat: fallback subject\n", encoding="utf-8")
+    monkeypatch.setattr(hooks.git, "run", lambda *a, **kw: None)
+    monkeypatch.chdir(tmp_path)
+
+    result = hooks.main(["update-unreleased"])
+
+    assert result == 0
+    assert "fallback subject" in changelog.read_text(encoding="utf-8")
+
+
+def test_main_update_unreleased_uses_empty_subject_when_no_commit_editmsg(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    captured: dict[str, str] = {}
+    monkeypatch.chdir(tmp_path)
+
+    def fake_run_update_unreleased(cwd: Path, *, subject: str, changelog_file: str) -> int:
+        captured["subject"] = subject
+        captured["changelog_file"] = changelog_file
+        return 0
+
+    monkeypatch.setattr(hooks, "run_update_unreleased", fake_run_update_unreleased)
+
+    assert hooks.main(["update-unreleased"]) == 0
+    assert captured == {"subject": "", "changelog_file": "CHANGELOG.md"}
+
+
+def test_detect_changelog_workflow_defaults_when_config_missing(tmp_path: Path) -> None:
+    assert _detect_changelog_workflow(tmp_path) == "incremental"
+
+
+def test_detect_changelog_workflow_defaults_for_missing_tool_rrt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        hooks,
+        "load_or_autodetect_config",
+        lambda cwd: (_ for _ in ()).throw(
+            ValueError("Missing rrt configuration in supported config files: pyproject.toml")
+        ),
+    )
+
+    assert _detect_changelog_workflow(Path.cwd()) == "incremental"
+
+
+def test_detect_changelog_workflow_raises_runtime_error_for_invalid_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        hooks,
+        "load_or_autodetect_config",
+        lambda cwd: (_ for _ in ()).throw(ValueError("totally broken config")),
+    )
+
+    with pytest.raises(RuntimeError, match="Failed to load changelog_workflow configuration"):
+        _detect_changelog_workflow(Path.cwd())
+
+
+def test_resolve_changelog_strategy_returns_explicit_strategy() -> None:
+    assert _resolve_changelog_strategy(Path.cwd(), "unreleased") == "unreleased"
+
+
+def test_resolve_changelog_strategy_uses_incremental_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(hooks, "_detect_changelog_workflow", lambda cwd: "incremental")
+
+    assert _resolve_changelog_strategy(Path.cwd(), "auto") == "per-commit"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from argparse import Namespace
 from pathlib import Path
 
+from repo_release_tools.commands import init as init_cmd
 from repo_release_tools.commands.init import cmd_init
 from repo_release_tools.config import (
     recommend_init_config,
@@ -450,3 +451,113 @@ def test_cmd_init_go_fallback_no_go_mod(monkeypatch, tmp_path: Path) -> None:
     content = (tmp_path / ".rrt.toml").read_text(encoding="utf-8")
     assert "[tool.rrt]" in content
     assert "go_version" in content
+
+
+def test_cmd_init_reports_config_discovery_error(monkeypatch, tmp_path: Path, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        init_cmd,
+        "find_explicit_config_file",
+        lambda root: (_ for _ in ()).throw(ValueError("broken config discovery")),
+    )
+
+    assert cmd_init(Namespace(dry_run=False, force=False)) == 1
+    assert "Could not read existing configuration" in capsys.readouterr().err
+
+
+def test_cmd_init_refuses_when_other_explicit_config_exists(
+    monkeypatch, tmp_path: Path, capsys
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='example'\n", encoding="utf-8")
+    monkeypatch.setattr(
+        init_cmd, "find_explicit_config_file", lambda root: tmp_path / "pyproject.toml"
+    )
+
+    assert cmd_init(Namespace(dry_run=False, force=False)) == 1
+    assert "Refusing to add .rrt.toml" in capsys.readouterr().err
+
+
+def test_cmd_init_refuses_existing_rrt_toml_without_force(
+    monkeypatch, tmp_path: Path, capsys
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".rrt.toml").write_text("[tool.rrt]\n", encoding="utf-8")
+    monkeypatch.setattr(init_cmd, "find_explicit_config_file", lambda root: None)
+
+    assert cmd_init(Namespace(dry_run=False, force=False)) == 1
+    assert ".rrt.toml already exists" in capsys.readouterr().err
+
+
+def test_cmd_init_reports_generation_error(monkeypatch, tmp_path: Path, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(init_cmd, "find_explicit_config_file", lambda root: None)
+    monkeypatch.setattr(
+        init_cmd,
+        "recommend_init_config",
+        lambda root: (_ for _ in ()).throw(RuntimeError("cannot recommend")),
+    )
+
+    assert cmd_init(Namespace(dry_run=False, force=False)) == 1
+    assert "Could not generate init config" in capsys.readouterr().err
+
+
+def test_cmd_init_pyproject_reports_generation_error(monkeypatch, tmp_path: Path, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "mypkg"\nversion = "1.0.0"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        init_cmd,
+        "recommend_init_section_for_pyproject",
+        lambda root: (_ for _ in ()).throw(RuntimeError("pyproject detection failed")),
+    )
+
+    assert cmd_init(Namespace(dry_run=False, force=False, target="pyproject")) == 1
+    assert "Could not generate init config" in capsys.readouterr().err
+
+
+def test_cmd_init_force_write_warns_when_other_config_still_precedes(
+    monkeypatch, tmp_path: Path, capsys
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='example'\n", encoding="utf-8")
+    monkeypatch.setattr(
+        init_cmd, "find_explicit_config_file", lambda root: tmp_path / "pyproject.toml"
+    )
+    monkeypatch.setattr(init_cmd, "recommend_init_config", lambda root: "[tool.rrt]\n")
+
+    assert cmd_init(Namespace(dry_run=False, force=True)) == 0
+    assert "still takes precedence" in capsys.readouterr().out
+
+
+def test_cmd_init_node_rejects_invalid_json(monkeypatch, tmp_path: Path, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "package.json").write_text("{broken", encoding="utf-8")
+
+    assert cmd_init(Namespace(dry_run=False, force=False, target="node")) == 1
+    assert "Could not parse package.json" in capsys.readouterr().err
+
+
+def test_cmd_init_node_rejects_non_object_json(monkeypatch, tmp_path: Path, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "package.json").write_text("[]", encoding="utf-8")
+
+    assert cmd_init(Namespace(dry_run=False, force=False, target="node")) == 1
+    assert "top-level object" in capsys.readouterr().err
+
+
+def test_cmd_init_node_reports_generation_error(monkeypatch, tmp_path: Path, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "package.json").write_text(
+        '{"name": "myapp", "version": "1.0.0"}', encoding="utf-8"
+    )
+    monkeypatch.setattr(
+        init_cmd,
+        "recommend_init_section_for_node",
+        lambda root: (_ for _ in ()).throw(RuntimeError("node detection failed")),
+    )
+
+    assert cmd_init(Namespace(dry_run=False, force=False, target="node")) == 1
+    assert "Could not generate init config" in capsys.readouterr().err

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,3 +1,5 @@
+import io
+
 import pytest
 
 from repo_release_tools import output
@@ -136,8 +138,70 @@ def test_spinner_lines_noop_yields_normally(capsys) -> None:
 
 def test_spinner_lines_propagates_exception() -> None:
     """Exceptions raised inside the context propagate out."""
-    import io
-
     with pytest.raises(ValueError, match="boom"):
         with output.spinner_lines("x", file=io.StringIO()):
             raise ValueError("boom")
+
+
+class _TtyBuffer(io.StringIO):
+    def isatty(self) -> bool:
+        return True
+
+
+class _FakeEvent:
+    def __init__(self) -> None:
+        self._is_set = False
+
+    def is_set(self) -> bool:
+        return self._is_set
+
+    def wait(self, timeout: float | None = None) -> bool:
+        self._is_set = True
+        return True
+
+    def set(self) -> None:
+        self._is_set = True
+
+
+class _FakeThread:
+    def __init__(self, target, daemon: bool) -> None:
+        self._target = target
+        self.daemon = daemon
+        self.join_timeout: float | None = None
+
+    def start(self) -> None:
+        self._target()
+
+    def join(self, timeout: float | None = None) -> None:
+        self.join_timeout = timeout
+
+
+def test_spinner_lines_writes_success_status_on_tty(monkeypatch: pytest.MonkeyPatch) -> None:
+    tty = _TtyBuffer()
+
+    monkeypatch.setattr(output.threading, "Event", _FakeEvent)
+    monkeypatch.setattr(output.threading, "Thread", _FakeThread)
+
+    with output.spinner_lines("Working", file=tty):
+        pass
+
+    rendered = tty.getvalue()
+    assert "Working" in rendered
+    assert f"{output.GLYPHS.bullet.ok}  Working" in rendered
+
+
+def test_spinner_lines_writes_error_status_on_tty_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tty = _TtyBuffer()
+
+    monkeypatch.setattr(output.threading, "Event", _FakeEvent)
+    monkeypatch.setattr(output.threading, "Thread", _FakeThread)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with output.spinner_lines("Exploding", file=tty):
+            raise RuntimeError("boom")
+
+    rendered = tty.getvalue()
+    assert "Exploding" in rendered
+    assert f"{output.GLYPHS.bullet.error}  Exploding" in rendered


### PR DESCRIPTION
This pull request updates the documentation and GitHub Action defaults for `repo-release-tools` to clarify and simplify changelog workflows, improve onboarding, and make the action's behavior more adaptive. The main changes are a clearer distinction between incremental and squash changelog workflows, improved documentation for setup in both CI and local environments, and a new default for changelog enforcement strategy that adapts to repository configuration.

**Changelog workflow and configuration improvements:**

* The default `changelog-strategy` input for the GitHub Action is now `"auto"`, which resolves to `per-commit` for incremental workflows and `release-only` for squash workflows, based on the new `changelog_workflow` setting in repo config. This makes changelog enforcement less error-prone and better tailored to the repository's actual workflow. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L38-R42) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L111-R112) [[3]](diffhunk://#diff-704c5597bdc5ccf8da15bdc11287d930193a06f53ebb7f8dd9a11b6c1217986cL333-R393) [[4]](diffhunk://#diff-704c5597bdc5ccf8da15bdc11287d930193a06f53ebb7f8dd9a11b6c1217986cL364-R410)
* Documentation now clearly distinguishes between "incremental" and "squash" changelog workflows, with tables and examples to help users pick the right setup. The docs provide sample `.pre-commit-config.yaml` files for both styles and explain how hooks behave in each. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L25-R82) [[2]](diffhunk://#diff-704c5597bdc5ccf8da15bdc11287d930193a06f53ebb7f8dd9a11b6c1217986cL77-R77) [[3]](diffhunk://#diff-704c5597bdc5ccf8da15bdc11287d930193a06f53ebb7f8dd9a11b6c1217986cL109-R143)
* The README and agent instructions have been rewritten for clarity, including improved quickstart guides, clearer entry points (GitHub Action vs. PyPI package), and links to relevant docs for each workflow and tool. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R43) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L55-R108)

**Documentation and example updates:**

* All references to the action and hooks have been updated to use version `v0.1.10` and the latest `actions/checkout@v6`, ensuring users get the most recent features and fixes. [[1]](diffhunk://#diff-704c5597bdc5ccf8da15bdc11287d930193a06f53ebb7f8dd9a11b6c1217986cL96-R96) [[2]](diffhunk://#diff-704c5597bdc5ccf8da15bdc11287d930193a06f53ebb7f8dd9a11b6c1217986cL132-R165) [[3]](diffhunk://#diff-704c5597bdc5ccf8da15bdc11287d930193a06f53ebb7f8dd9a11b6c1217986cL257-R290) [[4]](diffhunk://#diff-704c5597bdc5ccf8da15bdc11287d930193a06f53ebb7f8dd9a11b6c1217986cL271-R311) [[5]](diffhunk://#diff-704c5597bdc5ccf8da15bdc11287d930193a06f53ebb7f8dd9a11b6c1217986cL285-R322) [[6]](diffhunk://#diff-704c5597bdc5ccf8da15bdc11287d930193a06f53ebb7f8dd9a11b6c1217986cL299-R344) [[7]](diffhunk://#diff-704c5597bdc5ccf8da15bdc11287d930193a06f53ebb7f8dd9a11b6c1217986cL322-R359) [[8]](diffhunk://#diff-704c5597bdc5ccf8da15bdc11287d930193a06f53ebb7f8dd9a11b6c1217986cL333-R393) [[9]](diffhunk://#diff-704c5597bdc5ccf8da15bdc11287d930193a06f53ebb7f8dd9a11b6c1217986cL364-R410) [[10]](diffhunk://#diff-704c5597bdc5ccf8da15bdc11287d930193a06f53ebb7f8dd9a11b6c1217986cL382-R421)
* Example YAML and CLI snippets now consistently use the new `"auto"` strategy and reflect the recommended configuration for both CI and pre-commit/lefthook usage.

**Behavior and constraints clarification:**

* Documentation now explicitly states that `rrt-changelog` and `rrt-update-unreleased` are usually alternatives for incremental workflows and clarifies when to use each, as well as constraints for hook installation and changelog enforcement in different workflows. [[1]](diffhunk://#diff-704c5597bdc5ccf8da15bdc11287d930193a06f53ebb7f8dd9a11b6c1217986cL109-R143) [[2]](diffhunk://#diff-704c5597bdc5ccf8da15bdc11287d930193a06f53ebb7f8dd9a11b6c1217986cL142-R175) [[3]](diffhunk://#diff-704c5597bdc5ccf8da15bdc11287d930193a06f53ebb7f8dd9a11b6c1217986cL364-R410)

These changes make it easier for users to adopt the right changelog workflow for their team, reduce configuration errors, and ensure that both local and CI enforcement are consistent with project policy.