### PR TITLE
feat: enhance documentation and add docstring checks

### DIFF
--- a/.github/instructions/coverage-tests.instructions.md
+++ b/.github/instructions/coverage-tests.instructions.md
@@ -63,6 +63,10 @@ in the matching subdirectory:
 The structure is enforced by `rrt folder check` rules in `pyproject.toml` under
 `[tool.rrt.folders]`.
 
+When adding command-focused support tests (for example, docstring checks or CLI wiring
+helpers), place them under `tests/commands/` instead of the `tests/` root so the
+`tests-root` folder rule stays valid.
+
 ## Do not
 
 - Declare coverage done based on a passing test alone — coverage and correctness

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
       - id: rrt-docstring-check
         name: rrt docstring check
         # Run only the focused test and override pytest addopts to avoid the repo-wide coverage gate.
-        entry: bash -lc 'uv run pytest -q -o addopts="" tests/test_commands_docstrings.py'
+        entry: uv run pytest -q -o addopts= tests/commands/test_commands_docstrings.py
         language: system
         files: '^src/repo_release_tools/commands/'
         always_run: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,6 +44,16 @@ repos:
         pass_filenames: false
         stages: [pre-commit]
 
+      - id: rrt-docstring-check
+        name: rrt docstring check
+        # Run only the focused test and override pytest addopts to avoid the repo-wide coverage gate.
+        entry: bash -lc 'uv run pytest -q -o addopts="" tests/test_commands_docstrings.py'
+        language: system
+        files: '^src/repo_release_tools/commands/'
+        always_run: true
+        pass_filenames: false
+        stages: [pre-commit]
+
       - id: rrt-ci-lint-gate
         name: rrt ci lint gate
         entry: uvx pre-commit run --all-files --show-diff-on-failure

--- a/docs/commands/rrt-cli.md
+++ b/docs/commands/rrt-cli.md
@@ -190,54 +190,49 @@ Examples
 
 Compute and apply CI release versions from ``[tool.rrt]`` config.
 
-### Overview
+### file: ci_version.py
 
-This command mirrors the behavior of the repository's CI version helper, but
-uses the active ``[tool.rrt]`` configuration to discover version targets and
-group defaults.
+#### Overview
 
-It is organized into three subcommands:
+The ``rrt ci-version`` command family centralizes deterministic version
+computation and safe application for CI and release automation. It reads the
+repository's ``[tool.rrt]`` configuration, discovers version targets and group
+defaults, and uses the current CI environment (or explicit CLI overrides) to
+produce machine-friendly version identifiers suitable for downstream CI
+targets and release workflows.
 
-* ``compute`` - print the published version for the current GitHub Actions run
-* ``apply`` - write an explicit version string to all configured CI targets
-* ``sync`` - compute the published version and immediately apply it
+Subcommands:
 
-### Version rules
+- ``compute`` — deterministically compute the version for this run and emit a
+    single raw line for scripting and capture.
+- ``apply`` — update configured targets that declare a ``ci_format``,
+    transforming values when needed (for example converting PEP 440 dev
+    releases into Cargo-compatible prerelease identifiers).
+- ``sync`` — compute then apply the published version in one operation; both
+    ``apply`` and ``sync`` support ``--dry-run`` for safe previews.
 
-The computed CI version depends on the Git ref:
+Version rules (summary):
 
-* ``refs/tags/v*`` - return the tag name with the leading ``v`` removed
-* ``refs/heads/main`` - build a PEP 440 dev release using
-  ``{base}.dev{GITHUB_RUN_ID}{GITHUB_RUN_ATTEMPT:02d}``
-* any other ref - return the base version unchanged
+- Tag builds (``refs/tags/v*``) yield the tag name with the leading ``v``
+    removed.
+- Mainline (`refs/heads/main`) builds produce a PEP 440 dev release using
+    ``{base}.dev{GITHUB_RUN_ID}{GITHUB_RUN_ATTEMPT:02d}``.
+- Other refs return the configured base version unchanged. CLI flags such as
+    ``--ref``, ``--run-id``, or ``--base`` override environment-derived values.
 
-CLI flags such as ``--ref``, ``--ref-name``, ``--run-id``, ``--run-attempt``,
-``--base``, and ``--group`` override the corresponding environment variables
-and config defaults when present.
+Output formats & safety:
 
-### Output formats
+- Supported target formats: ``pep440`` and ``semver_pre`` (the latter maps
+    PEP 440 dev suffixes to SemVer prerelease tokens).
+- The command validates conversions and fails fast on incompatible inputs to
+    avoid writing invalid CI data.
+- ``compute`` is machine-friendly (single-line stdout); ``apply``/``sync`` are
+    human-friendly with progress, dry-run previews, and explicit error messages.
 
-When applying a version, each target uses its configured ``ci_format``:
+Examples::
 
-* ``pep440`` - write the version string unchanged
-* ``semver_pre`` - convert a PEP 440 dev release into a Cargo-compatible
-  prerelease string via ``to_semver()``
-
-Only targets with a valid ``ci_format`` are updated.
-
-### Safety notes
-
-* ``compute`` writes a single machine-readable version line to stdout.
-* ``apply`` and ``sync`` validate the selected config and fail fast on missing
-  or incompatible targets.
-* ``sync`` is equivalent to ``compute`` followed by ``apply`` using the result.
-* ``--dry-run`` previews file updates without modifying the repository.
-
-### Examples
-
-* ``rrt ci-version compute``
-* ``rrt ci-version apply 1.2.3.dev4``
-* ``rrt ci-version sync``
+        rrt ci-version compute
+        rrt ci-version apply 1.2.3.dev42 --group backend --dry-run
 
 ```text
 Usage:  rrt ci-version [OPTIONS] <ci_version_cmd>
@@ -989,7 +984,7 @@ Usage:  rrt docs [OPTIONS] <docs_action>
 Scan source files and extract inline documentation blocks
 across Python, TypeScript/JavaScript, Go, and Rust.
 
-Sub-actions: generate (default), check
+Sub-actions: generate (default), check, publish, inject, suggest
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Arguments
@@ -998,6 +993,7 @@ Arguments
   check        Exit 1 if the docs lockfile is stale.
   publish      Write CLI-reference docs from the live rrt parser.
   inject       Inject shared anchor blocks defined in [tool.rrt.docs.shared_blocks].
+  suggest      Suggest or scaffold rich module docstrings for Python files.
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Options
@@ -1013,7 +1009,8 @@ Examples:
   rrt docs generate                         # explicit mode, md output to stdout
   rrt docs generate --format toml           # write .rrt/docs.lock.toml
   rrt docs generate --format rich           # colourised terminal preview
-  rrt docs check                            # exits 1 if lockfile is stale
+    rrt docs check                            # exits 1 if lockfile is stale
+    rrt docs suggest                          # suggest rich module docstrings
   rrt docs generate --lang python,go        # multi-language extraction
 ```
 
@@ -1087,6 +1084,25 @@ Options
   --check      Fail if any anchor block is stale; do not write.
   --root PATH  Project root directory (default: current directory).
   --dry-run    Print which files would be updated without writing.
+```
+
+### `rrt docs suggest`
+
+```text
+Usage:  rrt docs suggest [OPTIONS] <paths>
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Arguments
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  <paths>        Optional files or directories to scan; defaults to the command modules.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  -h, --help     Show this message and exit.
+  --root PATH    Project root directory (default: current directory).
+  --min-chars N  Minimum docstring length to accept (default: 150).
+  --apply        Write scaffold docstrings back into the target files.
 ```
 
 ## `rrt folder`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -315,6 +315,11 @@ error_days = 0
 mirror_src_tree = true
 docs_dir = "docs"
 src_dir = "src/repo_release_tools"
+
+# Source-link settings used by docs exporters to build file/line URLs.
+source_repo_url = "https://github.com/Anselmoo/repo-release-tools"
+source_ref = "main"
+source_url_template = "{repo_url}/blob/{ref}/{path}#L{line}"
 stubs = [
     "commands/bump",
     "commands/ci_version",
@@ -323,6 +328,7 @@ stubs = [
     "commands/init",
 ]
 
+# Shared-block anchor id used by injected doc footer content.
 [[tool.rrt.docs.shared_blocks]]
 anchor_id = "doc-footer"
 content = """

--- a/src/repo_release_tools/commands/branch.py
+++ b/src/repo_release_tools/commands/branch.py
@@ -1,4 +1,27 @@
-"""Branch helpers for repo-release-tools."""
+"""Branch command helpers and utilities.
+
+Overview
+
+The `rrt branch` command family provides helpers for creating and validating
+semantic branch names that align with the repository's conventional-commit
+policy. It assists in creating feature/fix branches using the configured
+types (for example `feat/`, `fix/`, `chore/`), enforcing naming rules, and
+emitting helpful guidance to contributors and automation.
+
+Primary behaviors:
+
+- Validate branch names against the project's allowed prefixes and slug rules.
+- Create new branches with the canonical `<type>/<kebab-slug>` form.
+- Provide suggestions and error messages when a branch name does not conform.
+
+Examples:
+    rrt branch new feat/add-widget
+    rrt branch validate fix/my-bugfix
+
+This module implements the command handlers and helpers used by the
+top-level CLI surface; maintain a clear, multi-line module docstring so that
+automated checks and documentation generators can rely on it.
+"""
 
 from __future__ import annotations
 

--- a/src/repo_release_tools/commands/ci_version.py
+++ b/src/repo_release_tools/commands/ci_version.py
@@ -1,53 +1,49 @@
 """Compute and apply CI release versions from ``[tool.rrt]`` config.
 
+# file: ci_version.py
+
 ## Overview
 
-This command mirrors the behavior of the repository's CI version helper, but
-uses the active ``[tool.rrt]`` configuration to discover version targets and
-group defaults.
+The ``rrt ci-version`` command family centralizes deterministic version
+computation and safe application for CI and release automation. It reads the
+repository's ``[tool.rrt]`` configuration, discovers version targets and group
+defaults, and uses the current CI environment (or explicit CLI overrides) to
+produce machine-friendly version identifiers suitable for downstream CI
+targets and release workflows.
 
-It is organized into three subcommands:
+Subcommands:
 
-* ``compute`` - print the published version for the current GitHub Actions run
-* ``apply`` - write an explicit version string to all configured CI targets
-* ``sync`` - compute the published version and immediately apply it
+- ``compute`` — deterministically compute the version for this run and emit a
+    single raw line for scripting and capture.
+- ``apply`` — update configured targets that declare a ``ci_format``,
+    transforming values when needed (for example converting PEP 440 dev
+    releases into Cargo-compatible prerelease identifiers).
+- ``sync`` — compute then apply the published version in one operation; both
+    ``apply`` and ``sync`` support ``--dry-run`` for safe previews.
 
-## Version rules
+Version rules (summary):
 
-The computed CI version depends on the Git ref:
+- Tag builds (``refs/tags/v*``) yield the tag name with the leading ``v``
+    removed.
+- Mainline (`refs/heads/main`) builds produce a PEP 440 dev release using
+    ``{base}.dev{GITHUB_RUN_ID}{GITHUB_RUN_ATTEMPT:02d}``.
+- Other refs return the configured base version unchanged. CLI flags such as
+    ``--ref``, ``--run-id``, or ``--base`` override environment-derived values.
 
-* ``refs/tags/v*`` - return the tag name with the leading ``v`` removed
-* ``refs/heads/main`` - build a PEP 440 dev release using
-  ``{base}.dev{GITHUB_RUN_ID}{GITHUB_RUN_ATTEMPT:02d}``
-* any other ref - return the base version unchanged
+Output formats & safety:
 
-CLI flags such as ``--ref``, ``--ref-name``, ``--run-id``, ``--run-attempt``,
-``--base``, and ``--group`` override the corresponding environment variables
-and config defaults when present.
+- Supported target formats: ``pep440`` and ``semver_pre`` (the latter maps
+    PEP 440 dev suffixes to SemVer prerelease tokens).
+- The command validates conversions and fails fast on incompatible inputs to
+    avoid writing invalid CI data.
+- ``compute`` is machine-friendly (single-line stdout); ``apply``/``sync`` are
+    human-friendly with progress, dry-run previews, and explicit error messages.
 
-## Output formats
+Examples::
 
-When applying a version, each target uses its configured ``ci_format``:
+        rrt ci-version compute
+        rrt ci-version apply 1.2.3.dev42 --group backend --dry-run
 
-* ``pep440`` - write the version string unchanged
-* ``semver_pre`` - convert a PEP 440 dev release into a Cargo-compatible
-  prerelease string via ``to_semver()``
-
-Only targets with a valid ``ci_format`` are updated.
-
-## Safety notes
-
-* ``compute`` writes a single machine-readable version line to stdout.
-* ``apply`` and ``sync`` validate the selected config and fail fast on missing
-  or incompatible targets.
-* ``sync`` is equivalent to ``compute`` followed by ``apply`` using the result.
-* ``--dry-run`` previews file updates without modifying the repository.
-
-## Examples
-
-* ``rrt ci-version compute``
-* ``rrt ci-version apply 1.2.3.dev4``
-* ``rrt ci-version sync``
 """
 
 from __future__ import annotations

--- a/src/repo_release_tools/commands/docs_cmd.py
+++ b/src/repo_release_tools/commands/docs_cmd.py
@@ -122,12 +122,13 @@ def _build_docs_lock_sources(entries: list[DocEntry]) -> list[dict[str, object]]
 
     sources: list[dict[str, object]] = []
     for src_file, src_entries in by_file.items():
-        combined = "".join(e.hash for e in sorted(src_entries, key=lambda e: e.name))
+        sorted_entries = sorted(src_entries, key=lambda e: e.name)
+        combined = "".join(e.hash for e in sorted_entries)
         sources.append(
             {
                 "source_file": src_file,
                 "hash": hash_content(combined),
-                "symbols": [e.name for e in src_entries],
+                "symbols": [e.name for e in sorted_entries],
                 "lang": src_entries[0].lang,
             }
         )

--- a/src/repo_release_tools/commands/docs_cmd.py
+++ b/src/repo_release_tools/commands/docs_cmd.py
@@ -17,6 +17,7 @@ rrt docs generate
 rrt docs generate --format md
 rrt docs generate --format json
 rrt docs generate --format toml   # writes .rrt/docs.lock.toml
+rrt docs suggest
 rrt docs generate --lang python,go
 rrt docs generate --dry-run
 ```
@@ -71,6 +72,7 @@ import argparse
 import sys
 from pathlib import Path
 
+from repo_release_tools.commands.docs_suggest import cmd_docs_suggest
 from repo_release_tools.config import (
     DocsConfig,
     is_missing_tool_rrt_error,
@@ -108,6 +110,30 @@ def _config_for_cwd(cwd: Path) -> DocsConfig:
     return cfg.docs if cfg.docs is not None else DocsConfig()
 
 
+def _build_docs_lock_sources(entries: list[DocEntry]) -> list[dict[str, object]]:
+    """Group extracted doc entries into the lockfile source schema."""
+    from collections import defaultdict
+
+    from repo_release_tools.state import hash_content
+
+    by_file: dict[str, list[DocEntry]] = defaultdict(list)
+    for entry in entries:
+        by_file[entry.source_file].append(entry)
+
+    sources: list[dict[str, object]] = []
+    for src_file, src_entries in by_file.items():
+        combined = "".join(e.hash for e in sorted(src_entries, key=lambda e: e.name))
+        sources.append(
+            {
+                "source_file": src_file,
+                "hash": hash_content(combined),
+                "symbols": [e.name for e in src_entries],
+                "lang": src_entries[0].lang,
+            }
+        )
+    return sources
+
+
 # ---------------------------------------------------------------------------
 # generate sub-action
 # ---------------------------------------------------------------------------
@@ -125,8 +151,7 @@ def _cmd_generate(args: argparse.Namespace) -> int:
         raw_langs = [l.strip().lower() for l in args.lang.split(",") if l.strip()]  # noqa: E741
         from repo_release_tools.config import _VALID_LANGUAGES
 
-        invalid = [ln for ln in raw_langs if ln not in _VALID_LANGUAGES]
-        if invalid:
+        if invalid := [ln for ln in raw_langs if ln not in _VALID_LANGUAGES]:
             p.line(
                 f"Unsupported languages: {invalid}. Supported: {list(_VALID_LANGUAGES)}",
                 ok=False,
@@ -151,25 +176,7 @@ def _cmd_generate(args: argparse.Namespace) -> int:
 
     if args.dry_run and fmt == "toml":
         # In dry-run mode: build lock but don't write
-        from collections import defaultdict
-
-        from repo_release_tools.state import hash_content
-
-        by_file: dict[str, list[DocEntry]] = defaultdict(list)
-        for entry in entries:
-            by_file[entry.source_file].append(entry)
-
-        sources = []
-        for src_file, src_entries in by_file.items():
-            combined = "".join(e.hash for e in sorted(src_entries, key=lambda e: e.name))
-            sources.append(
-                {
-                    "source_file": src_file,
-                    "hash": hash_content(combined),
-                    "symbols": [e.name for e in src_entries],
-                    "lang": src_entries[0].lang,
-                }
-            )
+        sources = _build_docs_lock_sources(entries)
         build_lock(sources)  # validate structure; don't write
         lock_path = docs_lock_path(cwd, config.lock_file)
         p.would_write(str(lock_path), "docs lockfile (dry-run, not written)")
@@ -209,25 +216,7 @@ def _cmd_check(args: argparse.Namespace) -> int:
 
     entries = extract_docs_from_dir(cwd, config)
 
-    from collections import defaultdict
-
-    from repo_release_tools.state import hash_content
-
-    by_file: dict[str, list[DocEntry]] = defaultdict(list)
-    for entry in entries:
-        by_file[entry.source_file].append(entry)
-
-    sources = []
-    for src_file, src_entries in by_file.items():
-        combined = "".join(e.hash for e in sorted(src_entries, key=lambda e: e.name))
-        sources.append(
-            {
-                "source_file": src_file,
-                "hash": hash_content(combined),
-                "symbols": [e.name for e in src_entries],
-                "lang": src_entries[0].lang,
-            }
-        )
+    sources = _build_docs_lock_sources(entries)
 
     is_current, messages = lock_is_current(lock_path, sources)
     if is_current:
@@ -365,6 +354,16 @@ def _cmd_inject(args: argparse.Namespace) -> int:
 
 
 # ---------------------------------------------------------------------------
+# Suggest docstrings (scaffold + lint)
+# ---------------------------------------------------------------------------
+
+
+def _cmd_suggest(args: argparse.Namespace) -> int:
+    """Suggest or apply rich module docstrings for command modules."""
+    return cmd_docs_suggest(args)
+
+
+# ---------------------------------------------------------------------------
 # Dispatcher
 # ---------------------------------------------------------------------------
 
@@ -380,6 +379,8 @@ def cmd_docs(args: argparse.Namespace) -> int:
         return _cmd_publish(args)
     if sub == "inject":
         return _cmd_inject(args)
+    if sub == "suggest":
+        return _cmd_suggest(args)
     p = DryRunPrinter(False)
     p.line(f"Unknown docs action: {sub!r}", ok=False, stream=sys.stderr)
     return 1
@@ -396,7 +397,8 @@ Examples:
   rrt docs generate                         # explicit mode, md output to stdout
   rrt docs generate --format toml           # write .rrt/docs.lock.toml
   rrt docs generate --format rich           # colourised terminal preview
-  rrt docs check                            # exits 1 if lockfile is stale
+    rrt docs check                            # exits 1 if lockfile is stale
+    rrt docs suggest                          # suggest rich module docstrings
   rrt docs generate --lang python,go        # multi-language extraction
 """
 
@@ -409,7 +411,7 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
         description=(
             "Scan source files and extract inline documentation blocks\n"
             "across Python, TypeScript/JavaScript, Go, and Rust.\n\n"
-            "Sub-actions: generate (default), check"
+            "Sub-actions: generate (default), check, publish, inject, suggest"
         ),
         epilog=DOCS_EPILOG,
     )
@@ -529,3 +531,35 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
         help="Print which files would be updated without writing.",
     )
     inj_p.set_defaults(handler=cmd_docs)
+
+    # ── suggest ───────────────────────────────────────────────────────────
+    sug_p = sub.add_parser(
+        "suggest",
+        help="Suggest or scaffold rich module docstrings for Python files.",
+    )
+    sug_p.add_argument(
+        "paths",
+        nargs="*",
+        default=(),
+        help="Optional files or directories to scan; defaults to the command modules.",
+    )
+    sug_p.add_argument(
+        "--root",
+        default=".",
+        metavar="PATH",
+        help="Project root directory (default: current directory).",
+    )
+    sug_p.add_argument(
+        "--min-chars",
+        type=int,
+        default=150,
+        metavar="N",
+        help="Minimum docstring length to accept (default: 150).",
+    )
+    sug_p.add_argument(
+        "--apply",
+        action="store_true",
+        default=False,
+        help="Write scaffold docstrings back into the target files.",
+    )
+    sug_p.set_defaults(handler=cmd_docs)

--- a/src/repo_release_tools/commands/docs_suggest.py
+++ b/src/repo_release_tools/commands/docs_suggest.py
@@ -1,0 +1,181 @@
+"""Suggest or scaffold rich module docstrings for command modules.
+
+`rrt docs suggest` scans Python command modules for missing or thin module
+docstrings and emits a Markdown-rich scaffold that contributors can adapt in
+place. The command is intentionally narrow: it only targets the command module
+tree by default, focuses on human-readable module documentation, and supports
+an ``--apply`` mode for writing the scaffold back to disk when a file needs a
+full replacement.
+
+## Responsibilities
+
+- detect missing or underspecified top-level module docstrings
+- generate a consistent scaffold with overview, responsibilities, and examples
+- apply the scaffold in place when the caller requests it
+
+## Usage
+
+```bash
+uv run rrt docs suggest
+uv run rrt docs suggest --apply src/repo_release_tools/commands/branch.py
+```
+
+The implementation lives under ``src/`` so the feature stays aligned with the
+rest of the CLI instead of depending on a standalone helper script.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from textwrap import dedent
+from typing import Iterable
+
+from repo_release_tools.ui import DryRunPrinter
+
+DEFAULT_MIN_CHARS = 150
+DEFAULT_ROOT = Path("src") / "repo_release_tools" / "commands"
+EXEMPT_FILES = {"__init__.py", "__main__.py"}
+
+
+@dataclass(frozen=True)
+class _DocstringFinding:
+    path: Path
+    reason: str
+    scaffold: str
+
+
+def _iter_targets(paths: Iterable[Path]) -> list[Path]:
+    """Return the Python files to inspect."""
+    targets: list[Path] = []
+    for path in paths:
+        if path.is_dir():
+            targets.extend(sorted(path.rglob("*.py")))
+        elif path.is_file() and path.suffix == ".py":
+            targets.append(path)
+    return targets
+
+
+def _command_slug(path: Path) -> str:
+    """Convert a module path into a command slug."""
+    stem = path.stem
+    if stem.endswith("_cmd"):
+        stem = stem[:-4]
+    return stem.replace("_", "-")
+
+
+def _read_module_docstring(path: Path) -> str | None:
+    """Return the module docstring, or ``None`` when the file cannot be parsed."""
+    try:
+        module = ast.parse(path.read_text(encoding="utf-8"))
+    except SyntaxError:
+        return None
+    return ast.get_docstring(module)
+
+
+def build_scaffold(path: Path) -> str:
+    """Create a Markdown-rich docstring scaffold for *path*."""
+    slug = _command_slug(path)
+    title = f"`rrt {slug}` — rich command module docstring scaffold"
+    body = dedent(
+        f"""
+        {title}
+
+        ## Overview
+
+        Describe what `rrt {slug}` does, which files or repositories it reads,
+        and what side effects it may have. Keep the explanation specific to the
+        module and useful to both contributors and automation.
+
+        ## Responsibilities
+
+        - explain the command family and any notable subcommands
+        - note the main inputs, outputs, and safety constraints
+        - mention any config keys or environment variables that affect behavior
+
+        ## Examples
+
+        ```bash
+        rrt {slug} --help
+        ```
+
+        Replace this scaffold with a concise, accurate, multi-line module
+        docstring that uses Markdown consistently.
+        """
+    ).strip()
+    return f'"""{body}\n"""\n'
+
+
+def _insert_or_replace_docstring(path: Path, scaffold: str) -> None:
+    """Insert or replace the top-level module docstring in *path*."""
+    source = path.read_text(encoding="utf-8")
+    module = ast.parse(source)
+    lines = source.splitlines(keepends=True)
+
+    if module.body and isinstance(module.body[0], ast.Expr):
+        node = module.body[0]
+        if isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
+            start = node.lineno - 1
+            end = node.end_lineno or node.lineno
+            lines[start:end] = [scaffold]
+            path.write_text("".join(lines), encoding="utf-8")
+            return
+
+    insert_at = 1 if lines and lines[0].startswith("#!") else 0
+    while (
+        insert_at < len(lines) and lines[insert_at].startswith("#") and "coding" in lines[insert_at]
+    ):
+        insert_at += 1
+    lines[insert_at:insert_at] = [scaffold, "\n"]
+    path.write_text("".join(lines), encoding="utf-8")
+
+
+def scan(paths: Iterable[Path], *, min_chars: int = DEFAULT_MIN_CHARS) -> list[_DocstringFinding]:
+    """Find files whose module docstrings should be expanded."""
+    findings: list[_DocstringFinding] = []
+    for path in _iter_targets(paths):
+        if path.name in EXEMPT_FILES:
+            continue
+
+        docstring = _read_module_docstring(path)
+        doc = docstring.strip() if docstring else ""
+        needs_help = not docstring or "\n" not in doc or len(doc) < min_chars
+        if not needs_help:
+            continue
+
+        reason = "docstring is too short or too flat" if docstring else "missing docstring"
+        findings.append(_DocstringFinding(path=path, reason=reason, scaffold=build_scaffold(path)))
+    return findings
+
+
+def cmd_docs_suggest(args: argparse.Namespace) -> int:
+    """Suggest or apply rich module docstrings for command modules."""
+    root = Path(getattr(args, "root", ".")).resolve()
+    raw_paths = list(getattr(args, "paths", ()) or ())
+    paths = [Path(p).resolve() for p in raw_paths] if raw_paths else [root / DEFAULT_ROOT]
+    min_chars = int(getattr(args, "min_chars", DEFAULT_MIN_CHARS))
+    apply = bool(getattr(args, "apply", False))
+
+    p = DryRunPrinter(dry_run=False)
+    findings = scan(paths, min_chars=min_chars)
+
+    if not findings:
+        p.ok("No docstring scaffolds needed.")
+        return 0
+
+    for finding in findings:
+        try:
+            label = finding.path.relative_to(root)
+        except ValueError:
+            label = finding.path
+        p.section(str(label))
+        p.line(finding.reason, ok=False)
+        sys.stdout.write(f"{finding.scaffold}\n")
+        if apply:
+            _insert_or_replace_docstring(finding.path, finding.scaffold)
+            p.ok(f"Applied scaffold to {finding.path}")
+
+    return 0

--- a/src/repo_release_tools/commands/docs_suggest.py
+++ b/src/repo_release_tools/commands/docs_suggest.py
@@ -59,6 +59,13 @@ def _iter_targets(paths: Iterable[Path]) -> list[Path]:
     return targets
 
 
+def _resolve_target_path(path: Path, root: Path) -> Path:
+    """Resolve a caller-supplied target path against *root* when needed."""
+    if path.is_absolute():
+        return path.resolve()
+    return (root / path).resolve()
+
+
 def _command_slug(path: Path) -> str:
     """Convert a module path into a command slug."""
     stem = path.stem
@@ -109,10 +116,17 @@ def build_scaffold(path: Path) -> str:
     return f'"""{body}\n"""\n'
 
 
-def _insert_or_replace_docstring(path: Path, scaffold: str) -> None:
+def _insert_or_replace_docstring(path: Path, scaffold: str) -> bool:
     """Insert or replace the top-level module docstring in *path*."""
     source = path.read_text(encoding="utf-8")
-    module = ast.parse(source)
+    try:
+        module = ast.parse(source)
+    except SyntaxError as exc:
+        sys.stderr.write(
+            f"Skipping {path}: could not apply docstring scaffold because the file "
+            f"failed to parse ({exc.msg}).\n"
+        )
+        return False
     lines = source.splitlines(keepends=True)
 
     if module.body and isinstance(module.body[0], ast.Expr):
@@ -122,7 +136,7 @@ def _insert_or_replace_docstring(path: Path, scaffold: str) -> None:
             end = node.end_lineno or node.lineno
             lines[start:end] = [scaffold]
             path.write_text("".join(lines), encoding="utf-8")
-            return
+            return True
 
     insert_at = 1 if lines and lines[0].startswith("#!") else 0
     while (
@@ -131,6 +145,7 @@ def _insert_or_replace_docstring(path: Path, scaffold: str) -> None:
         insert_at += 1
     lines[insert_at:insert_at] = [scaffold, "\n"]
     path.write_text("".join(lines), encoding="utf-8")
+    return True
 
 
 def scan(paths: Iterable[Path], *, min_chars: int = DEFAULT_MIN_CHARS) -> list[_DocstringFinding]:
@@ -155,7 +170,11 @@ def cmd_docs_suggest(args: argparse.Namespace) -> int:
     """Suggest or apply rich module docstrings for command modules."""
     root = Path(getattr(args, "root", ".")).resolve()
     raw_paths = list(getattr(args, "paths", ()) or ())
-    paths = [Path(p).resolve() for p in raw_paths] if raw_paths else [root / DEFAULT_ROOT]
+    paths = (
+        [_resolve_target_path(Path(p), root) for p in raw_paths]
+        if raw_paths
+        else [root / DEFAULT_ROOT]
+    )
     min_chars = int(getattr(args, "min_chars", DEFAULT_MIN_CHARS))
     apply = bool(getattr(args, "apply", False))
 
@@ -174,8 +193,7 @@ def cmd_docs_suggest(args: argparse.Namespace) -> int:
         p.section(str(label))
         p.line(finding.reason, ok=False)
         sys.stdout.write(f"{finding.scaffold}\n")
-        if apply:
-            _insert_or_replace_docstring(finding.path, finding.scaffold)
+        if apply and _insert_or_replace_docstring(finding.path, finding.scaffold):
             p.ok(f"Applied scaffold to {finding.path}")
 
     return 0

--- a/src/repo_release_tools/commands/folder.py
+++ b/src/repo_release_tools/commands/folder.py
@@ -1,4 +1,27 @@
-"""Folder supervision and scaffolding command family."""
+"""Folder supervision and scaffolding command family.
+
+Overview
+
+`rrt folder` validates, scaffolds, and infers folder structures for a
+project. It supports three primary flows:
+
+- `check` — validate an existing tree against configured folder policies or
+    built-in templates and report violations.
+- `scaffold` — create missing files and directories from named templates,
+    optionally running in `--dry-run` mode to preview changes.
+- `design` — capture an existing directory tree and emit a reusable
+    template description (TOML) that can be applied elsewhere.
+
+Usage examples:
+
+    rrt folder check --template python-package
+    rrt folder scaffold --template cargo-inspired --dry-run
+    rrt folder design --name captured-template --root src
+
+This module implements the command handlers exposed via the top-level
+`rrt folder` command and is intentionally documented so contributors and
+automation can rely on a clear, multi-line module-level docstring.
+"""
 
 from __future__ import annotations
 

--- a/src/repo_release_tools/config/docs_config.py
+++ b/src/repo_release_tools/config/docs_config.py
@@ -120,6 +120,9 @@ def _load_docs_config(raw: object, *, root: Path | None = None) -> DocsConfig | 
         languages=_load_docs_languages(d),
         lock_file=_load_docs_lock_file(d),
         formats=_load_docs_formats(d),
+        source_repo_url=_load_optional_docs_string(d, "source_repo_url"),
+        source_ref=_load_optional_docs_string(d, "source_ref"),
+        source_url_template=_load_optional_docs_string(d, "source_url_template"),
         shared_blocks=_load_shared_blocks(d, root=root),
     )
 
@@ -179,6 +182,17 @@ def _load_docs_formats(d: dict[str, object]) -> tuple[str, ...]:
             f"Supported: {list(_VALID_FORMATS)}"
         )
     return tuple(fmts)
+
+
+def _load_optional_docs_string(d: dict[str, object], key: str) -> str | None:
+    raw = d.get(key)
+    if raw is None:
+        return None
+    if not isinstance(raw, str):
+        raise ValueError(f"tool.rrt.docs.{key} must be a string when provided")
+    if not (value := raw.strip()):
+        raise ValueError(f"tool.rrt.docs.{key} must not be empty when provided")
+    return value
 
 
 def _load_shared_blocks(

--- a/src/repo_release_tools/config/model.py
+++ b/src/repo_release_tools/config/model.py
@@ -339,6 +339,9 @@ class DocsConfig:
     languages: tuple[str, ...] = ("python",)
     lock_file: str = ".rrt/docs.lock.toml"
     formats: tuple[str, ...] = ("md",)
+    source_repo_url: str | None = None
+    source_ref: str | None = None
+    source_url_template: str | None = None
     shared_blocks: tuple[SharedBlock, ...] = ()
 
 

--- a/src/repo_release_tools/docs/formats.py
+++ b/src/repo_release_tools/docs/formats.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from typing import TYPE_CHECKING
+from urllib.parse import quote
 
 if TYPE_CHECKING:
     from repo_release_tools.config.core import DocsConfig
@@ -44,11 +45,9 @@ def _render_structured_txt(content: str) -> str:
             if parts and parts[-1] != "":
                 parts.append("")
             if level == 1:
-                parts.append(line.text.upper())
-                parts.append("=" * len(line.text))
+                parts.extend([line.text.upper(), "=" * len(line.text)])
             elif level == 2:
-                parts.append(line.text)
-                parts.append("-" * len(line.text))
+                parts.extend([line.text, "-" * len(line.text)])
             else:
                 indent = "  " * max(level - 3, 0)
                 parts.append(f"{indent}* {line.text}")
@@ -88,6 +87,37 @@ def _render_structured_rich(content: str) -> str:
     return "\n".join(parts).strip()
 
 
+def _source_path(entry: "DocEntry") -> str:
+    return entry.source_file.replace("\\", "/")
+
+
+def _source_reference(entry: "DocEntry") -> str:
+    return f"{entry.source_file}:{entry.line}"
+
+
+def _source_url(entry: "DocEntry", config: "DocsConfig") -> str | None:
+    repo_url = getattr(config, "source_repo_url", None)
+    template = getattr(config, "source_url_template", None)
+    ref = getattr(config, "source_ref", None) or "main"
+    if not repo_url and not template:
+        return None
+
+    path = quote(_source_path(entry), safe="/-._~")
+    mapping = {
+        "repo_url": repo_url or "",
+        "ref": ref,
+        "path": path,
+        "source_file": path,
+        "line": entry.line,
+        "name": entry.name,
+        "lang": entry.lang,
+    }
+    if template:
+        return template.format(**mapping)
+    repo_base = repo_url.rstrip("/") if repo_url else ""
+    return f"{repo_base}/blob/{ref}/{path}#L{entry.line}"
+
+
 # ---------------------------------------------------------------------------
 # Markdown
 # ---------------------------------------------------------------------------
@@ -98,9 +128,13 @@ def render_md(entries: list["DocEntry"], config: "DocsConfig") -> str:
     parts: list[str] = ["# Documentation\n"]
     for entry in entries:
         anchor = entry.name.lower().replace(" ", "-")
-        parts.append(f"\n## {entry.name} {{#{anchor}}}\n")
-        parts.append(f"*Source: `{entry.source_file}` line {entry.line} · lang: {entry.lang}*\n")
-        parts.append(f"\n{entry.content}\n")
+        source_url = _source_url(entry, config)
+        source_reference = _source_reference(entry)
+        if source_url:
+            source_line = f"*Source: [{source_reference}]({source_url}) · lang: {entry.lang}*\n"
+        else:
+            source_line = f"*Source: `{source_reference}` · lang: {entry.lang}*\n"
+        parts.extend([f"\n## {entry.name} {{#{anchor}}}\n", source_line, f"\n{entry.content}\n"])
     return "\n".join(parts)
 
 
@@ -137,11 +171,18 @@ def render_txt(entries: list["DocEntry"], config: "DocsConfig") -> str:
     """Render entries as plain text."""
     parts: list[str] = []
     for entry in entries:
-        parts.append(f"=== {entry.name} ({entry.lang}) ===")
-        parts.append(f"Source: {entry.source_file}:{entry.line}")
-        parts.append("")
-        parts.append(_render_structured_txt(entry.content))
-        parts.append("")
+        source_url = _source_url(entry, config)
+        source_reference = _source_reference(entry)
+        source_line = f"Source: {source_reference}" + (f" — {source_url}" if source_url else "")
+        parts.extend(
+            [
+                f"=== {entry.name} ({entry.lang}) ===",
+                source_line,
+                "",
+                _render_structured_txt(entry.content),
+                "",
+            ]
+        )
     return "\n".join(parts)
 
 
@@ -156,14 +197,14 @@ def render_rich(entries: list["DocEntry"], config: "DocsConfig") -> str:
 
     parts: list[str] = []
     for entry in entries:
-        parts.append(bold(f"  {entry.name}") + f"  [{entry.lang}]")
-        parts.append(subtle(f"  {entry.source_file}:{entry.line}"))
-        parts.append("")
+        source_url = _source_url(entry, config)
+        source_reference = _source_reference(entry)
+        source_line = subtle(f"  {source_reference}" + (f" — {source_url}" if source_url else ""))
+        parts.extend([f"{bold(f'  {entry.name}')}  [{entry.lang}]", source_line, ""])
         if has_markdown_headings(entry.content):
             parts.extend(_render_structured_rich(entry.content).splitlines())
         else:
-            for line in entry.content.splitlines():
-                parts.append(f"  {info(line)}")
+            parts.extend(f"  {info(line)}" for line in entry.content.splitlines())
         parts.append("")
     return "\n".join(parts)
 
@@ -175,7 +216,13 @@ def render_rich(entries: list["DocEntry"], config: "DocsConfig") -> str:
 
 def render_json(entries: list["DocEntry"], config: "DocsConfig") -> str:
     """Render entries as a JSON array."""
-    return json.dumps([e.to_dict() for e in entries], indent=2)
+    payload = []
+    for entry in entries:
+        item = entry.to_dict()
+        if source_url := _source_url(entry, config):
+            item["source_url"] = source_url
+        payload.append(item)
+    return json.dumps(payload, indent=2)
 
 
 # ---------------------------------------------------------------------------

--- a/src/repo_release_tools/docs/formats.py
+++ b/src/repo_release_tools/docs/formats.py
@@ -92,7 +92,7 @@ def _source_path(entry: "DocEntry") -> str:
 
 
 def _source_reference(entry: "DocEntry") -> str:
-    return f"{entry.source_file}:{entry.line}"
+    return f"{_source_path(entry)}:{entry.line}"
 
 
 def _source_url(entry: "DocEntry", config: "DocsConfig") -> str | None:
@@ -113,7 +113,14 @@ def _source_url(entry: "DocEntry", config: "DocsConfig") -> str | None:
         "lang": entry.lang,
     }
     if template:
-        return template.format(**mapping)
+        placeholders = ", ".join(sorted(mapping))
+        try:
+            return template.format(**mapping)
+        except (KeyError, ValueError) as exc:
+            raise ValueError(
+                "Invalid source_url_template "
+                f"{template!r}: {exc}. Supported placeholders: {placeholders}."
+            ) from exc
     repo_base = repo_url.rstrip("/") if repo_url else ""
     return f"{repo_base}/blob/{ref}/{path}#L{entry.line}"
 

--- a/tests/commands/test_commands_docstrings.py
+++ b/tests/commands/test_commands_docstrings.py
@@ -20,18 +20,23 @@ from pathlib import Path
 import pytest
 
 MIN_DEFAULT = 150
-MIN_CHARS = int(os.getenv("RRT_DOCSTRING_MIN_CHARS", str(MIN_DEFAULT)))
 
-ROOT = Path(__file__).resolve().parents[1]
+ROOT = Path(__file__).resolve().parents[2]
 COMMANDS_DIR = ROOT / "src" / "repo_release_tools" / "commands"
 
 
+def _load_min_chars() -> int:
+    raw = os.getenv("RRT_DOCSTRING_MIN_CHARS")
+    if raw is None:
+        return MIN_DEFAULT
+    try:
+        return int(raw)
+    except ValueError:
+        pytest.fail(f"RRT_DOCSTRING_MIN_CHARS must be an integer; got {raw!r}")
+
+
 def _should_exempt(path: Path, text: str) -> bool:
-    if path.name in ("__init__.py", "__main__.py"):
-        return True
-    if "rrt:docs-exempt" in text:
-        return True
-    return False
+    return path.name in ("__init__.py", "__main__.py") or "rrt:docs-exempt" in text
 
 
 def test_command_modules_have_rich_module_docstrings() -> None:
@@ -39,6 +44,7 @@ def test_command_modules_have_rich_module_docstrings() -> None:
     if not COMMANDS_DIR.exists():
         pytest.skip("commands directory not present")
 
+    min_chars = _load_min_chars()
     offenses: list[str] = []
     for py in sorted(COMMANDS_DIR.glob("*.py")):
         text = py.read_text(encoding="utf-8")
@@ -61,8 +67,8 @@ def test_command_modules_have_rich_module_docstrings() -> None:
             offenses.append(f"{py}: module docstring is single-line")
             continue
 
-        if len(doc_stripped) < MIN_CHARS:
-            offenses.append(f"{py}: module docstring too short ({len(doc_stripped)} < {MIN_CHARS})")
+        if len(doc_stripped) < min_chars:
+            offenses.append(f"{py}: module docstring too short ({len(doc_stripped)} < {min_chars})")
 
     if offenses:
         errors = "\n".join(offenses)

--- a/tests/commands/test_docs_cmd.py
+++ b/tests/commands/test_docs_cmd.py
@@ -10,14 +10,18 @@ import pytest
 
 from repo_release_tools.commands.docs_cmd import (
     SOURCE_OWNED_TOPIC_DOCS,
+    _build_docs_lock_sources,
     _cmd_check,
     _cmd_generate,
     _cmd_inject,
     _cmd_publish,
+    _cmd_suggest,
     _config_for_cwd,
     cmd_docs,
 )
 from repo_release_tools.config import DocsConfig, SharedBlock
+from repo_release_tools.docs.extractor import DocEntry
+from repo_release_tools.state import hash_content
 
 
 @pytest.fixture
@@ -210,6 +214,34 @@ class TestCmdGenerate:
         )
         result = _cmd_generate(args)
         assert result == 0
+
+
+class TestDocsLockSources:
+    """Tests for _build_docs_lock_sources."""
+
+    def test_build_docs_lock_sources_sorts_symbols(self) -> None:
+        entries = [
+            DocEntry(
+                name="zeta",
+                lang="python",
+                content="z",
+                source_file="src/module.py",
+                line=10,
+                hash=hash_content("z"),
+            ),
+            DocEntry(
+                name="alpha",
+                lang="python",
+                content="a",
+                source_file="src/module.py",
+                line=1,
+                hash=hash_content("a"),
+            ),
+        ]
+
+        sources = _build_docs_lock_sources(entries)
+
+        assert sources[0]["symbols"] == ["alpha", "zeta"]
 
 
 class TestCmdCheck:
@@ -415,6 +447,21 @@ class TestCmdDocs:
         args = argparse.Namespace(root=str(temp_repo), docs_action="suggest")
 
         assert cmd_docs(args) == 9
+
+
+class TestCmdSuggest:
+    """Test _cmd_suggest wrapper."""
+
+    def test_cmd_suggest_forwards_to_docs_suggest(
+        self, monkeypatch: pytest.MonkeyPatch, temp_repo: Path
+    ) -> None:
+        monkeypatch.setattr(
+            "repo_release_tools.commands.docs_cmd.cmd_docs_suggest", lambda args: 12
+        )
+
+        args = argparse.Namespace(root=str(temp_repo))
+
+        assert _cmd_suggest(args) == 12
 
 
 class TestCmdPublish:

--- a/tests/commands/test_docs_cmd.py
+++ b/tests/commands/test_docs_cmd.py
@@ -406,6 +406,16 @@ class TestCmdDocs:
 
         assert cmd_docs(args) == 8
 
+    def test_cmd_docs_dispatches_suggest(
+        self, monkeypatch: pytest.MonkeyPatch, temp_repo: Path
+    ) -> None:
+        """Should dispatch suggest to the suggest helper."""
+        monkeypatch.setattr("repo_release_tools.commands.docs_cmd._cmd_suggest", lambda args: 9)
+
+        args = argparse.Namespace(root=str(temp_repo), docs_action="suggest")
+
+        assert cmd_docs(args) == 9
+
 
 class TestCmdPublish:
     """Test _cmd_publish sub-action."""

--- a/tests/commands/test_docs_suggest.py
+++ b/tests/commands/test_docs_suggest.py
@@ -1,0 +1,36 @@
+"""Tests for the docs docstring suggestion feature."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from repo_release_tools.commands.docs_suggest import build_scaffold, cmd_docs_suggest, scan
+
+
+def test_build_scaffold_mentions_command_name() -> None:
+    scaffold = build_scaffold(Path("src/repo_release_tools/commands/ci_version.py"))
+    assert "rrt ci-version" in scaffold
+    assert "## Overview" in scaffold
+
+
+def test_scan_detects_missing_docstring(tmp_path: Path) -> None:
+    target = tmp_path / "example.py"
+    target.write_text("VALUE = 1\n", encoding="utf-8")
+
+    findings = scan([tmp_path])
+
+    assert findings
+    assert findings[0].path == target
+
+
+def test_cmd_docs_suggest_applies_scaffold(tmp_path: Path) -> None:
+    target = tmp_path / "example.py"
+    target.write_text("from __future__ import annotations\n\nVALUE = 1\n", encoding="utf-8")
+
+    args = argparse.Namespace(root=str(tmp_path), paths=[str(target)], min_chars=150, apply=True)
+
+    result = cmd_docs_suggest(args)
+
+    assert result == 0
+    assert target.read_text(encoding="utf-8").startswith('"""')

--- a/tests/commands/test_docs_suggest.py
+++ b/tests/commands/test_docs_suggest.py
@@ -3,15 +3,33 @@
 from __future__ import annotations
 
 import argparse
+import os
 from pathlib import Path
 
+import pytest
+
 from repo_release_tools.commands.docs_suggest import build_scaffold, cmd_docs_suggest, scan
+
+
+def _load_min_chars() -> int:
+    raw = os.getenv("RRT_DOCSTRING_MIN_CHARS")
+    if raw is None:
+        return 150
+    try:
+        return int(raw)
+    except ValueError:
+        pytest.fail(f"RRT_DOCSTRING_MIN_CHARS must be an integer; got {raw!r}")
 
 
 def test_build_scaffold_mentions_command_name() -> None:
     scaffold = build_scaffold(Path("src/repo_release_tools/commands/ci_version.py"))
     assert "rrt ci-version" in scaffold
     assert "## Overview" in scaffold
+
+
+def test_build_scaffold_strips_cmd_suffix() -> None:
+    scaffold = build_scaffold(Path("src/repo_release_tools/commands/folder_cmd.py"))
+    assert "rrt folder" in scaffold
 
 
 def test_scan_detects_missing_docstring(tmp_path: Path) -> None:
@@ -24,6 +42,24 @@ def test_scan_detects_missing_docstring(tmp_path: Path) -> None:
     assert findings[0].path == target
 
 
+def test_scan_ignores_exempt_init_files(tmp_path: Path) -> None:
+    target = tmp_path / "__init__.py"
+    target.write_text("VALUE = 1\n", encoding="utf-8")
+
+    findings = scan([tmp_path])
+
+    assert findings == []
+
+
+def test_scan_skips_healthy_docstring(tmp_path: Path) -> None:
+    target = tmp_path / "example.py"
+    target.write_text('"""Long enough docstring.\n\nBody text.\n"""\n', encoding="utf-8")
+
+    findings = scan([tmp_path], min_chars=10)
+
+    assert findings == []
+
+
 def test_cmd_docs_suggest_applies_scaffold(tmp_path: Path) -> None:
     target = tmp_path / "example.py"
     target.write_text("from __future__ import annotations\n\nVALUE = 1\n", encoding="utf-8")
@@ -34,3 +70,105 @@ def test_cmd_docs_suggest_applies_scaffold(tmp_path: Path) -> None:
 
     assert result == 0
     assert target.read_text(encoding="utf-8").startswith('"""')
+
+
+def test_cmd_docs_suggest_replaces_existing_docstring(tmp_path: Path) -> None:
+    target = tmp_path / "example.py"
+    target.write_text('"""Short docstring.\n\nBody.\n"""\nVALUE = 1\n', encoding="utf-8")
+
+    args = argparse.Namespace(root=str(tmp_path), paths=[str(target)], min_chars=200, apply=True)
+
+    result = cmd_docs_suggest(args)
+
+    assert result == 0
+    rewritten = target.read_text(encoding="utf-8")
+    assert rewritten.startswith('"""')
+    assert "Short docstring" not in rewritten
+
+
+def test_cmd_docs_suggest_inserts_after_shebang_and_encoding_comment(tmp_path: Path) -> None:
+    target = tmp_path / "example.py"
+    target.write_text(
+        "#!/usr/bin/env python3\n# coding: utf-8\nVALUE = 1\n",
+        encoding="utf-8",
+    )
+
+    args = argparse.Namespace(root=str(tmp_path), paths=[str(target)], min_chars=200, apply=True)
+
+    result = cmd_docs_suggest(args)
+
+    assert result == 0
+    lines = target.read_text(encoding="utf-8").splitlines()
+    assert lines[0] == "#!/usr/bin/env python3"
+    assert lines[1] == "# coding: utf-8"
+    assert lines[2].startswith('"""')
+
+
+def test_cmd_docs_suggest_resolves_relative_paths_against_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = tmp_path / "repo"
+    repo_src = repo / "src"
+    repo_src.mkdir(parents=True)
+    target = repo_src / "example.py"
+    target.write_text("VALUE = 1\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    args = argparse.Namespace(root=str(repo), paths=["src/example.py"], min_chars=150, apply=True)
+
+    result = cmd_docs_suggest(args)
+
+    assert result == 0
+    assert target.read_text(encoding="utf-8").startswith('"""')
+
+
+def test_cmd_docs_suggest_skips_unparseable_apply_targets(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    target = tmp_path / "broken.py"
+    target.write_text("def broken(\n", encoding="utf-8")
+
+    args = argparse.Namespace(root=str(tmp_path), paths=[str(target)], min_chars=150, apply=True)
+
+    result = cmd_docs_suggest(args)
+    captured = capsys.readouterr()
+
+    assert result == 0
+    assert "failed to parse" in captured.err
+    assert target.read_text(encoding="utf-8") == "def broken(\n"
+
+
+def test_cmd_docs_suggest_handles_paths_outside_root(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = tmp_path / "repo"
+    root.mkdir()
+    target = tmp_path / "outside.py"
+    target.write_text("VALUE = 1\n", encoding="utf-8")
+
+    args = argparse.Namespace(root=str(root), paths=[str(target)], min_chars=200, apply=False)
+
+    result = cmd_docs_suggest(args)
+    captured = capsys.readouterr()
+
+    assert result == 0
+    assert str(target) in captured.out
+
+
+def test_cmd_docs_suggest_no_findings(tmp_path: Path) -> None:
+    target = tmp_path / "example.py"
+    target.write_text('"""Long enough docstring.\n\nBody text.\n"""\n', encoding="utf-8")
+
+    args = argparse.Namespace(root=str(tmp_path), paths=[str(target)], min_chars=10, apply=False)
+
+    result = cmd_docs_suggest(args)
+
+    assert result == 0
+    assert target.read_text(encoding="utf-8").startswith('"""')
+
+
+def test_load_min_chars_rejects_invalid_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("RRT_DOCSTRING_MIN_CHARS", "oops")
+
+    with pytest.raises(pytest.fail.Exception, match="must be an integer"):
+        _load_min_chars()

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1637,6 +1637,28 @@ def test_load_config_docs_full(tmp_path: Path) -> None:
     assert cfg.docs.source_url_template == "{repo_url}/blob/{ref}/{path}#L{line}"
 
 
+def test_load_config_docs_optional_string_rejects_non_string(tmp_path: Path) -> None:
+    """Optional docs strings must be actual strings."""
+    _write_docs_cfg(
+        tmp_path,
+        "\n[tool.rrt.docs]\nsource_repo_url = 123\n",
+    )
+
+    with pytest.raises(ValueError, match="must be a string"):
+        load_config(tmp_path)
+
+
+def test_load_config_docs_optional_string_rejects_empty_string(tmp_path: Path) -> None:
+    """Optional docs strings must not be empty."""
+    _write_docs_cfg(
+        tmp_path,
+        '\n[tool.rrt.docs]\nsource_ref = ""\n',
+    )
+
+    with pytest.raises(ValueError, match="must not be empty"):
+        load_config(tmp_path)
+
+
 def test_load_config_docs_not_a_table(tmp_path: Path) -> None:
     """[tool.rrt.docs] must be a table, not a scalar."""
     (tmp_path / "pyproject.toml").write_text(

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1621,7 +1621,10 @@ def test_load_config_docs_full(tmp_path: Path) -> None:
     _write_docs_cfg(
         tmp_path,
         '\n[tool.rrt.docs]\nmirror_src_tree = true\ndocs_dir = "documentation"\n'
-        'src_dir = "src/mypackage"\nstubs = ["commands/bump", "commands/init"]\n',
+        'src_dir = "src/mypackage"\nstubs = ["commands/bump", "commands/init"]\n'
+        'source_repo_url = "https://github.com/Anselmoo/repo-release-tools"\n'
+        'source_ref = "main"\n'
+        'source_url_template = "{repo_url}/blob/{ref}/{path}#L{line}"\n',
     )
     cfg = load_config(tmp_path)
     assert cfg.docs is not None
@@ -1629,6 +1632,9 @@ def test_load_config_docs_full(tmp_path: Path) -> None:
     assert cfg.docs.docs_dir == "documentation"
     assert cfg.docs.src_dir == "src/mypackage"
     assert cfg.docs.stubs == ("commands/bump", "commands/init")
+    assert cfg.docs.source_repo_url == "https://github.com/Anselmoo/repo-release-tools"
+    assert cfg.docs.source_ref == "main"
+    assert cfg.docs.source_url_template == "{repo_url}/blob/{ref}/{path}#L{line}"
 
 
 def test_load_config_docs_not_a_table(tmp_path: Path) -> None:

--- a/tests/docs/test_docs_formats.py
+++ b/tests/docs/test_docs_formats.py
@@ -75,6 +75,55 @@ class TestRenderMd:
             in result
         )
 
+    def test_render_md_uses_fallback_source_url_when_no_template_is_set(self) -> None:
+        config = DocsConfig(
+            extraction_mode="explicit",
+            languages=("python",),
+            src_dir="src",
+            formats=("json",),
+            source_repo_url="https://github.com/Anselmoo/repo-release-tools",
+            source_ref="main",
+        )
+
+        result = render_md([_entry("hello", "Hello docs.")], config)
+
+        assert (
+            "[src/mod.py:1](https://github.com/Anselmoo/repo-release-tools/blob/main/src/mod.py#L1)"
+            in result
+        )
+
+    def test_render_md_normalizes_windows_source_path(self) -> None:
+        entry = _entry("hello", "Hello docs.")
+        entry = DocEntry(
+            name=entry.name,
+            lang=entry.lang,
+            content=entry.content,
+            source_file="src\\mod.py",
+            line=entry.line,
+            hash=entry.hash,
+        )
+
+        result = render_md([entry], _config_with_source_links())
+
+        assert (
+            "[src/mod.py:1](https://github.com/Anselmoo/repo-release-tools/blob/main/src/mod.py#L1)"
+            in result
+        )
+
+    def test_render_md_rejects_invalid_source_url_template(self) -> None:
+        config = DocsConfig(
+            extraction_mode="explicit",
+            languages=("python",),
+            src_dir="src",
+            formats=("json",),
+            source_repo_url="https://github.com/Anselmoo/repo-release-tools",
+            source_ref="main",
+            source_url_template="{repo_url}/blob/{missing}/{path}#L{line}",
+        )
+
+        with pytest.raises(ValueError, match="Supported placeholders"):
+            render_md([_entry()], config)
+
 
 class TestInjectMd:
     """Tests for inject_md — lines 54-64."""

--- a/tests/docs/test_docs_formats.py
+++ b/tests/docs/test_docs_formats.py
@@ -41,6 +41,18 @@ def _config() -> DocsConfig:
     )
 
 
+def _config_with_source_links() -> DocsConfig:
+    return DocsConfig(
+        extraction_mode="explicit",
+        languages=("python",),
+        src_dir="src",
+        formats=("json",),
+        source_repo_url="https://github.com/Anselmoo/repo-release-tools",
+        source_ref="main",
+        source_url_template="{repo_url}/blob/{ref}/{path}#L{line}",
+    )
+
+
 class TestRenderMd:
     """Tests for render_md."""
 
@@ -54,6 +66,14 @@ class TestRenderMd:
     def test_render_md_empty(self) -> None:
         result = render_md([], _config())
         assert "# Documentation" in result
+
+    def test_render_md_includes_source_link(self) -> None:
+        entries = [_entry("hello", "Hello docs.")]
+        result = render_md(entries, _config_with_source_links())
+        assert (
+            "[src/mod.py:1](https://github.com/Anselmoo/repo-release-tools/blob/main/src/mod.py#L1)"
+            in result
+        )
 
 
 class TestInjectMd:
@@ -113,6 +133,12 @@ class TestRenderTxt:
         result = render_txt(entries, _config())
         assert "hello" in result
         assert "Hello docs." in result
+
+    def test_render_txt_includes_source_url(self) -> None:
+        entries = [_entry("hello", "Hello docs.")]
+        result = render_txt(entries, _config_with_source_links())
+        assert "Source: src/mod.py:1" in result
+        assert "https://github.com/Anselmoo/repo-release-tools/blob/main/src/mod.py#L1" in result
 
     def test_render_txt_flattens_markdown_headings(self) -> None:
         entries = [_entry("hello", "# Overview\n\nBody text\n\n## Details\nMore text")]
@@ -175,6 +201,11 @@ class TestRenderRich:
         assert "Plain prose" in result
         assert "Second line" in result
 
+    def test_render_rich_includes_source_url(self) -> None:
+        entries = [_entry("hello", "Plain prose")]
+        result = render_rich(entries, _config_with_source_links())
+        assert "https://github.com/Anselmoo/repo-release-tools/blob/main/src/mod.py#L1" in result
+
 
 class TestRenderJson:
     """Tests for render_json."""
@@ -187,6 +218,14 @@ class TestRenderJson:
         parsed = json.loads(result)
         assert len(parsed) == 1
         assert parsed[0]["name"] == "hello"
+
+    def test_render_json_includes_source_url(self) -> None:
+        import json
+
+        entries = [_entry("hello", "Hello docs.")]
+        result = render_json(entries, _config_with_source_links())
+        parsed = json.loads(result)
+        assert parsed[0]["source_url"].endswith("/blob/main/src/mod.py#L1")
 
 
 class TestRender:

--- a/tests/test_commands_docstrings.py
+++ b/tests/test_commands_docstrings.py
@@ -1,0 +1,69 @@
+"""Ensure command modules provide rich, multi-line module docstrings.
+
+Rules enforced by this test:
+- Module-level docstring must exist.
+- Docstring must be multi-line (contain a newline).
+- Docstring must be at least MIN_CHARS characters long (default 150).
+- Files may opt out by including the marker "rrt:docs-exempt" anywhere in the file.
+- `__init__.py` and `__main__.py` are automatically exempt.
+
+The minimum length may be adjusted by setting the environment variable
+`RRT_DOCSTRING_MIN_CHARS`.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+from pathlib import Path
+
+import pytest
+
+MIN_DEFAULT = 150
+MIN_CHARS = int(os.getenv("RRT_DOCSTRING_MIN_CHARS", str(MIN_DEFAULT)))
+
+ROOT = Path(__file__).resolve().parents[1]
+COMMANDS_DIR = ROOT / "src" / "repo_release_tools" / "commands"
+
+
+def _should_exempt(path: Path, text: str) -> bool:
+    if path.name in ("__init__.py", "__main__.py"):
+        return True
+    if "rrt:docs-exempt" in text:
+        return True
+    return False
+
+
+def test_command_modules_have_rich_module_docstrings() -> None:
+    """Fail if any command module has a missing/insufficient module docstring."""
+    if not COMMANDS_DIR.exists():
+        pytest.skip("commands directory not present")
+
+    offenses: list[str] = []
+    for py in sorted(COMMANDS_DIR.glob("*.py")):
+        text = py.read_text(encoding="utf-8")
+        if _should_exempt(py, text):
+            continue
+
+        try:
+            module = ast.parse(text)
+        except SyntaxError as exc:  # pragma: no cover - defensive
+            offenses.append(f"{py}: could not parse: {exc}")
+            continue
+
+        doc = ast.get_docstring(module)
+        if not doc:
+            offenses.append(f"{py}: missing module docstring")
+            continue
+
+        doc_stripped = doc.strip()
+        if "\n" not in doc_stripped:
+            offenses.append(f"{py}: module docstring is single-line")
+            continue
+
+        if len(doc_stripped) < MIN_CHARS:
+            offenses.append(f"{py}: module docstring too short ({len(doc_stripped)} < {MIN_CHARS})")
+
+    if offenses:
+        errors = "\n".join(offenses)
+        pytest.fail("Insufficient module docstrings in command modules:\n" + errors)


### PR DESCRIPTION
- Introduced a new pre-commit hook for checking command module docstrings.
- Updated command documentation for `rrt ci-version` and `rrt folder` with clearer overviews and examples.
- Added a new command `rrt docs suggest` to scaffold rich module docstrings for Python files.
- Implemented source link settings in the documentation configuration for better traceability.
- Enhanced the rendering of documentation formats to include source links.
- Added tests to ensure command modules have rich, multi-line module docstrings.
- Refactored existing code for better organization and clarity.