### PR TITLE
docs: fix all legacy H1 headers and add Jekyll frontmatter for consistent naming

### DIFF
--- a/.github/instructions/coverage-tests.instructions.md
+++ b/.github/instructions/coverage-tests.instructions.md
@@ -21,6 +21,12 @@ reached before declaring work done. The coverage summary in
   `isinstance`, exhaustive `if/elif` above it, etc.) before writing the test.
 - Reach dead-code-by-construction branches by patching the dependency, not the SUT:
   `monkeypatch.setattr(_module, "_private_fn", lambda ...: <trigger_value>)`.
+- When the SUT imports a dependency directly into its module namespace, patch the
+  symbol where it is used — not the provider module — so the test actually intercepts
+  the call.
+- When overriding a module-level registry or tuple for a regression test, prefer
+  `monkeypatch.setattr(..., raising=False)` over direct assignment so the override is
+  both temporary and type-checker friendly.
 - To make a monkeypatched function raise an exception, use the generator throw pattern:
   `lambda *a, **kw: (_ for _ in ()).throw(SomeError("msg"))`.
 - When asserting exception messages with `pytest.raises(..., match=...)`, escape regex metacharacters in literal text (especially `[` and `]`) or use `re.escape(...)`.

--- a/.github/instructions/repo-release-tools.instructions.md
+++ b/.github/instructions/repo-release-tools.instructions.md
@@ -47,6 +47,7 @@ When working in `repo-release-tools`, follow these rules:
 - After moving code into a semantic package, update source imports and tests to the canonical package path and delete obsolete root modules in the same change. Do not leave permanent flat-module duplicates behind.
 - Inside a domain package, split logic by role (`core.py`, `data.py`, `detect.py`, `targets.py`, `semver.py`) rather than creating a new oversized sibling module.
 - Anchor-based file injection lives in `src/repo_release_tools/tools/inject.py` — import from `repo_release_tools.tools.inject`, not from `repo_release_tools.inject` (old path removed).
+- In `src/repo_release_tools/docs/publisher.py`, never add YAML frontmatter to content rendered for targets that use `anchor_id` (for example `docs/index.md` and `README.md`); anchored targets must render body-only fragments.
 - Author docs shared blocks inline in `[tool.rrt.docs.shared_blocks].content` under `pyproject.toml` or `.rrt.toml`; do not add new scripts or template files for doc footers, headers, or shared text fragments.
 - Use `fetch_webpage` and `mcp_github_search_code` when researching external examples, issue comments, or PR context before changing behavior.
 - Avoid proposing or creating PRs that lower test coverage; if a change is necessary and coverage drops, explain the coverage gap and add tests to restore it.

--- a/docs/action.md
+++ b/docs/action.md
@@ -1,3 +1,8 @@
+---
+title: "GitHub Action"
+permalink: "/action/"
+---
+
 # GitHub Action
 
 Use the GitHub Action when you want CI to enforce the same policy that

--- a/docs/agent-instructions.md
+++ b/docs/agent-instructions.md
@@ -1,4 +1,9 @@
-# repo-release-tools — Hook & Action Reference
+---
+title: "Hook & Action Reference"
+permalink: "/agent-instructions/"
+---
+
+# Hook & Action Reference
 
 <!-- Static context for agents: read this before using any prompt block below. -->
 

--- a/docs/commands/branch.md
+++ b/docs/commands/branch.md
@@ -1,4 +1,9 @@
-# Conventional branches for trunk-based publishing
+---
+title: "rrt branch"
+permalink: "/commands/branch/"
+---
+
+# rrt branch
 
 `repo-release-tools` uses conventional branches to keep trunk-based publishing
 predictable for humans, hooks, and automation.

--- a/docs/commands/bump.md
+++ b/docs/commands/bump.md
@@ -1,3 +1,8 @@
+---
+title: "rrt bump"
+permalink: "/commands/bump/"
+---
+
 # rrt bump
 
 Bump the version of the repository according to the configured version targets.

--- a/docs/commands/ci_version.md
+++ b/docs/commands/ci_version.md
@@ -1,3 +1,8 @@
+---
+title: "rrt ci-version"
+permalink: "/commands/ci_version/"
+---
+
 # rrt ci-version
 
 Emit the current project version for use in CI pipelines.

--- a/docs/commands/config_cmd.md
+++ b/docs/commands/config_cmd.md
@@ -1,3 +1,8 @@
+---
+title: "rrt config"
+permalink: "/commands/config_cmd/"
+---
+
 # rrt config
 
 Inspect and validate the resolved rrt configuration.

--- a/docs/commands/doctor.md
+++ b/docs/commands/doctor.md
@@ -1,3 +1,10 @@
+---
+title: "rrt doctor"
+permalink: "/commands/doctor/"
+---
+
+# rrt doctor
+
 Validate the core automation health of the resolved rrt configuration.
 
 ## Overview

--- a/docs/commands/env_cmd.md
+++ b/docs/commands/env_cmd.md
@@ -1,3 +1,8 @@
+---
+title: "rrt env"
+permalink: "/commands/env_cmd/"
+---
+
 # rrt env
 
 Display the resolved runtime environment information.

--- a/docs/commands/eol_check.md
+++ b/docs/commands/eol_check.md
@@ -1,3 +1,10 @@
+---
+title: "rrt eol"
+permalink: "/commands/eol_check/"
+---
+
+# rrt eol
+
 Runtime end-of-life (EOL) tracking for repo-release-tools.
 
 Supports Python, Go, Node.js, and Rust. Bundled data provides offline

--- a/docs/commands/folder.md
+++ b/docs/commands/folder.md
@@ -1,3 +1,8 @@
+---
+title: "rrt folder"
+permalink: "/commands/folder/"
+---
+
 # rrt folder
 
 Supervise and scaffold repository folder structures with reusable templates.

--- a/docs/commands/git_cmd.md
+++ b/docs/commands/git_cmd.md
@@ -1,9 +1,14 @@
-# Git magic
+---
+title: "rrt git"
+permalink: "/commands/git_cmd/"
+---
+
+# rrt git
 
 `repo-release-tools` ships a small set of opinionated Git workflows for branch
 health, commit drafting, sync, and history repair.
 
-This page is generated from `repo_release_tools.workflow.git.GIT_MAGIC_DOC`.
+This page is generated from `repo_release_tools.workflow.git.GIT_DOC`.
 This page stays workflow-oriented. For the full command surface and option
 details, see [docs/commands/rrt-cli.md](rrt-cli.md).
 

--- a/docs/commands/hooks.md
+++ b/docs/commands/hooks.md
@@ -1,4 +1,9 @@
-# pre-commit
+---
+title: "rrt hooks"
+permalink: "/commands/hooks/"
+---
+
+# rrt hooks
 
 `repo-release-tools` publishes reusable hooks in `.pre-commit-hooks.yaml`.
 

--- a/docs/commands/init.md
+++ b/docs/commands/init.md
@@ -1,3 +1,8 @@
+---
+title: "rrt init"
+permalink: "/commands/init/"
+---
+
 # rrt init
 
 Bootstrap rrt configuration in a new or existing repository.

--- a/docs/commands/rrt-cli.md
+++ b/docs/commands/rrt-cli.md
@@ -1,4 +1,9 @@
-# RRT CLI
+---
+title: "rrt CLI"
+permalink: "/commands/rrt-cli/"
+---
+
+# rrt CLI
 
 <!-- Auto-generated from repo_release_tools.cli.build_parser(); run `rrt docs publish` to refresh. -->
 
@@ -874,7 +879,7 @@ Examples
 
 ## `rrt tree`
 
-### Project tree
+### rrt tree
 
 `rrt tree` renders a deterministic project tree with Git-aware filtering and
 multiple output modes for terminal use, docs, and copy/paste workflows.
@@ -1168,7 +1173,7 @@ Options
 
 ## `rrt branch`
 
-### Conventional branches for trunk-based publishing
+### rrt branch
 
 `repo-release-tools` uses conventional branches to keep trunk-based publishing
 predictable for humans, hooks, and automation.
@@ -1377,12 +1382,12 @@ Examples
 
 ## `rrt git`
 
-### Git magic
+### rrt git
 
 `repo-release-tools` ships a small set of opinionated Git workflows for branch
 health, commit drafting, sync, and history repair.
 
-This page is generated from `repo_release_tools.workflow.git.GIT_MAGIC_DOC`.
+This page is generated from `repo_release_tools.workflow.git.GIT_DOC`.
 This page stays workflow-oriented. For the full command surface and option
 details, see [docs/commands/rrt-cli.md](rrt-cli.md).
 

--- a/docs/commands/skill.md
+++ b/docs/commands/skill.md
@@ -1,4 +1,9 @@
-# Skills
+---
+title: "rrt skill"
+permalink: "/commands/skill/"
+---
+
+# rrt skill
 
 This repository bundles two agent skills:
 
@@ -6,7 +11,7 @@ This repository bundles two agent skills:
 - `/.github/skills/repo-release-tools/SKILL.md` — guidance for an installed `rrt`
 
 If you need the exact CLI syntax for branch, Git, or skill commands, use the
-[RRT CLI reference](rrt-cli.md) first.
+[rrt CLI reference](rrt-cli.md) first.
 
 ## Which skill to use
 
@@ -53,10 +58,10 @@ Use `--dry-run` to preview the destination paths first.
 
 ## Related docs
 
-- [RRT CLI](rrt-cli.md)
+- [rrt CLI](rrt-cli.md)
 - [pre-commit / lefthook](hooks.md)
 - [GitHub Action](action.md)
-- [Git magic](git.md)
+- [rrt git](git_cmd.md)
 
 ## Skill eval fixtures
 

--- a/docs/commands/toc.md
+++ b/docs/commands/toc.md
@@ -1,4 +1,9 @@
-# Table of Contents — `rrt toc`
+---
+title: "rrt toc"
+permalink: "/commands/toc/"
+---
+
+# rrt toc
 
 Generate a Markdown table of contents from the ATX headings in a file.
 The TOC can be printed to stdout or injected in-place into a target file via

--- a/docs/commands/tree.md
+++ b/docs/commands/tree.md
@@ -1,4 +1,9 @@
-# Project tree
+---
+title: "rrt tree"
+permalink: "/commands/tree/"
+---
+
+# rrt tree
 
 `rrt tree` renders a deterministic project tree with Git-aware filtering and
 multiple output modes for terminal use, docs, and copy/paste workflows.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,9 @@
-# repo-release-tools docs
+---
+title: "repo-release-tools"
+permalink: "/"
+---
+
+# repo-release-tools
 
 `repo-release-tools` has three main surfaces:
 
@@ -7,7 +12,7 @@
 - **[GitHub Action](action.md)** for CI policy checks that mirror the
   local workflow
 - **Generated topic docs**:
-  [Semantic branches](commands/branch.md) and [Git magic](commands/git_cmd.md) for
+  [Semantic branches](commands/branch.md) and [rrt git](commands/git_cmd.md) for
   the branch naming model and Git workflow guidance
 
 If you need command syntax, start with the generated CLI reference first. It is
@@ -26,9 +31,9 @@ the canonical home for the current `rrt` command surface.
 ## Then follow the workflow
 
 <!-- rrt:auto:start:index-topic-links -->
-- [Semantic branches](commands/branch.md) — generated branch naming model and allowed branch types
-- [Git magic](commands/git_cmd.md) — generated Git helpers and workflow shortcuts
-- [Project tree](commands/tree.md) — generated guide for `rrt tree` output modes, ignore behavior, and traversal controls
+- [rrt branch](commands/branch.md) — generated branch naming model and allowed branch types
+- [rrt git](commands/git_cmd.md) — generated Git helpers and workflow shortcuts
+- [rrt tree](commands/tree.md) — generated guide for `rrt tree` output modes, ignore behavior, and traversal controls
 <!-- rrt:auto:end:index-topic-links -->
 
 ## Commands reference

--- a/src/repo_release_tools/__init__.py
+++ b/src/repo_release_tools/__init__.py
@@ -2,7 +2,7 @@
 
 __version__ = "1.2.0"
 
-INDEX_DOC = """# repo-release-tools docs
+INDEX_DOC = """# repo-release-tools
 
 `repo-release-tools` has three main surfaces:
 
@@ -11,7 +11,7 @@ INDEX_DOC = """# repo-release-tools docs
 - **[GitHub Action](action.md)** for CI policy checks that mirror the
   local workflow
 - **Generated topic docs**:
-  [Semantic branches](branch.md) and [Git magic](git.md) for
+  [Semantic branches](branch.md) and [rrt git](git_cmd.md) for
   the branch naming model and Git workflow guidance
 
 If you need command syntax, start with the generated CLI reference first. It is
@@ -31,7 +31,7 @@ the canonical home for the current `rrt` command surface.
 
 - [Semantic branches](branch.md) — generated branch naming model
   and allowed branch types
-- [Git magic](git.md) — generated Git helpers and workflow shortcuts
+- [rrt git](git_cmd.md) — generated Git helpers and workflow shortcuts
 
 ## Changelog workflow
 

--- a/src/repo_release_tools/commands/branch.py
+++ b/src/repo_release_tools/commands/branch.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from repo_release_tools.ui import GLYPHS, DryRunPrinter
 from repo_release_tools.workflow import git
 
-SEMANTIC_BRANCHES_DOC = """# Conventional branches for trunk-based publishing
+SEMANTIC_BRANCHES_DOC = """# rrt branch
 
 `repo-release-tools` uses conventional branches to keep trunk-based publishing
 predictable for humans, hooks, and automation.

--- a/src/repo_release_tools/commands/docs_cmd.py
+++ b/src/repo_release_tools/commands/docs_cmd.py
@@ -258,20 +258,26 @@ def _cmd_publish(args: argparse.Namespace) -> int:
     dry_run: bool = getattr(args, "dry_run", False)
     fail_on_change: bool = getattr(args, "fail_on_change", False)
 
-    if consistency_issues := docs_publisher.validate_generated_pages():
+    rendered_targets: list[tuple[docs_publisher.DocTarget, str]] = []
+    consistency_issues: list[str] = []
+    for target in docs_publisher.iter_generated_doc_targets():
+        rendered = target.render()
+        rendered_targets.append((target, rendered))
+        consistency_issues.extend(docs_publisher.validate_generated_page(target, rendered))
+
+    if consistency_issues:
         for issue in consistency_issues:
             sys.stderr.write(f"{issue}\n")
         return 1
 
     if dry_run:
         p = DryRunPrinter(dry_run=True)
-        for target in docs_publisher.iter_generated_doc_targets():
+        for target, _rendered in rendered_targets:
             p.would_write(str(target.output_path))
         return 0
 
     exit_code = 0
-    for target in docs_publisher.iter_generated_doc_targets():
-        content = target.render()
+    for target, content in rendered_targets:
         exit_code = max(
             exit_code,
             apply_generated_docs(

--- a/src/repo_release_tools/commands/docs_cmd.py
+++ b/src/repo_release_tools/commands/docs_cmd.py
@@ -258,6 +258,11 @@ def _cmd_publish(args: argparse.Namespace) -> int:
     dry_run: bool = getattr(args, "dry_run", False)
     fail_on_change: bool = getattr(args, "fail_on_change", False)
 
+    if consistency_issues := docs_publisher.validate_generated_pages():
+        for issue in consistency_issues:
+            sys.stderr.write(f"{issue}\n")
+        return 1
+
     if dry_run:
         p = DryRunPrinter(dry_run=True)
         for target in docs_publisher.iter_generated_doc_targets():

--- a/src/repo_release_tools/commands/skill.py
+++ b/src/repo_release_tools/commands/skill.py
@@ -73,7 +73,7 @@ SKILL_INSTALL_EXAMPLES = (
     "  $ rrt skill install --target copilot-global --force --dry-run"
 )
 
-SKILLS_DOC = """# Skills
+SKILLS_DOC = """# rrt skill
 
 This repository bundles two agent skills:
 
@@ -81,7 +81,7 @@ This repository bundles two agent skills:
 - `/.github/skills/repo-release-tools/SKILL.md` — guidance for an installed `rrt`
 
 If you need the exact CLI syntax for branch, Git, or skill commands, use the
-[RRT CLI reference](rrt-cli.md) first.
+[rrt CLI reference](rrt-cli.md) first.
 
 ## Which skill to use
 
@@ -128,10 +128,10 @@ Use `--dry-run` to preview the destination paths first.
 
 ## Related docs
 
-- [RRT CLI](rrt-cli.md)
+- [rrt CLI](rrt-cli.md)
 - [pre-commit / lefthook](hooks.md)
 - [GitHub Action](action.md)
-- [Git magic](git.md)
+- [rrt git](git_cmd.md)
 
 ## Skill eval fixtures
 

--- a/src/repo_release_tools/commands/tree.py
+++ b/src/repo_release_tools/commands/tree.py
@@ -67,7 +67,7 @@ rrt tree --format markdown --inject README.md --anchor project-tree --dry-run
 ## Related docs
 
 - [Generated CLI reference](rrt-cli.md)
-- [Git magic](git.md)
+- [rrt git](git_cmd.md)
 """
 
 from __future__ import annotations
@@ -110,7 +110,7 @@ TREE_EPILOG = """  $ rrt tree
   $ rrt tree --root src/repo_release_tools --dirs-only
   $ rrt tree --format markdown --inject README.md --anchor project-tree"""
 
-TREE_DOC = """# Project tree
+TREE_DOC = """# rrt tree
 
 `rrt tree` renders a deterministic project tree with Git-aware filtering and
 multiple output modes for terminal use, docs, and copy/paste workflows.

--- a/src/repo_release_tools/docs/publisher.py
+++ b/src/repo_release_tools/docs/publisher.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import argparse
 import inspect
 import os
+import re
 from collections.abc import Callable, Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -337,7 +338,7 @@ def render_help(argv: Sequence[str]) -> str:
 def generate_markdown() -> str:
     """Return the generated CLI reference Markdown."""
     parts = [
-        "# RRT CLI",
+        "# rrt CLI",
         "",
         AUTOGEN_NOTE,
         "",
@@ -376,17 +377,17 @@ def generate_semantic_branches_markdown() -> str:
     return _render_topic_doc("branch")
 
 
-def generate_git_magic_markdown() -> str:
-    """Return the generated Git magic topic page."""
+def generate_git_markdown() -> str:
+    """Return the generated rrt git topic page."""
     return _render_topic_doc("git")
 
 
 def generate_index_topic_links_markdown() -> str:
     """Return the generated topic-link bullets for docs/index.md."""
     links = [
-        "- [Semantic branches](commands/branch.md) — generated branch naming model and allowed branch types",
-        "- [Git magic](commands/git_cmd.md) — generated Git helpers and workflow shortcuts",
-        "- [Project tree](commands/tree.md) — generated guide for `rrt tree` output modes, "
+        "- [rrt branch](commands/branch.md) — generated branch naming model and allowed branch types",
+        "- [rrt git](commands/git_cmd.md) — generated Git helpers and workflow shortcuts",
+        "- [rrt tree](commands/tree.md) — generated guide for `rrt tree` output modes, "
         "ignore behavior, and traversal controls",
     ]
     return "\n".join(links)
@@ -428,10 +429,100 @@ TOPIC_PAGE_OUTPUTS: dict[str, Path] = {
 }
 
 
+# ---------------------------------------------------------------------------
+# Title / permalink helpers for generated pages
+# ---------------------------------------------------------------------------
+
+TITLE_OVERRIDES: dict[str, str] = {
+    "rrt-cli": "rrt CLI",
+    "branch": "rrt branch",
+    "git": "rrt git",
+    "tree": "rrt tree",
+    "hooks": "rrt hooks",
+    "action": "GitHub Action",
+    "skill": "rrt skill",
+    "agent-instructions": "Hook & Action Reference",
+    "doctor": "rrt doctor",
+    "eol": "rrt eol",
+}
+
+
+def _extract_first_h1(text: str) -> str | None:
+    """Return the first top-level heading text from *text*, or ``None``."""
+    m = re.search(r"(?m)^\s*#\s+(.+)$", text)
+    return m.group(1).strip() if m else None
+
+
+def _compute_permalink_for_output(output_path: Path) -> str:
+    """Compute a reasonable permalink for *output_path* when under `docs/`.
+
+    Examples:
+    - `docs/index.md` -> `/`
+    - `docs/commands/rrt-cli.md` -> `/commands/rrt-cli/`
+    """
+    try:
+        rel = output_path.relative_to("docs")
+    except Exception:
+        return ""
+    if rel.name == "index.md":
+        return "/"
+    # drop the suffix and produce a posix path with trailing slash
+    return "/" + str(rel.with_suffix("")).replace(os.sep, "/") + "/"
+
+
+def _wrap_with_frontmatter(
+    output_path: Path,
+    render_func: Callable[[], str],
+    *,
+    title_override: str | None = None,
+    slug: str | None = None,
+) -> Callable[[], str]:
+    """Return a render callable that prefixes generated content with YAML frontmatter.
+
+    The frontmatter contains at least a `title:` and, when applicable, a
+    `permalink:` so Jekyll/minima uses a stable label and URL for the page.
+    """
+
+    def _wrapped() -> str:
+        content = render_func()
+        # Determine title: overrides > TITLE_OVERRIDES > first H1 > fallback to filename
+        if title_override:
+            title = title_override
+        elif slug and slug in TITLE_OVERRIDES:
+            title = TITLE_OVERRIDES[slug]
+        else:
+            title = _extract_first_h1(content) or output_path.stem
+
+        # Ensure quotes in title are escaped
+        title = title.replace('"', '\\"')
+
+        if output_path.suffix.lower() == ".md" and output_path.parts[:2] == ("docs", "commands"):
+            content = _ensure_primary_h1(content, title)
+
+        permalink = _compute_permalink_for_output(output_path)
+
+        fm_lines = [f'title: "{title}"']
+        if permalink:
+            fm_lines.append(f'permalink: "{permalink}"')
+
+        frontmatter = "---\n" + "\n".join(fm_lines) + "\n---\n\n"
+        return frontmatter + content
+
+    return _wrapped
+
+
 def _build_generated_doc_targets() -> tuple[DocTarget, ...]:
     """Build the registry of generated doc outputs."""
     targets: list[DocTarget] = [
-        DocTarget(DEFAULT_OUTPUT, generate_markdown),
+        DocTarget(
+            DEFAULT_OUTPUT,
+            _wrap_with_frontmatter(
+                DEFAULT_OUTPUT,
+                generate_markdown,
+                title_override=TITLE_OVERRIDES.get("rrt-cli"),
+                slug="rrt-cli",
+            ),
+        ),
         DocTarget(
             Path("docs/index.md"),
             generate_index_topic_links_markdown,
@@ -443,9 +534,62 @@ def _build_generated_doc_targets() -> tuple[DocTarget, ...]:
             anchor_id="readme-links",
         ),
     ]
+
     for slug, output_path in TOPIC_PAGE_OUTPUTS.items():
-        targets.append(DocTarget(output_path, lambda slug=slug: _render_topic_doc(slug)))
+        render_fn = _wrap_with_frontmatter(
+            output_path,
+            lambda slug=slug: _render_topic_doc(slug),
+            title_override=TITLE_OVERRIDES.get(slug),
+            slug=slug,
+        )
+        targets.append(DocTarget(output_path, render_fn))
     return tuple(targets)
+
+
+def _ensure_primary_h1(content: str, title: str) -> str:
+    """Ensure *content* has a top-level H1 matching *title*.
+
+    If a top-level H1 exists, it is replaced with ``# <title>``.
+    If no top-level H1 exists, one is prepended.
+    """
+    lines = content.splitlines()
+    for idx, line in enumerate(lines):
+        if re.match(r"^\s*#\s+.+$", line):
+            lines[idx] = f"# {title}"
+            return "\n".join(lines).rstrip() + "\n"
+    body = content.lstrip("\n")
+    return f"# {title}\n\n{body}".rstrip() + "\n"
+
+
+def validate_generated_pages() -> list[str]:
+    """Return consistency issues for generated command pages.
+
+    Rules:
+    - top-level generated command pages must include frontmatter
+    - top-level generated command pages must include a top-level H1
+    """
+    issues: list[str] = []
+    for target in GENERATED_DOC_TARGETS:
+        if target.anchor_id is not None:
+            continue
+        if target.output_path.parts[:2] != ("docs", "commands"):
+            continue
+
+        rendered = target.render()
+        if not rendered.startswith("---\n"):
+            issues.append(f"{target.output_path}: missing YAML frontmatter")
+            continue
+
+        fm_close = rendered.find("\n---\n")
+        if fm_close == -1:
+            issues.append(f"{target.output_path}: malformed YAML frontmatter")
+            continue
+
+        body = rendered[fm_close + len("\n---\n") :].lstrip("\n")
+        if not body.startswith("# "):
+            issues.append(f"{target.output_path}: missing top-level H1")
+
+    return issues
 
 
 GENERATED_DOC_TARGETS: tuple[DocTarget, ...] = _build_generated_doc_targets()

--- a/src/repo_release_tools/docs/publisher.py
+++ b/src/repo_release_tools/docs/publisher.py
@@ -462,7 +462,7 @@ def _compute_permalink_for_output(output_path: Path) -> str:
     """
     try:
         rel = output_path.relative_to("docs")
-    except Exception:
+    except ValueError:
         return ""
     if rel.name == "index.md":
         return "/"
@@ -570,24 +570,31 @@ def validate_generated_pages() -> list[str]:
     """
     issues: list[str] = []
     for target in GENERATED_DOC_TARGETS:
-        if target.anchor_id is not None:
-            continue
-        if target.output_path.parts[:2] != ("docs", "commands"):
-            continue
+        issues.extend(validate_generated_page(target, target.render()))
 
-        rendered = target.render()
-        if not rendered.startswith("---\n"):
-            issues.append(f"{target.output_path}: missing YAML frontmatter")
-            continue
+    return issues
 
-        fm_close = rendered.find("\n---\n")
-        if fm_close == -1:
-            issues.append(f"{target.output_path}: malformed YAML frontmatter")
-            continue
 
-        body = rendered[fm_close + len("\n---\n") :].lstrip("\n")
-        if not body.startswith("# "):
-            issues.append(f"{target.output_path}: missing top-level H1")
+def validate_generated_page(target: DocTarget, rendered: str) -> list[str]:
+    """Return consistency issues for one generated command page rendering."""
+    if target.anchor_id is not None:
+        return []
+    if target.output_path.parts[:2] != ("docs", "commands"):
+        return []
+
+    issues: list[str] = []
+    if not rendered.startswith("---\n"):
+        issues.append(f"{target.output_path}: missing YAML frontmatter")
+        return issues
+
+    fm_close = rendered.find("\n---\n")
+    if fm_close == -1:
+        issues.append(f"{target.output_path}: malformed YAML frontmatter")
+        return issues
+
+    body = rendered[fm_close + len("\n---\n") :].lstrip("\n")
+    if not body.startswith("# "):
+        issues.append(f"{target.output_path}: missing top-level H1")
 
     return issues
 

--- a/src/repo_release_tools/hooks.py
+++ b/src/repo_release_tools/hooks.py
@@ -1084,7 +1084,7 @@ def main(argv: list[str] | None = None) -> int:
     )
 
 
-PRE_COMMIT_DOC = """# pre-commit
+PRE_COMMIT_DOC = """# rrt hooks
 
 `repo-release-tools` publishes reusable hooks in `.pre-commit-hooks.yaml`.
 
@@ -1318,7 +1318,7 @@ pre-commit:
 | Pre-push unreleased guard | `rrt-changelog` or `rrt-dirty-tree` | `rrt-hooks check-changelog --strategy unreleased` |
 """
 
-AGENT_INSTRUCTIONS_DOC = """# repo-release-tools — Hook & Action Reference
+AGENT_INSTRUCTIONS_DOC = """# Hook & Action Reference
 
 <!-- Static context for agents: read this before using any prompt block below. -->
 

--- a/src/repo_release_tools/workflow/git.py
+++ b/src/repo_release_tools/workflow/git.py
@@ -7,12 +7,12 @@ from pathlib import Path
 
 from repo_release_tools.ui import DryRunPrinter
 
-GIT_MAGIC_DOC = """# Git magic
+GIT_DOC = """# rrt git
 
 `repo-release-tools` ships a small set of opinionated Git workflows for branch
 health, commit drafting, sync, and history repair.
 
-This page is generated from `repo_release_tools.workflow.git.GIT_MAGIC_DOC`.
+This page is generated from `repo_release_tools.workflow.git.GIT_DOC`.
 This page stays workflow-oriented. For the full command surface and option
 details, see [docs/commands/rrt-cli.md](rrt-cli.md).
 
@@ -70,7 +70,7 @@ rrt git rebootstrap --yes-i-know-this-destroys-history --dry-run
 """
 
 # Ordered source-owned topic docs for future generic docs generation.
-SOURCE_OWNED_TOPIC_DOCS: tuple[tuple[str, str], ...] = (("git", GIT_MAGIC_DOC),)
+SOURCE_OWNED_TOPIC_DOCS: tuple[tuple[str, str], ...] = (("git", GIT_DOC),)
 
 
 def run(

--- a/src/repo_release_tools/workflow/hooks.py
+++ b/src/repo_release_tools/workflow/hooks.py
@@ -1084,7 +1084,7 @@ def main(argv: list[str] | None = None) -> int:
     )
 
 
-PRE_COMMIT_DOC = """# pre-commit
+PRE_COMMIT_DOC = """# rrt hooks
 
 `repo-release-tools` publishes reusable hooks in `.pre-commit-hooks.yaml`.
 
@@ -1318,7 +1318,7 @@ pre-commit:
 | Pre-push unreleased guard | `rrt-changelog` or `rrt-dirty-tree` | `rrt-hooks check-changelog --strategy unreleased` |
 """
 
-AGENT_INSTRUCTIONS_DOC = """# repo-release-tools — Hook & Action Reference
+AGENT_INSTRUCTIONS_DOC = """# Hook & Action Reference
 
 <!-- Static context for agents: read this before using any prompt block below. -->
 

--- a/tests/test_docs_cmd.py
+++ b/tests/test_docs_cmd.py
@@ -425,6 +425,7 @@ class TestCmdPublish:
             ),
         ]
         monkeypatch.setattr(docs_publisher, "iter_generated_doc_targets", lambda: iter(targets))
+        monkeypatch.setattr(docs_publisher, "validate_generated_pages", lambda: [])
 
         args = argparse.Namespace(check=False, dry_run=True, fail_on_change=False)
 
@@ -446,6 +447,7 @@ class TestCmdPublish:
             anchor_id="index-topic-links",
         )
         monkeypatch.setattr(docs_publisher, "iter_generated_doc_targets", lambda: iter([target]))
+        monkeypatch.setattr(docs_publisher, "validate_generated_pages", lambda: [])
 
         def fake_apply_generated_docs(
             content: str,
@@ -479,6 +481,23 @@ class TestCmdPublish:
                 "index-topic-links",
             )
         ]
+
+    def test_cmd_publish_fails_when_generated_pages_are_inconsistent(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Publish should fail fast when generated-page consistency checks report issues."""
+        from repo_release_tools.docs import publisher as docs_publisher
+
+        monkeypatch.setattr(
+            docs_publisher,
+            "validate_generated_pages",
+            lambda: ["docs/commands/doctor.md: missing top-level H1"],
+        )
+
+        args = argparse.Namespace(check=False, dry_run=False, fail_on_change=False)
+
+        assert _cmd_publish(args) == 1
+        assert "missing top-level H1" in capsys.readouterr().err
 
 
 class TestCmdInject:

--- a/tests/test_docs_cmd.py
+++ b/tests/test_docs_cmd.py
@@ -488,10 +488,15 @@ class TestCmdPublish:
         """Publish should fail fast when generated-page consistency checks report issues."""
         from repo_release_tools.docs import publisher as docs_publisher
 
+        target = docs_publisher.DocTarget(
+            Path("docs/commands/doctor.md"),
+            lambda: '---\ntitle: "rrt doctor"\n---\n\n# rrt doctor\n',
+        )
+        monkeypatch.setattr(docs_publisher, "iter_generated_doc_targets", lambda: iter([target]))
         monkeypatch.setattr(
             docs_publisher,
-            "validate_generated_pages",
-            lambda: ["docs/commands/doctor.md: missing top-level H1"],
+            "validate_generated_page",
+            lambda target, rendered: ["docs/commands/doctor.md: missing top-level H1"],
         )
 
         args = argparse.Namespace(check=False, dry_run=False, fail_on_change=False)

--- a/tests/test_generate_cli_docs.py
+++ b/tests/test_generate_cli_docs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import importlib
 import io
 import os
@@ -15,6 +16,12 @@ def _load_generator_module() -> ModuleType:
 
     importlib.reload(pub)
     return pub
+
+
+def _assert_frontmatter_and_h1(rendered: str, *, title: str) -> None:
+    assert rendered.startswith("---\n")
+    assert f'title: "{title}"' in rendered
+    assert f"\n# {title}\n" in rendered
 
 
 def test_iter_help_sections_covers_root_commands_and_nested_subcommands() -> None:
@@ -232,17 +239,9 @@ def test_generated_command_topics_have_frontmatter_and_command_h1() -> None:
     eol = by_name["eol_check.md"].render()
     git_doc = by_name["git_cmd.md"].render()
 
-    assert doctor.startswith("---\n")
-    assert 'title: "rrt doctor"' in doctor
-    assert "\n# rrt doctor\n" in doctor
-
-    assert eol.startswith("---\n")
-    assert 'title: "rrt eol"' in eol
-    assert "\n# rrt eol\n" in eol
-
-    assert git_doc.startswith("---\n")
-    assert 'title: "rrt git"' in git_doc
-    assert "\n# rrt git\n" in git_doc
+    _assert_frontmatter_and_h1(doctor, title="rrt doctor")
+    _assert_frontmatter_and_h1(eol, title="rrt eol")
+    _assert_frontmatter_and_h1(git_doc, title="rrt git")
 
 
 def test_validate_generated_pages_returns_no_issues_for_current_registry() -> None:
@@ -258,6 +257,54 @@ def test_extract_first_h1_and_compute_permalink_helpers() -> None:
     assert docs._extract_first_h1("No heading here\n") is None
 
     assert docs._compute_permalink_for_output(Path("docs/index.md")) == "/"
+
+
+def test_compute_permalink_only_swallows_value_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    docs = _load_generator_module()
+
+    def boom(self: Path, other: object) -> Path:
+        raise RuntimeError("unexpected path error")
+
+    monkeypatch.setattr(Path, "relative_to", boom)
+
+    with pytest.raises(RuntimeError, match="unexpected path error"):
+        docs._compute_permalink_for_output(Path("docs/example.md"))
+
+
+def test_cmd_publish_renders_each_target_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    docs = _load_generator_module()
+    from repo_release_tools.commands import docs_cmd
+
+    calls: list[str] = []
+
+    class FakeTarget:
+        def __init__(self, name: str) -> None:
+            self.output_path = Path(f"docs/commands/{name}.md")
+            self.anchor_id = None
+            self.name = name
+            self.render_calls = 0
+
+        def render(self) -> str:
+            self.render_calls += 1
+            return f'---\ntitle: "{self.name}"\n---\n\n# {self.name}\n'
+
+    targets = [FakeTarget("alpha"), FakeTarget("beta")]
+
+    monkeypatch.setattr(docs, "iter_generated_doc_targets", lambda: iter(targets))
+    monkeypatch.setattr(docs, "validate_generated_page", lambda target, rendered: [])
+    monkeypatch.setattr(
+        docs_cmd,
+        "apply_generated_docs",
+        lambda content, **kwargs: calls.append(content) or 0,
+    )
+
+    exit_code = docs_cmd._cmd_publish(
+        argparse.Namespace(check=False, dry_run=False, fail_on_change=False)
+    )
+
+    assert exit_code == 0
+    assert [target.render_calls for target in targets] == [1, 1]
+    assert len(calls) == 2
     assert (
         docs._compute_permalink_for_output(Path("docs/commands/rrt-cli.md")) == "/commands/rrt-cli/"
     )
@@ -305,20 +352,27 @@ def test_wrap_with_frontmatter_uses_title_override_registry_when_slug_known() ->
 
 def test_validate_generated_pages_reports_each_invalid_render_shape() -> None:
     docs = _load_generator_module()
-    original_targets = docs.GENERATED_DOC_TARGETS  # ty: ignore[unresolved-attribute]
-    try:
-        docs.GENERATED_DOC_TARGETS = (  # ty: ignore[unresolved-attribute]
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(
+        docs,
+        "GENERATED_DOC_TARGETS",
+        (
             docs.DocTarget(Path("docs/commands/no-frontmatter.md"), lambda: "# heading\n"),
             docs.DocTarget(
-                Path("docs/commands/malformed-frontmatter.md"), lambda: "---\nname: x\n# heading\n"
+                Path("docs/commands/malformed-frontmatter.md"),
+                lambda: "---\nname: x\n# heading\n",
             ),
             docs.DocTarget(
                 Path("docs/commands/no-h1.md"), lambda: "---\nname: x\n---\nplain body\n"
             ),
-        )
+        ),
+        raising=False,
+    )
+    try:
         issues = docs.validate_generated_pages()
     finally:
-        docs.GENERATED_DOC_TARGETS = original_targets  # ty: ignore[unresolved-attribute]
+        monkeypatch.undo()
 
     assert any("missing YAML frontmatter" in issue for issue in issues)
     assert any("malformed YAML frontmatter" in issue for issue in issues)

--- a/tests/test_generate_cli_docs.py
+++ b/tests/test_generate_cli_docs.py
@@ -36,15 +36,16 @@ def test_generate_markdown_has_stable_sections_without_ansi_sequences() -> None:
 
     content = docs.generate_markdown()
 
-    assert content.startswith("# RRT CLI\n")
+    assert content.startswith("# rrt CLI\n")
     assert "## Global help" in content
     assert "## `rrt branch`" in content
-    assert "Conventional branches for trunk-based publishing" in content
-    assert "Git magic" in content
+    assert "conventional branches" in content
+    assert "rrt git" in content
     assert "### `rrt branch new`" in content
     assert "### `rrt git diff`" in content
     assert "### `rrt ci-version compute`" in content
     assert "### `rrt skill install`" in content
+    assert "RRT CLI" not in content
     assert "\x1b[" not in content
 
 
@@ -70,8 +71,8 @@ def test_render_command_docs_prefers_source_owned_topic_docs_for_branch_and_git(
     branch_rendered = docs.render_command_docs(("branch",), heading_level=2)
     git_rendered = docs.render_command_docs(("git",), heading_level=2)
 
-    assert "Conventional branches for trunk-based publishing" in branch_rendered
-    assert "Git magic" in git_rendered
+    assert "conventional branches" in branch_rendered
+    assert "rrt git" in git_rendered
     assert "branch helpers for repo-release-tools" not in branch_rendered
     assert "Git helpers for repo-release-tools" not in git_rendered
 
@@ -188,9 +189,9 @@ def test_topic_doc_generators_use_source_owned_markdown_constants() -> None:
     docs = _load_generator_module()
 
     assert docs.generate_semantic_branches_markdown() == docs.branch_module.SEMANTIC_BRANCHES_DOC
-    assert docs.generate_git_magic_markdown() == docs.git_helpers.GIT_MAGIC_DOC
-    assert docs.generate_semantic_branches_markdown().startswith("# Conventional branches")
-    assert docs.generate_git_magic_markdown().startswith("# Git magic")
+    assert docs.generate_git_markdown() == docs.git_helpers.GIT_DOC
+    assert docs.generate_semantic_branches_markdown().startswith("# rrt branch")
+    assert docs.generate_git_markdown().startswith("# rrt git")
     assert docs.GENERATED_DOC_TARGETS[0].output_path.name == "rrt-cli.md"
     assert len(docs.GENERATED_DOC_TARGETS) >= 3
     assert "branch" in docs.TOPIC_PAGE_OUTPUTS
@@ -208,6 +209,7 @@ def test_generated_doc_targets_include_anchored_index_block() -> None:
 
     assert len(index_targets) == 1
     assert index_targets[0].anchor_id == "index-topic-links"
+    assert not index_targets[0].render().startswith("---\n")
 
 
 def test_generated_doc_targets_include_anchored_readme_links_block() -> None:
@@ -219,6 +221,108 @@ def test_generated_doc_targets_include_anchored_readme_links_block() -> None:
 
     assert len(readme_targets) == 1
     assert readme_targets[0].anchor_id == "readme-links"
+
+
+def test_generated_command_topics_have_frontmatter_and_command_h1() -> None:
+    docs = _load_generator_module()
+
+    by_name = {target.output_path.name: target for target in docs.GENERATED_DOC_TARGETS}
+
+    doctor = by_name["doctor.md"].render()
+    eol = by_name["eol_check.md"].render()
+    git_doc = by_name["git_cmd.md"].render()
+
+    assert doctor.startswith("---\n")
+    assert 'title: "rrt doctor"' in doctor
+    assert "\n# rrt doctor\n" in doctor
+
+    assert eol.startswith("---\n")
+    assert 'title: "rrt eol"' in eol
+    assert "\n# rrt eol\n" in eol
+
+    assert git_doc.startswith("---\n")
+    assert 'title: "rrt git"' in git_doc
+    assert "\n# rrt git\n" in git_doc
+
+
+def test_validate_generated_pages_returns_no_issues_for_current_registry() -> None:
+    docs = _load_generator_module()
+
+    assert docs.validate_generated_pages() == []
+
+
+def test_extract_first_h1_and_compute_permalink_helpers() -> None:
+    docs = _load_generator_module()
+
+    assert docs._extract_first_h1("# Title\n\nBody\n") == "Title"
+    assert docs._extract_first_h1("No heading here\n") is None
+
+    assert docs._compute_permalink_for_output(Path("docs/index.md")) == "/"
+    assert (
+        docs._compute_permalink_for_output(Path("docs/commands/rrt-cli.md")) == "/commands/rrt-cli/"
+    )
+    assert docs._compute_permalink_for_output(Path("README.md")) == ""
+
+
+def test_wrap_with_frontmatter_falls_back_to_h1_or_stem_for_unknown_slug() -> None:
+    docs = _load_generator_module()
+
+    wrapped_h1 = docs._wrap_with_frontmatter(
+        Path("docs/commands/custom-topic.md"),
+        lambda: "# Custom Topic\n\nBody\n",
+        title_override=None,
+        slug="custom-topic",
+    )
+    rendered_h1 = wrapped_h1()
+    assert 'title: "Custom Topic"' in rendered_h1
+    assert "\n# Custom Topic\n" in rendered_h1
+
+    wrapped_stem = docs._wrap_with_frontmatter(
+        Path("docs/commands/no-heading.md"),
+        lambda: "Body without heading\n",
+        title_override=None,
+        slug="not-registered",
+    )
+    rendered_stem = wrapped_stem()
+    assert 'title: "no-heading"' in rendered_stem
+    assert "\n# no-heading\n" in rendered_stem
+
+
+def test_wrap_with_frontmatter_uses_title_override_registry_when_slug_known() -> None:
+    docs = _load_generator_module()
+
+    wrapped = docs._wrap_with_frontmatter(
+        Path("docs/commands/doctor.md"),
+        lambda: "# Something else\n\nBody\n",
+        title_override=None,
+        slug="doctor",
+    )
+    rendered = wrapped()
+
+    assert 'title: "rrt doctor"' in rendered
+    assert "\n# rrt doctor\n" in rendered
+
+
+def test_validate_generated_pages_reports_each_invalid_render_shape() -> None:
+    docs = _load_generator_module()
+    original_targets = docs.GENERATED_DOC_TARGETS  # ty: ignore[unresolved-attribute]
+    try:
+        docs.GENERATED_DOC_TARGETS = (  # ty: ignore[unresolved-attribute]
+            docs.DocTarget(Path("docs/commands/no-frontmatter.md"), lambda: "# heading\n"),
+            docs.DocTarget(
+                Path("docs/commands/malformed-frontmatter.md"), lambda: "---\nname: x\n# heading\n"
+            ),
+            docs.DocTarget(
+                Path("docs/commands/no-h1.md"), lambda: "---\nname: x\n---\nplain body\n"
+            ),
+        )
+        issues = docs.validate_generated_pages()
+    finally:
+        docs.GENERATED_DOC_TARGETS = original_targets  # ty: ignore[unresolved-attribute]
+
+    assert any("missing YAML frontmatter" in issue for issue in issues)
+    assert any("malformed YAML frontmatter" in issue for issue in issues)
+    assert any("missing top-level H1" in issue for issue in issues)
 
 
 def test_generate_readme_links_markdown_contains_all_doc_entries() -> None:


### PR DESCRIPTION
- Fix source constant H1s: SEMANTIC_BRANCHES_DOC -> '# rrt branch', SKILLS_DOC -> '# rrt skill', TREE_DOC -> '# rrt tree', PRE_COMMIT_DOC -> '# rrt hooks', AGENT_INSTRUCTIONS_DOC -> '# Hook & Action Reference', INDEX_DOC -> '# repo-release-tools'
- Add Jekyll frontmatter (title + permalink) to all static docs: bump, ci-version, config, env, folder, init, toc, index
- Regenerate all docs to pick up new canonical H1s
- Update test assertions for renamed H1s
- Add ty: ignore[unresolved-attribute] suppressions for ModuleType patches

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>