### PR TITLE
fix: add health snapshot to resolve strict doctor check failure

### DIFF
--- a/.rrt/health.lock.toml
+++ b/.rrt/health.lock.toml
@@ -1,0 +1,23 @@
+[meta]
+generated_at = "2026-05-23T20:21:16+00:00"
+rrt_version = "1.6.2"
+
+[checks.pre_commit]
+status = "ok"
+message = ".pre-commit-config.yaml includes repo-release-tools hooks"
+updated_at = "2026-05-23T20:21:16+00:00"
+
+[checks.lefthook]
+status = "ok"
+message = "lefthook.yml includes repo-release-tools hooks"
+updated_at = "2026-05-23T20:21:16+00:00"
+
+[checks.husky]
+status = "warning"
+message = ".husky not configured"
+updated_at = "2026-05-23T20:21:16+00:00"
+
+[checks.workflows]
+status = "ok"
+message = ".github/workflows includes repo-release-tools policy checks (cicd.yml, hook-runners.yml)"
+updated_at = "2026-05-23T20:21:16+00:00"


### PR DESCRIPTION
The `.rrt/health.lock.toml` snapshot was never committed, causing `rrt doctor --check --strict` in the pages CI to fail on every run as it treated all four checks (pre_commit, lefthook, husky, workflows) as new regressions.