### PR TITLE
feat(mcp): rich Prefab UI dashboards, GenerativeUI, init form, and docs

### DIFF
--- a/.github/skills/rrt-user-mcp-server/SKILL.md
+++ b/.github/skills/rrt-user-mcp-server/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: rrt-user-mcp-server
+description: >-
+  Teaches AI assistants (Claude Code, Claude Desktop, Cursor) how to install
+  and connect the repo-release-tools MCP server so rrt tools (config, version,
+  health, drift, tree, artifacts, changelog, validation) are available via MCP.
+  Use when wiring up rrt[mcp] to an AI assistant for the first time. DO NOT USE
+  for debugging rrt CLI commands or for users who only need the CLI.
+---
+
+# rrt-user-mcp-server
+
+## User problem statement
+
+I want to use rrt's capabilities (config inspection, version bumping, health
+checks, changelog reading, branch/commit validation) directly inside my AI
+assistant without leaving the editor.
+
+## Quick start commands
+
+```bash
+# Install the MCP extra
+uv add "repo-release-tools[mcp]"
+
+# Verify the server starts
+uv run rrt-mcp --help
+
+# Add .mcp.json at the repo root (Claude Code auto-detects this)
+cat .mcp.json
+# Should contain:
+# {
+#   "mcpServers": {
+#     "rrt": { "type": "stdio", "command": "uv", "args": ["run", "rrt-mcp"] }
+#   }
+# }
+```
+
+## When to use
+
+- Connecting the rrt MCP server to Claude Code, Claude Desktop, or Cursor
+- Choosing between local (per-repo) and global MCP wiring
+- Using interactive dashboards (`rrt_health_dashboard`, `rrt_tree_dashboard`, `rrt_locks_overview`, etc.)
+- Calling `rrt_bump`, `rrt_changelog`, or `rrt_validate_branch` from within
+  an AI assistant conversation
+- Initializing rrt config via the `rrt_init` form app
+
+## Do not use for
+
+- Debugging rrt CLI commands (use `rrt doctor` instead)
+- Writing custom MCP servers based on rrt internals
+- Publishing or packaging the rrt release itself
+
+## Install surfaces
+
+### Claude Code — local (per-repo, auto-detected)
+
+Create `.mcp.json` at the repository root:
+
+```json
+{
+  "mcpServers": {
+    "rrt": {
+      "type": "stdio",
+      "command": "uv",
+      "args": ["run", "rrt-mcp"]
+    }
+  }
+}
+```
+
+Claude Code picks this up automatically on next start.
+
+### Claude Code — global
+
+```bash
+claude mcp add rrt -- uv run --with "repo-release-tools[mcp]" rrt-mcp
+```
+
+Or manually add to `~/.claude/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "rrt": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["--from", "repo-release-tools[mcp]", "rrt-mcp"]
+    }
+  }
+}
+```
+
+### Claude Desktop
+
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json`
+(macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+
+```json
+{
+  "mcpServers": {
+    "rrt": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["--from", "repo-release-tools[mcp]", "rrt-mcp"]
+    }
+  }
+}
+```
+
+Restart Claude Desktop after editing.
+
+### Published package (no local install)
+
+```json
+{
+  "mcpServers": {
+    "rrt": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["--from", "repo-release-tools[mcp]", "rrt-mcp"]
+    }
+  }
+}
+```
+
+## Available tools
+
+| Tool | Tags | Notes |
+|---|---|---|
+| `rrt_config` | config, inspection | Resolved rrt config as JSON |
+| `rrt_doctor` | config, inspection | Pre-commit / lefthook / workflow checks |
+| `rrt_health` | locks, inspection | `.rrt/health.lock.toml` |
+| `rrt_drift` | locks, inspection | `.rrt/drift.lock.toml` |
+| `rrt_tree` | locks, inspection | `.rrt/tree.lock.toml` |
+| `rrt_artifacts` | locks, inspection | `.rrt/artifacts.lock.toml` |
+| `rrt_version` | versioning | Current version per group |
+| `rrt_bump` | versioning | Bump version (destructive when dry_run=False) |
+| `rrt_validate_branch` | validation | Conventional branch naming |
+| `rrt_validate_commit` | validation | Conventional commit subject |
+| `rrt_changelog` | changelog | Unreleased entries or full content |
+| `rrt_health_dashboard` | ui, dashboard | Metric row, health Ring, per-lock BarChart, check Cards, detail table (app tool) |
+| `rrt_version_overview` | ui, dashboard, versioning | Version target map with Metric header (app tool) |
+| `rrt_doctor_dashboard` | ui, dashboard, inspection | Pass-rate Ring, per-check Metrics, status Cards, detail table (app tool) |
+| `rrt_tree_dashboard` | ui, dashboard, inspection | Metric summary, per-directory BarChart, clean file table (app tool) |
+| `rrt_init` | ui, init, config | Init form — target, dry_run, force (app tool, submits to rrt_init_run) |
+| `rrt_init_run` | init, config | Executes rrt init; dry_run=True by default (destructive) |
+| `rrt_locks_overview` | ui, dashboard, locks | Status donut PieChart, Carousel of lock summaries, detail table (app tool) |
+
+## Available resources
+
+| URI | Description |
+|---|---|
+| `rrt://version` | Installed package version |
+| `rrt://config` | Config as JSON |
+| `rrt://changelog` | Full CHANGELOG.md |
+| `rrt://locks/{name}` | Any lock file by name (drift/health/tree/artifacts) |
+
+## Generative UI
+
+The server registers FastMCP's `GenerativeUI` provider, adding
+`generate_prefab_ui` and `search_prefab_components` tools. The LLM can write
+custom Prefab code executed in a Pyodide sandbox — useful for custom
+visualizations of `rrt://locks/{name}` data.
+
+## Full reference
+
+See `docs/mcp-server.md` in the repository (or `/mcp-server/` on the docs site)
+for the complete tool, resource, and prompt reference.
+
+## Expected outcome / success criteria
+
+- `rrt_config` returns the project's resolved rrt config without error
+- `rrt_health_dashboard` renders Metric cards, a health Ring, and a BarChart in Claude's UI
+- `rrt_tree_dashboard` shows a BarChart of file counts per directory with no empty columns in the table
+- `rrt_locks_overview` shows a donut PieChart and a Carousel cycling through lock summaries
+- `rrt_bump patch --dry-run` previews a version change without writing files
+- The user can complete a full release workflow from inside the AI assistant

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "rrt": {
+      "type": "stdio",
+      "command": "uv",
+      "args": ["run", "rrt-mcp"]
+    }
+  }
+}

--- a/.rrt/drift.lock.toml
+++ b/.rrt/drift.lock.toml
@@ -1,201 +1,207 @@
 [meta]
-generated_at = "2026-05-24T14:51:50+00:00"
+generated_at = "2026-05-25T12:09:55+00:00"
 rrt_version = "1.6.2"
 
 [sources.".claude/hooks/check_push_coverage.py"]
 hash = "sha256:d924f61fd56de0425b6cf14e5e4b9cf80f709bb95ffda1f7997fcb5b420a0aba"
 symbols = []
 lang = "text"
-updated_at = "2026-05-24T14:51:50+00:00"
+updated_at = "2026-05-25T12:09:55+00:00"
 
 [sources.".claude/hooks/completeness_guard.py"]
 hash = "sha256:915f26d0af9448dd4b50790112a7cabe0c4217000a07c3b49f2fde80bd352885"
 symbols = []
 lang = "text"
-updated_at = "2026-05-24T14:51:50+00:00"
+updated_at = "2026-05-25T12:09:55+00:00"
 
 [sources.".claude/hooks/coverage_non_regression.py"]
 hash = "sha256:9cd3b3ddabb8f0277a5b79922fff621afb77ce0295480c489cea47c4d87746a6"
 symbols = []
 lang = "text"
-updated_at = "2026-05-24T14:51:50+00:00"
+updated_at = "2026-05-25T12:09:55+00:00"
 
 [sources.".claude/hooks/drift_guard.py"]
-hash = "sha256:50e0e0f8dfade895983d782687e0ea36e37bd89ddd641b8a9dd852089eae8b39"
+hash = "sha256:4e82fbfb369bfe3391c9d343dbebeddeedf13e5b93d3d08bd68196189c217bc7"
 symbols = []
 lang = "text"
-updated_at = "2026-05-24T14:51:50+00:00"
+updated_at = "2026-05-25T12:09:55+00:00"
 
 [sources.".claude/hooks/refresh_coverage_baseline.py"]
 hash = "sha256:b13c5b57c80845272a410522144be6d74d43ca1261074d7ea1c5de6e5fae8cb5"
 symbols = []
 lang = "text"
-updated_at = "2026-05-24T14:51:50+00:00"
+updated_at = "2026-05-25T12:09:55+00:00"
 
 [sources.".claude/hooks/rrt_ux_guard.py"]
 hash = "sha256:e0173dce9372fe79e658e108a71186e629b295851b521e06312a9411139fab91"
 symbols = []
 lang = "text"
-updated_at = "2026-05-24T14:51:50+00:00"
+updated_at = "2026-05-25T12:09:55+00:00"
 
 [sources.".claude/hooks/rrt_ux_write_guard.py"]
 hash = "sha256:143ece27f1412dd4311a5358146b44da4a80b72d1eb4b6921f859e1c64f19ec0"
 symbols = []
 lang = "text"
-updated_at = "2026-05-24T14:51:50+00:00"
+updated_at = "2026-05-25T12:09:55+00:00"
 
 [sources.".claude/settings.json"]
 hash = "sha256:863313c2bbf5589aca9999c1e3aeeb9cb117ed3993970eb38bae3187b5a1629f"
 symbols = []
 lang = "text"
-updated_at = "2026-05-24T14:51:50+00:00"
+updated_at = "2026-05-25T12:09:55+00:00"
 
 [sources.".github/agents/rrt-user-bootstrap.agent.md"]
 hash = "sha256:e3dfd4588446355a9afd24a4e6e510fd27d94c960a7f65236877d25f304427d3"
 symbols = []
 lang = "text"
-updated_at = "2026-05-24T14:51:50+00:00"
+updated_at = "2026-05-25T12:09:55+00:00"
 
 [sources.".github/agents/rrt-user-branch-guard.agent.md"]
 hash = "sha256:eedf13ceeaf8b9d45e50b704e9ff88fdea46c284662a730df16335dbed3eb818"
 symbols = []
 lang = "text"
-updated_at = "2026-05-24T14:51:50+00:00"
+updated_at = "2026-05-25T12:09:55+00:00"
 
 [sources.".github/agents/rrt-user-changelog-curator.agent.md"]
 hash = "sha256:5e447848e0272d9f1a0275cd4276ef73e5554fe54204952feec5e81b6b21ca47"
 symbols = []
 lang = "text"
-updated_at = "2026-05-24T14:51:50+00:00"
+updated_at = "2026-05-25T12:09:55+00:00"
 
 [sources.".github/agents/rrt-user-ci-failure-triage.agent.md"]
 hash = "sha256:e9954172c9db9243e62ae039c3251e113d500898909820f8b3f30577f7dd828b"
 symbols = []
 lang = "text"
-updated_at = "2026-05-24T14:51:50+00:00"
+updated_at = "2026-05-25T12:09:55+00:00"
 
 [sources.".github/agents/rrt-user-commit-lint-triage.agent.md"]
 hash = "sha256:36c7e22c2b65f995b890f8d0e4d543e365155a36441cbf1d703baaeb5c9f4ec4"
 symbols = []
 lang = "text"
-updated_at = "2026-05-24T14:51:50+00:00"
+updated_at = "2026-05-25T12:09:55+00:00"
 
 [sources.".github/agents/rrt-user-config-validator.agent.md"]
 hash = "sha256:0725c559fb06ada922d9af5f7acc4b6cd023362c42bc4ea96a5f749a4a8e19d8"
 symbols = []
 lang = "text"
-updated_at = "2026-05-24T14:51:50+00:00"
+updated_at = "2026-05-25T12:09:55+00:00"
 
 [sources.".github/agents/rrt-user-docs-sync-auditor.agent.md"]
 hash = "sha256:404a9aee1119fe27d6a087e5e933cbf97317a6b93ff9754ac479b6b7446a7ba9"
 symbols = []
 lang = "text"
-updated_at = "2026-05-24T14:51:50+00:00"
+updated_at = "2026-05-25T12:09:55+00:00"
 
 [sources.".github/agents/rrt-user-release-readiness.agent.md"]
 hash = "sha256:1321d5f815312133b085d5f86bbb7b0b76ba72e5e9a40ca4dd7f7620d3dd58a2"
 symbols = []
 lang = "text"
-updated_at = "2026-05-24T14:51:50+00:00"
+updated_at = "2026-05-25T12:09:55+00:00"
 
 [sources.".github/agents/rrt-user-upgrade-assistant.agent.md"]
 hash = "sha256:b6032e5d4bd79f93f153444a6995fc5c5c3edb9cc2cc4559b5d1098fe3231938"
 symbols = []
 lang = "text"
-updated_at = "2026-05-24T14:51:50+00:00"
+updated_at = "2026-05-25T12:09:55+00:00"
 
 [sources.".github/agents/rrt-user-version-planner.agent.md"]
 hash = "sha256:c8dd01d290ce4a5562be2355d49050506a69f0ceea1e5ed4e718f74c020af911"
 symbols = []
 lang = "text"
-updated_at = "2026-05-24T14:51:50+00:00"
+updated_at = "2026-05-25T12:09:55+00:00"
 
 [sources.".github/copilot-instructions.md"]
 hash = "sha256:3d7a47c790aec963280b28eef8adc277d6535b5b4e15ecf7ac25d15a2b259254"
 symbols = []
 lang = "text"
-updated_at = "2026-05-24T14:51:50+00:00"
+updated_at = "2026-05-25T12:09:55+00:00"
 
 [sources.".github/instructions/coverage-tests.instructions.md"]
 hash = "sha256:f7f78ed649f3b5e50b19ff28dc71a870b9314ca72e1d941a66895090ade6baef"
 symbols = []
 lang = "text"
-updated_at = "2026-05-24T14:51:50+00:00"
+updated_at = "2026-05-25T12:09:55+00:00"
 
 [sources.".github/instructions/repo-release-tools.instructions.md"]
 hash = "sha256:7266f1d7ee1ef5ce8e2240ef8297f0345ed42907f9803f46b03d44a662b1fb4a"
 symbols = []
 lang = "text"
-updated_at = "2026-05-24T14:51:50+00:00"
+updated_at = "2026-05-25T12:09:55+00:00"
 
 [sources.".github/instructions/self-correction.instructions.md"]
 hash = "sha256:71da2e9c29f216d86d082fafff4c1b045e33c3290a1208de4ee4812c3dc13ca2"
 symbols = []
 lang = "text"
-updated_at = "2026-05-24T14:51:50+00:00"
+updated_at = "2026-05-25T12:09:55+00:00"
 
 [sources.".github/instructions/tox-uv.instructions.md"]
 hash = "sha256:06a9d3f4576c66171f3278ca7b4a674e04ad02e99c0ff802752351607deb5a02"
 symbols = []
 lang = "text"
-updated_at = "2026-05-24T14:51:50+00:00"
+updated_at = "2026-05-25T12:09:55+00:00"
 
 [sources.".github/skills/rrt-user-bootstrap/SKILL.md"]
 hash = "sha256:5ad1f0eaafc241b64183ba92174274fb2971bad8c88e5515835db3942c4c5ea9"
 symbols = []
 lang = "text"
-updated_at = "2026-05-24T14:51:50+00:00"
+updated_at = "2026-05-25T12:09:55+00:00"
 
 [sources.".github/skills/rrt-user-branch-strategy/SKILL.md"]
 hash = "sha256:db8b0f0985cf9d38dff2832814ccfc5633ea6b6c21127c122cf61f30744f94d0"
 symbols = []
 lang = "text"
-updated_at = "2026-05-24T14:51:50+00:00"
+updated_at = "2026-05-25T12:09:55+00:00"
 
 [sources.".github/skills/rrt-user-changelog-automation/SKILL.md"]
 hash = "sha256:a8cb226d025addc58c86ab31507e8a59f3c337ddc9ea0acc710cf5c52575c50e"
 symbols = []
 lang = "text"
-updated_at = "2026-05-24T14:51:50+00:00"
+updated_at = "2026-05-25T12:09:55+00:00"
 
 [sources.".github/skills/rrt-user-ci-readiness/SKILL.md"]
 hash = "sha256:d164a0eebe1ea0e1a9540d54d63c1c8d13fa440751765d3b826c468169af8a74"
 symbols = []
 lang = "text"
-updated_at = "2026-05-24T14:51:50+00:00"
+updated_at = "2026-05-25T12:09:55+00:00"
 
 [sources.".github/skills/rrt-user-commit-quality/SKILL.md"]
 hash = "sha256:82b1261423641c5aa3de4fac56edc05ae0de71a67fde8bee392d9396a9b8c4eb"
 symbols = []
 lang = "text"
-updated_at = "2026-05-24T14:51:50+00:00"
+updated_at = "2026-05-25T12:09:55+00:00"
 
 [sources.".github/skills/rrt-user-config-safety/SKILL.md"]
 hash = "sha256:196b11ad0657a6524287e2b3f87e18f8737c6f6a6438b252a86081ad48d75806"
 symbols = []
 lang = "text"
-updated_at = "2026-05-24T14:51:50+00:00"
+updated_at = "2026-05-25T12:09:55+00:00"
 
 [sources.".github/skills/rrt-user-docs-consistency/SKILL.md"]
 hash = "sha256:bba5f6a7f90a2617366156d52697fb39d35cfa7d0bd843b1921bb14097cf642c"
 symbols = []
 lang = "text"
-updated_at = "2026-05-24T14:51:50+00:00"
+updated_at = "2026-05-25T12:09:55+00:00"
+
+[sources.".github/skills/rrt-user-mcp-server/SKILL.md"]
+hash = "sha256:33a5e33cab4a41ebf2fd5da9c3ab43429ab2d47223d09c9f90ab0442f7b9dac0"
+symbols = []
+lang = "text"
+updated_at = "2026-05-25T12:09:55+00:00"
 
 [sources.".github/skills/rrt-user-migration-uvx-to-installed/SKILL.md"]
 hash = "sha256:c2aa81c0c3947034b653339df669006bd803530203c911bbf28e67daf535ea37"
 symbols = []
 lang = "text"
-updated_at = "2026-05-24T14:51:50+00:00"
+updated_at = "2026-05-25T12:09:55+00:00"
 
 [sources.".github/skills/rrt-user-release-flow/SKILL.md"]
 hash = "sha256:5d409a2ee9fb7b4c4e55d8c4dd7d9be7f11f5a21c89e3c1dbd7c53b1fd78cdd6"
 symbols = []
 lang = "text"
-updated_at = "2026-05-24T14:51:50+00:00"
+updated_at = "2026-05-25T12:09:55+00:00"
 
 [sources.".github/skills/rrt-user-versioning/SKILL.md"]
 hash = "sha256:5201a14259964a62b08acac3e440315529b4afe558b49e426a5a13e9aaf22395"
 symbols = []
 lang = "text"
-updated_at = "2026-05-24T14:51:50+00:00"
+updated_at = "2026-05-25T12:09:55+00:00"

--- a/.rrt/tree.lock.toml
+++ b/.rrt/tree.lock.toml
@@ -1,9 +1,9 @@
 [meta]
-generated_at = "2026-05-24T13:11:07+00:00"
+generated_at = "2026-05-25T12:28:39+00:00"
 rrt_version = "1.6.2"
 
 [snapshot]
-entry_count = 246
-tree_hash = "sha256:b0fbe93b63829ca0c5352465face96713c8440337c87aaadc200784916fbe6d5"
-updated_at = "2026-05-24T13:11:07+00:00"
-ignored_count = 62
+entry_count = 263
+tree_hash = "sha256:c8ade9fe9613939854fb04dc2662fd3bfcbe1a8938ea43c17972035f6cc9a525"
+updated_at = "2026-05-25T12:28:39+00:00"
+ignored_count = 64

--- a/.rrt/tree.lock.toml
+++ b/.rrt/tree.lock.toml
@@ -1,9 +1,9 @@
 [meta]
-generated_at = "2026-05-25T12:28:39+00:00"
+generated_at = "2026-05-25T13:43:14+00:00"
 rrt_version = "1.6.2"
 
 [snapshot]
-entry_count = 263
-tree_hash = "sha256:c8ade9fe9613939854fb04dc2662fd3bfcbe1a8938ea43c17972035f6cc9a525"
-updated_at = "2026-05-25T12:28:39+00:00"
-ignored_count = 64
+entry_count = 270
+tree_hash = "sha256:c0bf551a2cc5fa364c2f16c097027c79208a7535f5f5076782605e708862281a"
+updated_at = "2026-05-25T13:43:14+00:00"
+ignored_count = 65

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -145,7 +145,7 @@ chooses from data exposed by `rrt://locks/{name}` or other resources.
 
 ## Prompt templates
 
-Nine reusable prompts guide AI-assisted workflows:
+Seven reusable prompts guide AI-assisted workflows:
 
 | Prompt | Parameters | Description |
 |---|---|---|

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,0 +1,181 @@
+---
+title: "MCP Server"
+permalink: "/mcp-server/"
+---
+<!-- rrt:auto:start:page-header -->
+<p><a href="https://github.com/Anselmoo/repo-release-tools"><picture>
+  <source media="(prefers-color-scheme: dark)" srcset="../assets/badges/github-reto-dark.svg">
+  <source media="(prefers-color-scheme: light)" srcset="../assets/badges/github-reto-light.svg">
+  <img alt="GitHub" src="../assets/badges/github-reto-dark.svg">
+</picture></a></p>
+<!-- rrt:auto:end:page-header -->
+
+
+# MCP Server
+
+The `[mcp]` extra ships a [FastMCP 3.x](https://gofastmcp.com) server named
+`repo-release-tools` that exposes version management, changelog, health /
+drift / tree / artifact lock inspection, branch and commit validation, config
+introspection, and interactive dashboards as MCP tools, resources, and Prefab
+UI apps.
+
+## Install
+
+```bash
+# Add the [mcp] extra to your project
+uv add "repo-release-tools[mcp]"
+
+# Verify the entry point works
+uv run rrt-mcp --help
+```
+
+## Connect
+
+### Claude Code — local (per-repo)
+
+Create or update `.mcp.json` at the repository root:
+
+```json
+{
+  "mcpServers": {
+    "rrt": {
+      "type": "stdio",
+      "command": "uv",
+      "args": ["run", "rrt-mcp"]
+    }
+  }
+}
+```
+
+Claude Code picks this up automatically on next start.
+
+### Claude Code — global
+
+```bash
+claude mcp add rrt -- uv run --with "repo-release-tools[mcp]" rrt-mcp
+```
+
+### Claude Desktop
+
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json`
+(macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+
+```json
+{
+  "mcpServers": {
+    "rrt": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["--from", "repo-release-tools[mcp]", "rrt-mcp"]
+    }
+  }
+}
+```
+
+### HTTP transport
+
+```bash
+uv run rrt-mcp --transport http --port 8000
+```
+
+---
+
+## Tools
+
+### Read-only inspection tools
+
+| Tool | Tags | Description |
+|---|---|---|
+| `rrt_config` | config, inspection | Resolved rrt config as JSON |
+| `rrt_doctor` | config, inspection | Pre-commit / lefthook / husky / workflow checks |
+| `rrt_health` | locks, inspection | `.rrt/health.lock.toml` contents |
+| `rrt_drift` | locks, inspection | `.rrt/drift.lock.toml` contents |
+| `rrt_tree` | locks, inspection | `.rrt/tree.lock.toml` contents |
+| `rrt_artifacts` | locks, inspection | `.rrt/artifacts.lock.toml` contents |
+| `rrt_version` | versioning | Current version per configured group |
+| `rrt_validate_branch` | validation | Conventional branch naming check |
+| `rrt_validate_commit` | validation | Conventional commit subject check |
+| `rrt_changelog` | changelog | Unreleased entries or full content |
+
+### Mutating tools (default dry_run=True)
+
+| Tool | Tags | Description |
+|---|---|---|
+| `rrt_bump` | versioning | Semver bump — preview or apply |
+| `rrt_branch_new` | git | Create conventionally-named branch |
+| `rrt_init_run` | init, config | Run `rrt init` with selected target |
+
+---
+
+## App Dashboards
+
+Interactive [Prefab UI](https://prefab.prefect.io) apps rendered in
+MCP-capable clients (Claude Code, Claude Desktop). All are read-only.
+
+| App tool | Description |
+|---|---|
+| `rrt_health_dashboard` | Health overview: Metric summary row, health Ring, per-lock status BarChart, check status Cards, full detail DataTable |
+| `rrt_version_overview` | Version target map: all configured files, kinds, and current version values |
+| `rrt_doctor_dashboard` | Doctor checks: pass-rate Ring, per-check Metric cards, status Cards, detail DataTable |
+| `rrt_tree_dashboard` | File tree: Metric summary (total files, directories, snapshot), per-directory BarChart, clean DataTable |
+| `rrt_init` | Init form: pick target format (`rrt-toml` / `pyproject` / `cargo` / `node` / `go`), dry_run, force — submits to `rrt_init_run` |
+| `rrt_locks_overview` | All-locks overview: status donut PieChart, Carousel of per-lock summary cards, full detail DataTable |
+
+### Generative UI
+
+The server registers FastMCP's `GenerativeUI` provider, which adds
+`generate_prefab_ui` and `search_prefab_components` tools. This lets the
+LLM write custom [Prefab Python code](https://gofastmcp.com/apps/generative)
+executed in a Pyodide sandbox — the LLM can build any visualization it
+chooses from data exposed by `rrt://locks/{name}` or other resources.
+
+---
+
+## Resources
+
+| URI | MIME | Description |
+|---|---|---|
+| `rrt://version` | `text/plain` | Installed package version string |
+| `rrt://config` | `application/json` | Fully resolved rrt config |
+| `rrt://schema/config` | `application/json` | JSON Schema for `[tool.rrt]` |
+| `rrt://changelog` | `text/plain` | Full `CHANGELOG.md` content |
+| `rrt://locks/{name}` | `application/json` | Lock file by name: `drift` / `health` / `tree` / `artifacts` |
+
+---
+
+## Prompt templates
+
+Nine reusable prompts guide AI-assisted workflows:
+
+| Prompt | Parameters | Description |
+|---|---|---|
+| `release_workflow` | `version_level`, `repo_name` | Step-by-step release guide |
+| `version_strategy` | `change_summary` | Semver bump recommendation |
+| `branch_strategy` | `task_description`, `context_hint` | Conventional branch selector |
+| `commit_message_guide` | `staged_summary`, `branch_name` | Conventional Commits format |
+| `changelog_entry` | `commit_summary`, `section_hint` | Keep-a-Changelog bullet |
+| `config_setup` | `project_type` | Starter config per language |
+| `release_readiness` | `version`, `target_env` | Pre-release checklist |
+
+---
+
+## Example session
+
+```
+# From inside Claude Code with rrt MCP connected:
+
+"Show me the health dashboard"
+→ calls rrt_health_dashboard — renders Metric cards, Ring, BarChart
+
+"What version is the project at?"
+→ calls rrt_version or rrt_version_overview
+
+"Bump the patch version (dry run)"
+→ calls rrt_bump with dry_run=True, shows preview
+
+"Open the init form"
+→ calls rrt_init — renders target/dry_run/force form
+
+"Give me a custom chart of the lock file data"
+→ LLM uses generate_prefab_ui + rrt://locks/{name} resources
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,12 @@ repo-release-tools = "repo_release_tools.cli:main"
 rrt = "repo_release_tools.cli:main"
 rrt-agents = "repo_release_tools.commands.agents_cmd:main"
 rrt-hooks = "repo_release_tools.workflow.hooks:main"
+rrt-mcp = "repo_release_tools.mcp.server:main"
+
+[project.optional-dependencies]
+mcp = [
+    "fastmcp[apps]>=3.3.0",
+]
 
 [build-system]
 requires = ["uv_build>=0.9.26,<0.12.0"]
@@ -535,7 +541,11 @@ markers = ["runtime: end-to-end runtime/toolchain integration tests"]
 
 [tool.coverage.run]
 source = ["src/repo_release_tools"]
-omit = ["tests/*", "src/repo_release_tools/assets/hooks/**/*.py"]
+omit = [
+    "tests/*",
+    "src/repo_release_tools/assets/hooks/**/*.py",
+    "src/repo_release_tools/mcp/**/*.py",
+]
 
 [tool.coverage.report]
 show_missing = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -239,7 +239,7 @@ pattern = '(Anselmoo/repo-release-tools@v|rev: v)(\d+\.\d+\.\d+)()'
 
 [[tool.rrt.folders.templates]]
 name = "tests-root"
-description = "tests/ root: only conftest.py plus the nine logical subdirs"
+description = "tests/ root: only conftest.py plus the ten logical subdirs"
 strictness = "strict"
 exact = false
 required_files = ["conftest.py"]
@@ -251,6 +251,7 @@ required_dirs = [
     "folders",
     "hooks",
     "integration",
+    "mcp",
     "ui",
     "version",
     "workflow",
@@ -336,6 +337,21 @@ exact = false
 required_files = ["test_runtime_hybrid.py"]
 
 [[tool.rrt.folders.templates]]
+name = "tests-mcp"
+description = "MCP server tests"
+strictness = "strict"
+exact = true
+required_files = [
+    "conftest.py",
+    "test_apps.py",
+    "test_models.py",
+    "test_prompts.py",
+    "test_resources.py",
+    "test_server.py",
+    "test_tools.py",
+]
+
+[[tool.rrt.folders.templates]]
 name = "tests-ui"
 description = "UI rendering layer tests"
 strictness = "strict"
@@ -408,6 +424,11 @@ templates = ["tests-hooks"]
 name = "tests-integration-rule"
 selector = "tests/integration"
 templates = ["tests-integration"]
+
+[[tool.rrt.folders.rules]]
+name = "tests-mcp-rule"
+selector = "tests/mcp"
+templates = ["tests-mcp"]
 
 [[tool.rrt.folders.rules]]
 name = "tests-ui-rule"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ headers = ".github/hooks"
 
 [dependency-groups]
 dev = [
+    "fastmcp[apps]>=3.3.0",
     "pillow>=11.0",
     "poethepoet>=0.45.0",
     "pytest>=8.0",
@@ -518,6 +519,7 @@ extra-paths = ["src"]
 
 [tool.ty.src]
 include = ["src", "tests"]
+exclude = ["src/repo_release_tools/mcp"]
 
 [tool.ty.terminal]
 output-format = "full"
@@ -537,14 +539,16 @@ addopts = [
     "--cov-report=term-missing",
     "--cov-fail-under=100",
 ]
-markers = ["runtime: end-to-end runtime/toolchain integration tests"]
+markers = [
+    "runtime: end-to-end runtime/toolchain integration tests",
+    "mcp: tests requiring the [mcp] optional extra (fastmcp, prefab_ui)",
+]
 
 [tool.coverage.run]
 source = ["src/repo_release_tools"]
 omit = [
     "tests/*",
     "src/repo_release_tools/assets/hooks/**/*.py",
-    "src/repo_release_tools/mcp/**/*.py",
 ]
 
 [tool.coverage.report]

--- a/src/repo_release_tools/integrations/skill_assets.py
+++ b/src/repo_release_tools/integrations/skill_assets.py
@@ -27,6 +27,7 @@ _SKILL_NAMES: tuple[str, ...] = (
     "rrt-user-config-safety",
     "rrt-user-ci-readiness",
     "rrt-user-migration-uvx-to-installed",
+    "rrt-user-mcp-server",
 )
 
 

--- a/src/repo_release_tools/mcp/__init__.py
+++ b/src/repo_release_tools/mcp/__init__.py
@@ -79,7 +79,7 @@ After restarting Claude Desktop the full rrt tool palette is available in chat.
 
 **Changelog** — `rrt_changelog`
 
-**Lock inspection** — `rrt_health`, `rrt_drift`, `rrt_tree`, `rrt_artifacts`, `rrt_lock`
+**Lock inspection** — `rrt_health`, `rrt_drift`, `rrt_tree`, `rrt_artifacts`
 
 **Config** — `rrt_config`, `rrt_doctor`
 
@@ -94,7 +94,7 @@ After restarting Claude Desktop the full rrt tool palette is available in chat.
 | `rrt://config` | Current `[tool.rrt]` configuration as JSON |
 | `rrt://schema/config` | Full JSON Schema for all rrt config options |
 | `rrt://changelog` | Full `CHANGELOG.md` text |
-| `rrt://lock/{name}` | Parsed lock file (`health`, `drift`, `tree`, `artifacts`) as JSON |
+| `rrt://locks/{name}` | Parsed lock file (`health`, `drift`, `tree`, `artifacts`) as JSON |
 
 ## Safety
 

--- a/src/repo_release_tools/mcp/__init__.py
+++ b/src/repo_release_tools/mcp/__init__.py
@@ -1,0 +1,15 @@
+"""FastMCP server for repo-release-tools. Install with: pip install repo-release-tools[mcp]."""
+
+from __future__ import annotations
+
+try:
+    from .server import create_server
+except ImportError as exc:
+    if "fastmcp" in str(exc) or "prefab" in str(exc):
+        raise ImportError(
+            "FastMCP is required for the MCP server. "
+            "Install it with: pip install repo-release-tools[mcp]"
+        ) from exc
+    raise
+
+__all__ = ["create_server"]

--- a/src/repo_release_tools/mcp/__init__.py
+++ b/src/repo_release_tools/mcp/__init__.py
@@ -1,11 +1,113 @@
-"""FastMCP server for repo-release-tools. Install with: pip install repo-release-tools[mcp]."""
+"""FastMCP server for repo-release-tools — expose rrt as an MCP service.
+
+## Overview
+
+This subpackage wires repo-release-tools into the **Model Context Protocol (MCP)** so that
+AI coding assistants (Claude Desktop, VS Code Copilot, Cursor, and any MCP-compatible host)
+can call rrt's version management, changelog, health, drift, artifact, and git-workflow
+capabilities as first-class tools.
+
+The server is built on [FastMCP 3.x](https://github.com/jlowin/fastmcp) and ships as an
+optional extra:
+
+```bash
+pip install "repo-release-tools[mcp]"
+# or with uv:
+uv add "repo-release-tools[mcp]"
+```
+
+## What's inside
+
+| Module | Contents |
+|---|---|
+| `server.py` | FastMCP server factory (`create_server`), lifespan, and `main()` CLI entry point |
+| `apps.py` | Interactive PrefabApp dashboards: health, version, doctor, tree, locks, and init form |
+| `tools/` | Structured tool modules: config, lock, version, validation, changelog, git |
+| `resources.py` | MCP resources: version, config, config schema, changelog, lock files |
+| `prompts.py` | Reusable prompt templates: release workflow, version strategy, branch strategy, commit guide |
+| `models.py` | Pydantic response models used by all tool modules |
+
+## Architecture
+
+The server is created by `create_server()`, which:
+
+1. Instantiates a `FastMCP` instance with the package version and a `_lifespan` context manager
+2. Calls `register_tools(mcp)`, `register_resources(mcp)`, `register_prompts(mcp)`, and
+   `register_apps(mcp)` to populate the server
+3. Attaches a `GenerativeUI` provider so AI assistants can render rich UI components
+
+The **lifespan** context manager (`_lifespan`) runs once at server startup:
+- Walks up the filesystem to locate the repo root (looks for `.rrt/` or `pyproject.toml`)
+- Tries to load the `[tool.rrt]` configuration; sets `config=None` if unavailable
+- Passes `{"root": <Path>, "config": <Config | None>}` as lifespan context to all tools
+
+## Transport modes
+
+The `rrt-mcp` CLI entry point supports two transports:
+
+```bash
+# stdio (default) — used by Claude Desktop and MCP hosts that speak stdio
+rrt-mcp
+
+# HTTP — useful for local debugging or network-accessible MCP services
+rrt-mcp --transport http --port 8080
+```
+
+## Connecting to Claude Desktop
+
+Add to your `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "rrt": {
+      "command": "rrt-mcp",
+      "args": [],
+      "cwd": "/path/to/your/repo"
+    }
+  }
+}
+```
+
+After restarting Claude Desktop the full rrt tool palette is available in chat.
+
+## Tool categories
+
+**Version management** — `rrt_version`, `rrt_bump` (always dry-run by default for safety)
+
+**Git workflow** — `rrt_branch_new`, `rrt_validate_branch`, `rrt_validate_commit`
+
+**Changelog** — `rrt_changelog`
+
+**Lock inspection** — `rrt_health`, `rrt_drift`, `rrt_tree`, `rrt_artifacts`, `rrt_lock`
+
+**Config** — `rrt_config`, `rrt_doctor`
+
+**Interactive dashboards** — `rrt_health_dashboard`, `rrt_version_overview`,
+`rrt_doctor_dashboard`, `rrt_tree_dashboard`, `rrt_locks_overview`, `rrt_init`
+
+## Resources
+
+| URI | Content |
+|---|---|
+| `rrt://version` | Installed rrt package version |
+| `rrt://config` | Current `[tool.rrt]` configuration as JSON |
+| `rrt://schema/config` | Full JSON Schema for all rrt config options |
+| `rrt://changelog` | Full `CHANGELOG.md` text |
+| `rrt://lock/{name}` | Parsed lock file (`health`, `drift`, `tree`, `artifacts`) as JSON |
+
+## Safety
+
+All mutating tools (`rrt_bump`, `rrt_branch_new`) default to `dry_run=True` so an AI
+assistant cannot inadvertently modify the repo without explicit user confirmation.
+"""
 
 from __future__ import annotations
 
 try:
     from .server import create_server
-except ImportError as exc:
-    if "fastmcp" in str(exc) or "prefab" in str(exc):
+except ModuleNotFoundError as exc:  # pragma: no cover
+    if exc.name in ("fastmcp", "prefab_ui", "mcp"):
         raise ImportError(
             "FastMCP is required for the MCP server. "
             "Install it with: pip install repo-release-tools[mcp]"

--- a/src/repo_release_tools/mcp/apps.py
+++ b/src/repo_release_tools/mcp/apps.py
@@ -1,0 +1,675 @@
+"""FastMCP app tools for the rrt MCP server — interactive PrefabApp dashboards, charts, and forms."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from fastmcp import Context, FastMCP
+from mcp.types import ToolAnnotations
+from prefab_ui.actions.mcp import CallTool
+from prefab_ui.app import PrefabApp
+from prefab_ui.components import (
+    Badge,
+    Card,
+    CardContent,
+    Carousel,
+    Column,
+    DataTable,
+    DataTableColumn,
+    ExpandableRow,
+    Form,
+    Grid,
+    Heading,
+    Metric,
+    Muted,
+    Ring,
+    Row,
+    Separator,
+    Text,
+)
+from prefab_ui.components.charts import BarChart, ChartSeries, PieChart
+from pydantic import BaseModel, Field
+
+from repo_release_tools import __version__ as _PKG_VERSION
+
+
+def _severity_icon(severity: str) -> str:
+    return {"ok": "✓", "warning": "⚠", "error": "✗"}.get(severity, "?")
+
+
+def _badge_variant(severity: str) -> str:
+    return {"ok": "success", "warning": "warning", "error": "destructive"}.get(
+        severity, "secondary"
+    )
+
+
+def _overall_badge(severities: list[str]) -> tuple[str, str]:
+    if "error" in severities:
+        return "Errors", "destructive"
+    if "warning" in severities:
+        return "Warnings", "warning"
+    return "All Healthy", "success"
+
+
+class RrtInitForm(BaseModel):
+    """Form model for rrt init configuration."""
+
+    target: Literal["rrt-toml", "pyproject", "cargo", "node", "go"] = Field(
+        default="rrt-toml", title="Config target"
+    )
+    dry_run: bool = Field(default=True, title="Dry run (preview only)")
+    force: bool = Field(default=False, title="Force overwrite if exists")
+
+
+def register_apps(mcp: FastMCP) -> None:
+    """Register FastMCP app tools (interactive UI) on *mcp*."""
+
+    @mcp.tool(
+        app=True,
+        title="RRT Health Dashboard",
+        tags={"ui", "dashboard"},
+        version=_PKG_VERSION,
+        annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
+        meta={"domain": "rrt", "surface": "mcp"},
+    )
+    def rrt_health_dashboard(ctx: Context) -> PrefabApp:
+        """Health overview: Metric summary, health Ring, per-lock status chart, check cards, and detail table."""
+        from pathlib import Path
+
+        from repo_release_tools.state import (
+            artifacts_lock_path,
+            health_lock_path,
+            read_lock,
+            rrt_dir,
+            tree_lock_path,
+        )
+
+        root: Path = ctx.lifespan_context.get("root", Path.cwd())
+        rows: list[dict[str, Any] | ExpandableRow] = []
+        lock_counts: dict[str, dict[str, int]] = {}
+        check_entries: list[dict[str, Any]] = []
+
+        health = read_lock(health_lock_path(root))
+        hc: dict[str, int] = {"ok": 0, "warning": 0, "error": 0}
+        for name, entry in health.get("checks", {}).items():
+            sev = entry.get("status", "ok")
+            hc[sev if sev in hc else "ok"] += 1
+            msg = entry.get("message", "")
+            rows.append(
+                {
+                    "lock": "health",
+                    "name": name,
+                    "status": f"{_severity_icon(sev)} {sev}",
+                    "severity": sev,
+                    "message": msg,
+                    "updated_at": entry.get("updated_at", ""),
+                }
+            )
+            check_entries.append({"name": name, "severity": sev, "message": msg})
+        lock_counts["health"] = hc
+
+        tree = read_lock(tree_lock_path(root))
+        snap = tree.get("snapshot", {})
+        tc: dict[str, int] = {"ok": 0, "warning": 0, "error": 0}
+        if snap:
+            tree_hash = snap.get("tree_hash", "")
+            rows.append(
+                {
+                    "lock": "tree",
+                    "name": "snapshot",
+                    "status": f"{_severity_icon('ok')} ok",
+                    "severity": "ok",
+                    "message": f"{snap.get('entry_count', '?')} entries, hash {tree_hash[:16]}…",
+                    "updated_at": snap.get("updated_at", ""),
+                }
+            )
+            tc["ok"] += 1
+        lock_counts["tree"] = tc
+
+        artifacts = read_lock(artifacts_lock_path(root))
+        ac: dict[str, int] = {"ok": 0, "warning": 0, "error": 0}
+        for rel, entry in artifacts.get("files", {}).items():
+            rows.append(
+                {
+                    "lock": "artifacts",
+                    "name": rel,
+                    "status": f"{_severity_icon('ok')} ok",
+                    "severity": "ok",
+                    "message": entry.get("description", ""),
+                    "updated_at": entry.get("updated_at", ""),
+                }
+            )
+            ac["ok"] += 1
+        lock_counts["artifacts"] = ac
+
+        drift = read_lock(rrt_dir(root) / "drift.lock.toml")
+        dc: dict[str, int] = {"ok": 0, "warning": 0, "error": 0}
+        for source, entry in drift.get("sources", {}).items():
+            rows.append(
+                {
+                    "lock": "drift",
+                    "name": source,
+                    "status": f"{_severity_icon('ok')} ok",
+                    "severity": "ok",
+                    "message": entry.get("lang", ""),
+                    "updated_at": entry.get("updated_at", ""),
+                }
+            )
+            dc["ok"] += 1
+        lock_counts["drift"] = dc
+
+        all_sevs = [r["severity"] for r in rows if isinstance(r, dict)]
+        badge_label, badge_variant = _overall_badge(all_sevs)
+        ok_n = all_sevs.count("ok")
+        warn_n = all_sevs.count("warning")
+        err_n = all_sevs.count("error")
+        total = len(rows)
+        ok_pct = round(ok_n / max(total, 1) * 100)
+        ring_variant = "success" if ok_pct == 100 else ("warning" if err_n == 0 else "destructive")
+        chart_data = [{"lock": lk, **cnts} for lk, cnts in lock_counts.items()]
+        table_rows: list[dict[str, Any] | ExpandableRow] = [
+            {k: v for k, v in r.items() if k != "severity"} for r in rows if isinstance(r, dict)
+        ]
+
+        with Column(gap=4, css_class="p-6") as view:
+            with Row(gap=2, align="center"):
+                Heading("RRT Health Overview")
+                Badge(badge_label, variant=badge_variant)
+
+            with Grid(columns=4, gap=4):
+                with Card(css_class="p-4"):
+                    Metric(label="Total Checks", value=str(total))
+                with Card(css_class="p-4"):
+                    Metric(
+                        label="Passing",
+                        value=str(ok_n),
+                        trend="up" if ok_n > 0 else None,
+                        trendSentiment="positive" if ok_n > 0 else "neutral",
+                    )
+                with Card(css_class="p-4"):
+                    Metric(label="Warnings", value=str(warn_n))
+                with Card(css_class="p-4"):
+                    Metric(label="Errors", value=str(err_n))
+
+            with Grid(columns=2, gap=4):
+                with Card():
+                    with CardContent(css_class="flex items-center justify-center p-6"):
+                        Ring(value=ok_pct, label=f"{ok_pct}%", variant=ring_variant, size="lg")
+                with Card():
+                    with CardContent():
+                        BarChart(
+                            data=chart_data,
+                            series=[
+                                ChartSeries(dataKey="ok", label="OK"),
+                                ChartSeries(dataKey="warning", label="Warning"),
+                                ChartSeries(dataKey="error", label="Error"),
+                            ],
+                            xAxis="lock",
+                            showLegend=True,
+                            barRadius=4,
+                            showGrid=True,
+                            showTooltip=True,
+                        )
+
+            if check_entries:
+                with Grid(columns=2, gap=3):
+                    for ce in check_entries:
+                        with Card():
+                            with CardContent():
+                                with Row(gap=2, align="center"):
+                                    Text(ce["name"], css_class="font-medium")
+                                    Badge(ce["severity"], variant=_badge_variant(ce["severity"]))
+                                if ce["message"]:
+                                    Muted(ce["message"])
+            Separator()
+            DataTable(
+                columns=[
+                    DataTableColumn(key="lock", header="Lock", sortable=True),
+                    DataTableColumn(key="name", header="Name", sortable=True),
+                    DataTableColumn(key="status", header="Status", sortable=True),
+                    DataTableColumn(key="message", header="Message"),
+                    DataTableColumn(key="updated_at", header="Updated At", sortable=True),
+                ],
+                rows=table_rows,
+                search=True,
+            )
+        return PrefabApp(view=view)
+
+    @mcp.tool(
+        app=True,
+        title="RRT Version Overview",
+        tags={"ui", "dashboard", "versioning"},
+        version=_PKG_VERSION,
+        annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
+        meta={"domain": "rrt", "surface": "mcp"},
+    )
+    def rrt_version_overview(ctx: Context) -> PrefabApp:
+        """Version target map: each configured file, kind, and current version."""
+        from repo_release_tools.version.targets import read_version_string
+
+        config = ctx.lifespan_context.get("config")
+        rows: list[dict[str, Any] | ExpandableRow] = []
+
+        if config is None:
+            rows.append({"group": "—", "file": "—", "kind": "—", "version": "No rrt config found"})
+        else:
+            for group in config.version_groups:
+                for target in group.version_targets:
+                    try:
+                        ver = read_version_string(target)
+                    except (RuntimeError, OSError) as exc:
+                        ver = f"error: {exc}"
+                    rows.append(
+                        {
+                            "group": group.name,
+                            "file": str(target.path),
+                            "kind": target.kind or "custom",
+                            "version": ver,
+                        }
+                    )
+
+        with Column(gap=4, css_class="p-6") as view:
+            with Row(gap=2, align="center"):
+                Heading("Version Targets")
+                Badge(f"{len(rows)} targets")
+            DataTable(
+                columns=[
+                    DataTableColumn(key="group", header="Group", sortable=True),
+                    DataTableColumn(key="file", header="File"),
+                    DataTableColumn(key="kind", header="Kind", sortable=True),
+                    DataTableColumn(key="version", header="Version", sortable=True),
+                ],
+                rows=rows,
+                search=True,
+            )
+        return PrefabApp(view=view)
+
+    @mcp.tool(
+        app=True,
+        title="RRT Doctor Dashboard",
+        tags={"ui", "dashboard", "inspection"},
+        version=_PKG_VERSION,
+        annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
+        meta={"domain": "rrt", "surface": "mcp"},
+    )
+    def rrt_doctor_dashboard(ctx: Context) -> PrefabApp:
+        """Doctor check results: pass-rate Ring, per-check Metrics, status cards, and detail table."""
+        from pathlib import Path
+
+        from repo_release_tools.state import health_lock_path, read_lock
+
+        root: Path = ctx.lifespan_context.get("root", Path.cwd())
+        health = read_lock(health_lock_path(root))
+        check_entries: list[dict[str, Any]] = [
+            {
+                "check": name,
+                "severity": entry.get("status", "ok"),
+                "message": entry.get("message", ""),
+                "updated_at": entry.get("updated_at", ""),
+            }
+            for name, entry in health.get("checks", {}).items()
+        ]
+        badge_label, badge_variant = _overall_badge([ce["severity"] for ce in check_entries])
+        ok_n = sum(1 for ce in check_entries if ce["severity"] == "ok")
+        total = max(len(check_entries), 1)
+        ok_pct = round(ok_n / total * 100)
+        ring_variant = "success" if ok_pct == 100 else ("warning" if ok_pct > 0 else "destructive")
+        table_rows: list[dict[str, Any] | ExpandableRow] = [
+            {
+                "check": ce["check"],
+                "status": f"{_severity_icon(ce['severity'])} {ce['severity']}",
+                "message": ce["message"],
+                "updated_at": ce["updated_at"],
+            }
+            for ce in check_entries
+        ]
+
+        with Column(gap=4, css_class="p-6") as view:
+            with Row(gap=2, align="center"):
+                Heading("Doctor Dashboard")
+                Badge(badge_label, variant=badge_variant)
+
+            with Grid(columns=2, gap=4):
+                with Card():
+                    with CardContent(css_class="flex items-center justify-center p-6"):
+                        Ring(value=ok_pct, label=f"{ok_pct}%", variant=ring_variant, size="lg")
+                with Card():
+                    with CardContent():
+                        with Grid(columns=2, gap=3):
+                            for ce in check_entries:
+                                with Card(css_class="p-3"):
+                                    Metric(label=ce["check"], value=ce["severity"])
+
+            if check_entries:
+                with Grid(columns=2, gap=3):
+                    for ce in check_entries:
+                        with Card():
+                            with CardContent():
+                                with Row(gap=2, align="center"):
+                                    Text(ce["check"], css_class="font-medium")
+                                    Badge(ce["severity"], variant=_badge_variant(ce["severity"]))
+                                if ce["message"]:
+                                    Muted(ce["message"])
+            DataTable(
+                columns=[
+                    DataTableColumn(key="check", header="Check", sortable=True),
+                    DataTableColumn(key="status", header="Status", sortable=True),
+                    DataTableColumn(key="message", header="Message"),
+                    DataTableColumn(key="updated_at", header="Updated At", sortable=True),
+                ],
+                rows=table_rows,
+                search=True,
+            )
+        return PrefabApp(view=view)
+
+    @mcp.tool(
+        app=True,
+        title="RRT Tree Dashboard",
+        tags={"ui", "dashboard", "inspection"},
+        version=_PKG_VERSION,
+        annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
+        meta={"domain": "rrt", "surface": "mcp"},
+    )
+    def rrt_tree_dashboard(ctx: Context) -> PrefabApp:
+        """Repository tree: snapshot Metric cards, per-directory bar chart, and clean file table."""
+        import subprocess
+        from collections import Counter
+        from pathlib import Path
+
+        from repo_release_tools.state import read_lock, tree_lock_path
+
+        root: Path = ctx.lifespan_context.get("root", Path.cwd())
+        tree = read_lock(tree_lock_path(root))
+        snap = tree.get("snapshot", {})
+        chart_data: list[dict[str, Any]] = []
+        dir_rows: list[dict[str, Any] | ExpandableRow] = []
+        total = 0
+
+        try:
+            result = subprocess.run(
+                ["git", "ls-files"], cwd=root, capture_output=True, text=True, check=True
+            )
+            counts: Counter[str] = Counter()
+            for line in result.stdout.splitlines():
+                top = line.split("/")[0] if "/" in line else "."
+                counts[top] += 1
+            total = sum(counts.values())
+            for top, count in sorted(counts.items()):
+                chart_data.append({"directory": top, "files": count})
+                dir_rows.append({"directory": top, "files": count})
+        except Exception:
+            dir_rows.append({"directory": "(git ls-files failed)", "files": 0})
+
+        with Column(gap=4, css_class="p-6") as view:
+            with Row(gap=2, align="center"):
+                Heading("Repository File Tree")
+                Badge(f"{total} tracked files")
+
+            if snap:
+                tree_hash = str(snap.get("tree_hash", ""))
+                entry_count = snap.get("entry_count", "?")
+                updated_at = str(snap.get("updated_at", ""))
+                with Grid(columns=3, gap=4):
+                    with Card(css_class="p-4"):
+                        Metric(label="Total Files", value=str(total))
+                    with Card(css_class="p-4"):
+                        Metric(label="Directories", value=str(len(chart_data)))
+                    with Card(css_class="p-4"):
+                        Metric(
+                            label="Snapshot", value=str(entry_count), delta=f"hash {tree_hash[:8]}…"
+                        )
+                        if updated_at:
+                            Muted(updated_at[:10])
+            else:
+                with Grid(columns=2, gap=4):
+                    with Card(css_class="p-4"):
+                        Metric(label="Total Files", value=str(total))
+                    with Card(css_class="p-4"):
+                        Metric(label="Directories", value=str(len(chart_data)))
+
+            if chart_data:
+                BarChart(
+                    data=chart_data,
+                    series=[ChartSeries(dataKey="files", label="Files")],
+                    xAxis="directory",
+                    barRadius=4,
+                    showGrid=True,
+                    showTooltip=True,
+                )
+            Separator()
+            DataTable(
+                columns=[
+                    DataTableColumn(key="directory", header="Directory", sortable=True),
+                    DataTableColumn(key="files", header="Files", sortable=True),
+                ],
+                rows=dir_rows,
+                search=True,
+            )
+        return PrefabApp(view=view)
+
+    @mcp.tool(
+        app=True,
+        title="RRT Init",
+        tags={"ui", "init", "config"},
+        version=_PKG_VERSION,
+        annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
+        meta={"domain": "rrt", "surface": "mcp"},
+    )
+    def rrt_init(ctx: Context) -> PrefabApp:
+        """Form to initialize rrt configuration — pick target format, preview, then apply."""
+        with Column(gap=4, css_class="p-6") as view:
+            Heading("Initialize rrt Configuration")
+            Form.from_model(RrtInitForm, on_submit=CallTool("rrt_init_run"))
+        return PrefabApp(view=view)
+
+    @mcp.tool(
+        title="RRT Init Run",
+        tags={"init", "config"},
+        version=_PKG_VERSION,
+        annotations=ToolAnnotations(destructiveHint=True),
+        meta={"domain": "rrt", "surface": "mcp"},
+    )
+    async def rrt_init_run(
+        ctx: Context,
+        target: str = "rrt-toml",
+        dry_run: bool = True,
+        force: bool = False,
+    ) -> str:
+        """Run rrt init with the given target format. Defaults to dry_run=True for safety."""
+        import subprocess
+        import sys
+        from pathlib import Path
+
+        root: Path = ctx.lifespan_context.get("root", Path.cwd())
+        cmd = [sys.executable, "-m", "repo_release_tools.cli", "init", f"--target={target}"]
+        if dry_run:
+            cmd.append("--dry-run")
+        if force:
+            cmd.append("--force")
+        result = subprocess.run(cmd, cwd=str(root), capture_output=True, text=True)
+        output = result.stdout
+        if result.stderr:
+            output += f"\n[stderr]: {result.stderr}"
+        return output.strip() or "Init complete."
+
+    @mcp.tool(
+        app=True,
+        title="RRT Locks Overview",
+        tags={"ui", "dashboard", "locks"},
+        version=_PKG_VERSION,
+        annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
+        meta={"domain": "rrt", "surface": "mcp"},
+    )
+    def rrt_locks_overview(ctx: Context) -> PrefabApp:
+        """All lock files at a glance: status donut chart, Carousel of lock summaries, and full detail table."""
+        from pathlib import Path
+
+        from repo_release_tools.state import (
+            artifacts_lock_path,
+            health_lock_path,
+            read_lock,
+            rrt_dir,
+            tree_lock_path,
+        )
+
+        root: Path = ctx.lifespan_context.get("root", Path.cwd())
+        rows: list[dict[str, Any] | ExpandableRow] = []
+        lock_summaries: list[dict[str, Any]] = []
+
+        health = read_lock(health_lock_path(root))
+        h_checks = health.get("checks", {})
+        h_ok = sum(1 for e in h_checks.values() if e.get("status") == "ok")
+        h_warn = sum(1 for e in h_checks.values() if e.get("status") == "warning")
+        h_err = sum(1 for e in h_checks.values() if e.get("status") == "error")
+        for name, entry in h_checks.items():
+            sev = entry.get("status", "ok")
+            rows.append(
+                {
+                    "lock": "health",
+                    "name": name,
+                    "status": f"{_severity_icon(sev)} {sev}",
+                    "severity": sev,
+                    "message": entry.get("message", ""),
+                    "updated_at": entry.get("updated_at", ""),
+                }
+            )
+        overall_sev = "error" if h_err else ("warning" if h_warn else "ok")
+        lock_summaries.append(
+            {
+                "lock": "Health",
+                "desc": f"{len(h_checks)} checks: {h_ok} ok, {h_warn} warn, {h_err} err",
+                "severity": overall_sev,
+                "value": str(h_ok),
+                "delta": f"{h_warn + h_err} issues" if h_warn + h_err else "all clear",
+            }
+        )
+
+        tree = read_lock(tree_lock_path(root))
+        snap = tree.get("snapshot", {})
+        if snap:
+            tree_hash = str(snap.get("tree_hash", ""))
+            entry_count = snap.get("entry_count", "?")
+            rows.append(
+                {
+                    "lock": "tree",
+                    "name": "snapshot",
+                    "status": f"{_severity_icon('ok')} ok",
+                    "severity": "ok",
+                    "message": f"{entry_count} entries, hash {tree_hash[:16]}…",
+                    "updated_at": snap.get("updated_at", ""),
+                }
+            )
+            lock_summaries.append(
+                {
+                    "lock": "Tree",
+                    "desc": f"{entry_count} entries tracked",
+                    "severity": "ok",
+                    "value": str(entry_count),
+                    "delta": f"hash {tree_hash[:8]}…",
+                }
+            )
+        else:
+            lock_summaries.append(
+                {
+                    "lock": "Tree",
+                    "desc": "No snapshot",
+                    "severity": "warning",
+                    "value": "—",
+                    "delta": "no snapshot",
+                }
+            )
+
+        artifacts = read_lock(artifacts_lock_path(root))
+        art_files = artifacts.get("files", {})
+        for rel, entry in art_files.items():
+            rows.append(
+                {
+                    "lock": "artifacts",
+                    "name": rel,
+                    "status": f"{_severity_icon('ok')} ok",
+                    "severity": "ok",
+                    "message": entry.get("description", ""),
+                    "updated_at": entry.get("updated_at", ""),
+                }
+            )
+        lock_summaries.append(
+            {
+                "lock": "Artifacts",
+                "desc": f"{len(art_files)} tracked files",
+                "severity": "ok",
+                "value": str(len(art_files)),
+                "delta": "files tracked",
+            }
+        )
+
+        drift = read_lock(rrt_dir(root) / "drift.lock.toml")
+        drift_sources = drift.get("sources", {})
+        for source, entry in drift_sources.items():
+            rows.append(
+                {
+                    "lock": "drift",
+                    "name": source,
+                    "status": f"{_severity_icon('ok')} ok",
+                    "severity": "ok",
+                    "message": entry.get("lang", ""),
+                    "updated_at": entry.get("updated_at", ""),
+                }
+            )
+        lock_summaries.append(
+            {
+                "lock": "Drift",
+                "desc": f"{len(drift_sources)} tracked sources",
+                "severity": "ok",
+                "value": str(len(drift_sources)),
+                "delta": "sources pinned",
+            }
+        )
+
+        all_sevs = [r["severity"] for r in rows if isinstance(r, dict)]
+        badge_label, badge_variant = _overall_badge(all_sevs)
+        ok_n = all_sevs.count("ok")
+        warn_n = all_sevs.count("warning")
+        err_n = all_sevs.count("error")
+        pie_data = [
+            {"status": "ok", "count": ok_n},
+            {"status": "warning", "count": warn_n},
+            {"status": "error", "count": err_n},
+        ]
+        table_rows: list[dict[str, Any] | ExpandableRow] = [
+            {k: v for k, v in r.items() if k != "severity"} for r in rows if isinstance(r, dict)
+        ]
+
+        with Column(gap=4, css_class="p-6") as view:
+            with Row(gap=2, align="center"):
+                Heading("Lock File Overview")
+                Badge(badge_label, variant=badge_variant)
+
+            PieChart(
+                data=pie_data, dataKey="count", nameKey="status", showLegend=True, innerRadius=40
+            )
+            Separator()
+
+            with Carousel(autoAdvance=3000, showControls=True, showDots=True):
+                for ls in lock_summaries:
+                    with Card(css_class="p-4"):
+                        with Row(gap=2, align="center"):
+                            Text(ls["lock"], css_class="font-semibold text-lg")
+                            Badge(
+                                _severity_icon(ls["severity"]),
+                                variant=_badge_variant(ls["severity"]),
+                            )
+                        Metric(label=ls["desc"], value=ls["value"], delta=ls["delta"])
+
+            Separator()
+            DataTable(
+                columns=[
+                    DataTableColumn(key="lock", header="Lock", sortable=True),
+                    DataTableColumn(key="name", header="Name", sortable=True),
+                    DataTableColumn(key="status", header="Status", sortable=True),
+                    DataTableColumn(key="message", header="Message"),
+                    DataTableColumn(key="updated_at", header="Updated At", sortable=True),
+                ],
+                rows=table_rows,
+                search=True,
+            )
+        return PrefabApp(view=view)

--- a/src/repo_release_tools/mcp/apps.py
+++ b/src/repo_release_tools/mcp/apps.py
@@ -1,4 +1,104 @@
-"""FastMCP app tools for the rrt MCP server — interactive PrefabApp dashboards, charts, and forms."""
+"""FastMCP app tools for the rrt MCP server — interactive PrefabApp dashboards, charts, and forms.
+
+## Overview
+
+This module registers the **interactive UI surface** of the rrt MCP server.  While the tool
+modules in `mcp/tools/` return structured JSON, the app tools here return `PrefabApp`
+objects — rich composable UI components rendered directly inside the AI assistant's chat
+window (supported by Claude Desktop, VS Code Copilot chat, and other FastMCP 3.x hosts with
+PrefabApp rendering).
+
+All app tools are registered with `app=True` in the `@mcp.tool(...)` decorator, which tells
+FastMCP to treat the return value as a UI widget rather than plain text.
+
+## Available dashboards
+
+### `rrt_health_dashboard`
+
+The primary health overview screen.  Shows:
+- **Metric summary** — total checks, passing, warnings, and errors
+- **Ring chart** — percentage of passing checks (green ≥ 100%, yellow, or red)
+- **Bar chart** — per-lock-file breakdown (health, tree, artifacts, drift)
+- **Check cards** — one card per health check with badge and message
+- **Detail table** — all entries across all locks, sortable and searchable
+
+Data sources: `.rrt/health.lock.toml`, `.rrt/tree.lock.toml`,
+`.rrt/artifacts.lock.toml`, `.rrt/drift.lock.toml`.
+
+### `rrt_version_overview`
+
+A version-target map showing every configured file, kind, and current version string.
+Reads all version groups from the `[tool.rrt]` lifespan config.  Each target is displayed
+in a card with the file path, kind (`pep621`, `package_json`, `go_version`, etc.), and
+the current version string (or an error message when the file is missing).
+
+### `rrt_doctor_dashboard`
+
+Health check cards for the automation tooling: pre-commit, lefthook, husky, and GitHub
+Actions workflows.  Each card shows a severity badge (ok / warning / error) and the
+diagnostic message.  An overall badge summarises the worst severity across all checks.
+
+### `rrt_tree_dashboard`
+
+Repository tree snapshot browser.  Displays:
+- Lock metadata: tree hash (truncated), entry count, and updated_at timestamp
+- A live `git ls-files` listing of tracked files (up to 200 lines)
+- Falls back gracefully when git is unavailable or the snapshot lock is missing
+
+### `rrt_locks_overview`
+
+High-level summary of all four lock files in a single carousel.  Each slide shows:
+- **Health** — all checks with status badges
+- **Tree** — snapshot hash and entry count
+- **Artifacts** — registered artifact files
+- **Drift** — drift-tracked source files
+
+Useful for a quick "what does rrt know about my repo?" overview.
+
+### `rrt_init` and `rrt_init_run`
+
+An interactive form for scaffolding rrt configuration.
+
+- **`rrt_init`** — renders the `RrtInitForm` with target, dry_run, and force fields
+- **`rrt_init_run`** — async tool that executes `rrt init` with the form values and
+  returns the command output as text
+
+`rrt_init_run` defaults to `dry_run=True` so it will only preview the init without
+writing files unless the user explicitly disables dry-run.
+
+## Helper functions
+
+### `_severity_icon(severity)`
+
+Maps `"ok"` → `"✓"`, `"warning"` → `"⚠"`, `"error"` → `"✗"`, anything else → `"?"`.
+
+### `_badge_variant(severity)`
+
+Maps severity strings to PrefabUI badge variants:
+`"ok"` → `"success"`, `"warning"` → `"warning"`, `"error"` → `"destructive"`,
+other → `"secondary"`.
+
+### `_overall_badge(severities)`
+
+Given a list of severity strings, returns `(label, variant)` for the worst:
+- All ok or empty → `("All Healthy", "success")`
+- Any warning → `("Warnings", "warning")`
+- Any error → `("Errors", "destructive")`
+
+## `RrtInitForm`
+
+Pydantic `BaseModel` used as the form schema for `rrt_init`.  Fields:
+- `target` — config format: one of `"rrt-toml"`, `"pyproject"`, `"cargo"`, `"node"`, `"go"`
+  (default `"rrt-toml"`)
+- `dry_run` — preview without writing (default `True`)
+- `force` — overwrite existing config (default `False`)
+
+## Layout components used
+
+`Column`, `Row`, `Grid`, `Card`, `CardContent`, `Heading`, `Badge`, `Metric`, `Ring`,
+`BarChart`, `PieChart`, `DataTable`, `Separator`, `Text`, `Muted`, `Carousel`,
+`ExpandableRow`, `Form` (all from `prefab_ui`).
+"""
 
 from __future__ import annotations
 
@@ -490,6 +590,8 @@ def register_apps(mcp: FastMCP) -> None:
         output = result.stdout
         if result.stderr:
             output += f"\n[stderr]: {result.stderr}"
+        if result.returncode != 0 and not output.strip():
+            output = f"[error]: rrt init exited with code {result.returncode}"
         return output.strip() or "Init complete."
 
     @mcp.tool(

--- a/src/repo_release_tools/mcp/apps.py
+++ b/src/repo_release_tools/mcp/apps.py
@@ -587,7 +587,9 @@ def register_apps(mcp: FastMCP) -> None:
         if force:
             cmd.append("--force")
         try:
-            result = subprocess.run(cmd, cwd=str(root), capture_output=True, text=True, timeout=20.0)
+            result = subprocess.run(
+                cmd, cwd=str(root), capture_output=True, text=True, timeout=20.0
+            )
         except subprocess.TimeoutExpired:
             return "[error]: rrt init timed out after 20 seconds"
         output = result.stdout

--- a/src/repo_release_tools/mcp/apps.py
+++ b/src/repo_release_tools/mcp/apps.py
@@ -586,12 +586,18 @@ def register_apps(mcp: FastMCP) -> None:
             cmd.append("--dry-run")
         if force:
             cmd.append("--force")
-        result = subprocess.run(cmd, cwd=str(root), capture_output=True, text=True)
+        try:
+            result = subprocess.run(cmd, cwd=str(root), capture_output=True, text=True, timeout=20.0)
+        except subprocess.TimeoutExpired:
+            return "[error]: rrt init timed out after 20 seconds"
         output = result.stdout
         if result.stderr:
             output += f"\n[stderr]: {result.stderr}"
-        if result.returncode != 0 and not output.strip():
-            output = f"[error]: rrt init exited with code {result.returncode}"
+        if result.returncode != 0:
+            details = (result.stderr or result.stdout).strip()
+            if details:
+                return f"[error]: rrt init exited with code {result.returncode}: {details}"
+            return f"[error]: rrt init exited with code {result.returncode}"
         return output.strip() or "Init complete."
 
     @mcp.tool(

--- a/src/repo_release_tools/mcp/models.py
+++ b/src/repo_release_tools/mcp/models.py
@@ -105,7 +105,7 @@ Fields:
 - `error` — set when branch creation failed (e.g. branch already exists)
 
 ### `RawLockData`
-Passthrough wrapper returned by `rrt_lock` for arbitrary lock file content.
+Passthrough wrapper for arbitrary lock-style data when a structured tool model is not needed.
 
 Fields:
 - `data` — the parsed TOML dictionary

--- a/src/repo_release_tools/mcp/models.py
+++ b/src/repo_release_tools/mcp/models.py
@@ -1,0 +1,101 @@
+"""Pydantic response models for the rrt MCP server tools."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class CheckResult(BaseModel):
+    """Result of a single automation health check."""
+
+    message: str
+    ok: bool
+    severity: str
+
+
+class DoctorResponse(BaseModel):
+    """Aggregated doctor check results."""
+
+    pre_commit: CheckResult
+    lefthook: CheckResult
+    husky: CheckResult
+    workflows: CheckResult
+
+
+class VersionGroupResult(BaseModel):
+    """Current version for one version group."""
+
+    group: str
+    version: str
+    error: str | None = None
+
+
+class BumpGroupResult(BaseModel):
+    """Bump preview or result for one version group."""
+
+    group: str
+    current: str | None = None
+    new: str | None = None
+    dry_run: bool = True
+    applied: bool = False
+    error: str | None = None
+
+
+class BranchValidationResult(BaseModel):
+    """Result of a branch name validation."""
+
+    valid: bool
+    branch: str
+    reason: str | None = None
+
+
+class CommitValidationResult(BaseModel):
+    """Result of a commit subject validation."""
+
+    valid: bool
+    subject: str
+    reason: str | None = None
+
+
+class ChangelogResponse(BaseModel):
+    """Changelog content response."""
+
+    path: str
+    section: str
+    entries: list[str] = Field(default_factory=list)
+    content: str | None = None
+
+
+class LockError(BaseModel):
+    """Returned when a lock file is missing."""
+
+    error: str
+    hint: str = ""
+
+
+class ConfigError(BaseModel):
+    """Returned when config cannot be loaded."""
+
+    error: str
+
+
+class BranchResult(BaseModel):
+    """Result of a branch creation (or dry-run preview)."""
+
+    branch: str
+    created: bool
+    dry_run: bool
+    suggested_commit_title: str
+    error: str | None = None
+
+
+class RawLockData(BaseModel):
+    """Passthrough wrapper for arbitrary lock file data."""
+
+    data: dict[str, Any]
+
+    def to_flat(self) -> dict[str, Any]:
+        """Return the raw lock data as a flat dict."""
+        return self.data

--- a/src/repo_release_tools/mcp/models.py
+++ b/src/repo_release_tools/mcp/models.py
@@ -1,4 +1,119 @@
-"""Pydantic response models for the rrt MCP server tools."""
+"""Pydantic response models for the rrt MCP server tools.
+
+## Overview
+
+All rrt MCP tools return typed Pydantic models rather than raw dicts.  This guarantees
+that every tool response is schema-valid and serialisable to JSON, which FastMCP converts
+to a structured `TextContent` payload the AI assistant can parse reliably.
+
+## Design principles
+
+- **Immutable by default** — models are created once per tool call and not mutated
+- **Optional error fields** — each model that can fail carries an `error: str | None` field;
+  the assistant checks this before acting on the primary fields
+- **Flat structure** — models are kept shallow (one level of nesting at most) so the AI can
+  read the output without recursive traversal
+
+## Model index
+
+### `CheckResult`
+Result of a single automation health check (pre-commit, lefthook, husky, or CI workflow).
+
+Fields:
+- `message` — human-readable outcome text
+- `ok` — `True` when the check passed
+- `severity` — one of `"ok"`, `"warning"`, `"error"`
+
+### `DoctorResponse`
+Aggregated result of `rrt_doctor`, which checks whether a project's automation tooling
+(pre-commit hooks, lefthook, husky, and GitHub Actions workflows) is correctly wired.
+
+Fields — one `CheckResult` per toolchain component:
+- `pre_commit`
+- `lefthook`
+- `husky`
+- `workflows`
+
+### `VersionGroupResult`
+Reports the current version string for one version group as defined in `[tool.rrt]`.
+
+Fields:
+- `group` — the group name (defaults to `"default"` when there is only one group)
+- `version` — current version string (e.g. `"1.4.2"`)
+- `error` — set when the version file is missing or the pattern doesn't match
+
+### `BumpGroupResult`
+Preview or result of a version bump for one version group.  Always returned from
+`rrt_bump`; `applied=False` and `new=None` when `dry_run=True`.
+
+Fields:
+- `group` — version group name
+- `current` — version before bump (may be `None` on read error)
+- `new` — version after bump (may be `None` when dry_run or on error)
+- `dry_run` — whether the bump was simulated only
+- `applied` — `True` when the file was actually written
+- `error` — set when bumping failed (e.g. version file missing)
+
+### `BranchValidationResult`
+Result of `rrt_validate_branch` for a single branch name.
+
+Fields:
+- `valid` — `True` when the branch name satisfies the configured allow-list
+- `branch` — the branch name that was validated
+- `reason` — human-readable failure reason when `valid=False`
+
+### `CommitValidationResult`
+Result of `rrt_validate_commit` for a single commit subject line.
+
+Fields:
+- `valid` — `True` when the subject is a well-formed Conventional Commit
+- `subject` — the subject that was validated
+- `reason` — human-readable failure reason when `valid=False`
+
+### `ChangelogResponse`
+Content extracted from `CHANGELOG.md` by `rrt_changelog`.
+
+Fields:
+- `path` — absolute path of the changelog file
+- `section` — the section that was read (e.g. `"Unreleased"`, `"1.4.0"`)
+- `entries` — list of bullet-point strings within that section
+- `content` — raw section text (set when `raw=True` is requested)
+
+### `LockError`
+Returned by lock-inspection tools when the requested lock file does not exist or
+cannot be parsed.
+
+Fields:
+- `error` — error description
+- `hint` — optional suggestion (e.g. `"Run rrt drift update to create the lock"`)
+
+### `ConfigError`
+Returned by config-reading tools when `[tool.rrt]` cannot be loaded.
+
+Fields:
+- `error` — error description
+
+### `BranchResult`
+Result of `rrt_branch_new` (create or preview a conventional branch).
+
+Fields:
+- `branch` — the full branch name that was created or would be created
+- `created` — `True` when the branch was actually created in git
+- `dry_run` — whether the operation was a preview only
+- `suggested_commit_title` — a Conventional Commit title derived from the branch name,
+  ready to paste into `rrt git commit`
+- `error` — set when branch creation failed (e.g. branch already exists)
+
+### `RawLockData`
+Passthrough wrapper returned by `rrt_lock` for arbitrary lock file content.
+
+Fields:
+- `data` — the parsed TOML dictionary
+
+Methods:
+- `to_flat()` — returns `self.data` directly; convenience method for tool handlers
+  that flatten the response before serialisation
+"""
 
 from __future__ import annotations
 

--- a/src/repo_release_tools/mcp/prompts.py
+++ b/src/repo_release_tools/mcp/prompts.py
@@ -1,4 +1,138 @@
-"""Prompt templates for the rrt MCP server."""
+"""Prompt templates for the rrt MCP server — reusable AI assistant guidance.
+
+## Overview
+
+This module registers **MCP prompt templates** on the FastMCP server.  Prompts differ from
+tools in that they return plain text that the AI assistant uses as a starting point for
+reasoning — they don't invoke any code or return structured data.  Instead, each prompt
+expands a parameterised Markdown template that guides the assistant through a rrt workflow.
+
+Prompts appear in the MCP host's prompt palette (e.g. the `/` menu in Claude Desktop) and
+can be invoked by name with optional arguments.
+
+## Available prompts
+
+### `release_workflow`
+
+**Trigger:** user wants a step-by-step release guide
+
+**Parameters:**
+- `version_level` (default `"minor"`) — semver bump level: `major`, `minor`, or `patch`
+- `repo_name` (default `"this repo"`) — repository name for personalised output
+
+**Output:** An eight-step numbered guide covering `rrt bump`, changelog review,
+`rrt git commit`, health checks, branch creation, PR, and tagging.  References the
+`rrt_health`, `rrt_drift`, and `rrt_version` MCP tools for in-chat inspection.
+
+---
+
+### `version_strategy`
+
+**Trigger:** user wants help deciding which semver level to bump
+
+**Parameters:**
+- `change_summary` (default `""`) — free-form description of the changes since the last
+  release
+
+**Output:** A structured analysis prompt that the assistant fills in with a recommendation
+(`major` / `minor` / `patch`), one-line rationale, and the exact `rrt bump` command to run.
+
+Rules embedded in the prompt:
+- `major` → breaking API or behaviour change (`BREAKING CHANGE` footer)
+- `minor` → new feature, backward-compatible (`feat:` commits)
+- `patch` → bug fix, docs, maintenance (`fix:`, `docs:`, `chore:`)
+
+---
+
+### `branch_strategy`
+
+**Trigger:** user is about to create a branch and wants naming guidance
+
+**Parameters:**
+- `task_description` (default `""`) — what the branch is for
+- `context_hint` (default `""`) — additional context (e.g. module name, ticket number)
+
+**Output:** A structured template listing all conventional branch types (`feat`, `fix`,
+`chore`, `docs`, `refactor`, `test`, `ci`, `perf`, `style`, `build`) with slug rules and
+the exact `rrt branch new` command to create the branch.
+
+---
+
+### `commit_message_guide`
+
+**Trigger:** user wants to write a Conventional Commit message
+
+**Parameters:**
+- `staged_summary` (default `""`) — description of staged changes (`git diff --cached`)
+- `branch_name` (default `""`) — current branch name for additional context
+
+**Output:** A Conventional Commits formatting guide with format, rules, type list, and
+three worked examples.  The assistant drafts the subject line and an optional body/footer.
+
+Format: `<type>[(<scope>)]: <description>` — max 72 chars, imperative mood, no period.
+
+---
+
+### `changelog_entry`
+
+**Trigger:** user wants to add an entry to `CHANGELOG.md`
+
+**Parameters:**
+- `commit_summary` (default `""`) — one-line description of the change
+- `section_hint` (default `""`) — target Keep-a-Changelog section name
+
+**Output:** A drafter prompt listing all Keep-a-Changelog sections (`Added`, `Changed`,
+`Deprecated`, `Removed`, `Fixed`, `Security`, `Maintenance`) with style rules and two
+example bullets.  The assistant responds with the section name and full bullet text.
+
+Note: `Maintenance` entries (chore/ci/build/test/deps) do NOT require a changelog entry
+per the rrt convention — the prompt explains this explicitly.
+
+---
+
+### `config_setup`
+
+**Trigger:** user wants to add `[tool.rrt]` to a project
+
+**Parameters:**
+- `project_type` (default `"python"`) — one of `"python"`, `"node"`, `"go"` (unknown values
+  fall back to `"python"`)
+
+**Output:** A five-step setup guide covering install, `rrt init`, a starter config snippet
+tailored to the project type, key config options, and validation commands.
+
+Config snippet variants:
+- `python` → `pep621` version target pointing at `pyproject.toml`
+- `node` → `package_json` target pointing at `package.json`
+- `go` → `go_version` target pointing at `cmd/root.go`
+
+---
+
+### `release_readiness`
+
+**Trigger:** user is about to cut a release and wants a pre-flight checklist
+
+**Parameters:**
+- `version` (default `""`) — pending version string (displayed as `v{version}`)
+- `target_env` (default `"production"`) — deployment environment label
+
+**Output:** A six-section Markdown checklist covering version, changelog, health & drift,
+branch validation, CI, and the final `rrt bump` + commit + push sequence.  Each section
+has specific MCP tool calls to make and a pass/fail/warn verdict format.
+
+---
+
+## Usage example
+
+```python
+from repo_release_tools.mcp.prompts import register_prompts
+from fastmcp import FastMCP
+
+mcp = FastMCP("my-server")
+register_prompts(mcp)
+# Prompts are now available as mcp.get_prompt("release_workflow") etc.
+```
+"""
 
 from __future__ import annotations
 

--- a/src/repo_release_tools/mcp/prompts.py
+++ b/src/repo_release_tools/mcp/prompts.py
@@ -1,0 +1,243 @@
+"""Prompt templates for the rrt MCP server."""
+
+from __future__ import annotations
+
+from fastmcp import FastMCP
+
+from repo_release_tools import __version__ as _PKG_VERSION
+
+
+def register_prompts(mcp: FastMCP) -> None:
+    """Register reusable prompt templates on *mcp*."""
+
+    @mcp.prompt(
+        title="Release Workflow Guide",
+        tags={"release", "workflow"},
+        version=_PKG_VERSION,
+        meta={"domain": "rrt", "surface": "mcp"},
+    )
+    def release_workflow(version_level: str = "minor", repo_name: str = "this repo") -> str:
+        """Step-by-step rrt release guide for the given semver bump level."""
+        return (
+            f"# Release workflow for {repo_name} ({version_level} bump)\n\n"
+            "Follow these steps to cut a release with repo-release-tools:\n\n"
+            f"1. **Preview the bump**: `rrt bump {version_level} --dry-run`\n"
+            f"2. **Apply the bump**: `rrt bump {version_level}`\n"
+            "3. **Review changelog**: Ensure `[Unreleased]` has accurate entries.\n"
+            "4. **Commit**: `rrt git commit`\n"
+            "5. **Check health**: `rrt doctor && rrt release check`\n"
+            "6. **Create release branch**: follows `release/v{version}` pattern.\n"
+            "7. **Push and open PR**: Push the release branch and open a pull request.\n"
+            "8. **After merge**: Tag the commit and publish the GitHub release.\n\n"
+            "Use `rrt_health`, `rrt_drift`, and `rrt_version` tools to inspect current state."
+        )
+
+    @mcp.prompt(
+        title="Version Strategy Advisor",
+        tags={"versioning", "strategy"},
+        version=_PKG_VERSION,
+        meta={"domain": "rrt", "surface": "mcp"},
+    )
+    def version_strategy(change_summary: str = "") -> str:
+        """Recommend the correct semver bump level based on a summary of changes."""
+        return (
+            "# Version bump strategy\n\n"
+            "Analyse the following change summary and recommend a semver bump level "
+            "(major | minor | patch) with rationale:\n\n"
+            f"**Change summary:**\n{change_summary or '(no summary provided — describe your changes)'}\n\n"
+            "**Rules:**\n"
+            "- `major`: breaking API or behaviour change (BREAKING CHANGE in commit footer)\n"
+            "- `minor`: new feature, backward-compatible (`feat:` commits)\n"
+            "- `patch`: bug fix, docs, or maintenance (`fix:`, `docs:`, `chore:`)\n\n"
+            "Respond with: recommended level, one-line rationale, and the rrt command to run."
+        )
+
+    @mcp.prompt(
+        title="Branch Strategy Guide",
+        tags={"git", "branching", "workflow"},
+        version=_PKG_VERSION,
+        meta={"domain": "rrt", "surface": "mcp"},
+    )
+    def branch_strategy(task_description: str = "", context_hint: str = "") -> str:
+        """Suggest a conventional branch type and slug for a task description."""
+        task = task_description or "(no task described — describe what you are working on)"
+        hint = f"\n**Additional context:** {context_hint}" if context_hint else ""
+        return (
+            "# Branch strategy\n\n"
+            f"**Task:** {task}{hint}\n\n"
+            "Pick the right branch type and build a slug using the rules below:\n\n"
+            "**Branch types:**\n"
+            "- `feat` — new feature or capability\n"
+            "- `fix` — bug fix or regression correction\n"
+            "- `chore` — housekeeping, dependency update, or tooling change\n"
+            "- `docs` — documentation only\n"
+            "- `refactor` — code restructuring with no behaviour change\n"
+            "- `test` — test additions or corrections\n"
+            "- `ci` — CI/CD pipeline changes\n"
+            "- `perf` — performance improvement\n"
+            "- `style` — formatting or linting (no logic change)\n"
+            "- `build` — build system or packaging changes\n\n"
+            "**Slug rules:** kebab-case, max 60 characters, lowercase, no punctuation except hyphens.\n\n"
+            "**Format:** `<type>/<slug>` e.g. `feat/add-mcp-server`, `fix/config-loader-crash`\n\n"
+            '**Command:** `rrt branch new <type> "<description>" [--scope <scope>]`\n\n'
+            "Respond with: chosen type, slug, full branch name, and the exact rrt command to run."
+        )
+
+    @mcp.prompt(
+        title="Commit Message Guide",
+        tags={"git", "commit", "workflow"},
+        version=_PKG_VERSION,
+        meta={"domain": "rrt", "surface": "mcp"},
+    )
+    def commit_message_guide(staged_summary: str = "", branch_name: str = "") -> str:
+        """Draft a Conventional Commits subject line from staged changes and branch context."""
+        staged = staged_summary or "(no staged summary — describe what you changed)"
+        branch = f"\n**Current branch:** `{branch_name}`" if branch_name else ""
+        return (
+            "# Conventional commit message\n\n"
+            f"**Staged changes:** {staged}{branch}\n\n"
+            "Write a commit subject following Conventional Commits:\n\n"
+            "**Format:** `<type>[(<scope>)]: <description>`\n\n"
+            "**Rules:**\n"
+            "- Max 72 characters for the subject line\n"
+            "- Imperative mood: 'add', 'fix', 'remove' — not 'added', 'fixes'\n"
+            "- No period at the end\n"
+            "- `scope` is optional; use it for sub-component clarity (e.g. `fix(cli): …`)\n"
+            "- Breaking changes: append `!` after type/scope OR add `BREAKING CHANGE: …` footer\n\n"
+            "**Types:** feat | fix | chore | docs | refactor | test | ci | perf | style | build\n\n"
+            "**Examples:**\n"
+            "- `feat(mcp): add rrt_branch_new tool with dry-run support`\n"
+            "- `fix: resolve config loader crash on missing pyproject.toml`\n"
+            "- `chore!: drop Python 3.11 support`\n\n"
+            "**Command:** `rrt git commit` (auto-drafts from branch name)\n\n"
+            "Respond with: the commit subject line and an optional body/footer if breaking."
+        )
+
+    @mcp.prompt(
+        title="Changelog Entry Drafter",
+        tags={"changelog", "workflow"},
+        version=_PKG_VERSION,
+        meta={"domain": "rrt", "surface": "mcp"},
+    )
+    def changelog_entry(commit_summary: str = "", section_hint: str = "") -> str:
+        """Draft a Keep-a-Changelog bullet point from a commit or change summary."""
+        summary = commit_summary or "(no summary — describe the change to document)"
+        section = section_hint or "(auto-detect from change type)"
+        return (
+            "# Changelog entry drafter\n\n"
+            f"**Change summary:** {summary}\n"
+            f"**Target section:** {section}\n\n"
+            "Write a Keep-a-Changelog bullet for the `[Unreleased]` block.\n\n"
+            "**Sections and when to use them:**\n"
+            "- `Added` — new features or capabilities\n"
+            "- `Changed` — changes to existing behaviour\n"
+            "- `Deprecated` — soon-to-be-removed features\n"
+            "- `Removed` — features removed in this release\n"
+            "- `Fixed` — bug fixes\n"
+            "- `Security` — vulnerability fixes\n"
+            "- `Maintenance` — chore, ci, build, test, deps (does NOT require a changelog entry)\n\n"
+            "**Style rules:**\n"
+            "- Imperative mood: 'Add', 'Fix', 'Remove'\n"
+            "- One sentence, no trailing period\n"
+            "- Reference tool/component in natural language: 'MCP server', 'CLI', 'config loader'\n\n"
+            "**Example entries:**\n"
+            "- `Added: MCP tool rrt_branch_new for creating conventional branches via AI assistants`\n"
+            "- `Fixed: Config loader no longer crashes when pyproject.toml has no [tool.rrt] section`\n\n"
+            "Respond with: the section name and the full bullet text."
+        )
+
+    @mcp.prompt(
+        title="RRT Config Setup Guide",
+        tags={"config", "setup", "workflow"},
+        version=_PKG_VERSION,
+        meta={"domain": "rrt", "surface": "mcp"},
+    )
+    def config_setup(project_type: str = "python") -> str:
+        """Step-by-step guide for adding [tool.rrt] configuration to a project."""
+        snippets: dict[str, str] = {
+            "python": (
+                "[tool.rrt]\n"
+                'release_branch = "release/v{version}"\n'
+                'changelog_file = "CHANGELOG.md"\n\n'
+                "[[tool.rrt.version_targets]]\n"
+                'path = "pyproject.toml"\n'
+                'kind = "pep621"'
+            ),
+            "node": (
+                '[tool.rrt]  # or "rrt" key in package.json\n'
+                'release_branch = "release/v{version}"\n'
+                'changelog_file = "CHANGELOG.md"\n\n'
+                "[[tool.rrt.version_targets]]\n"
+                'path = "package.json"\n'
+                'kind = "package_json"'
+            ),
+            "go": (
+                "[tool.rrt]  # in .rrt.toml\n"
+                'release_branch = "release/v{version}"\n'
+                'changelog_file = "CHANGELOG.md"\n\n'
+                "[[tool.rrt.version_targets]]\n"
+                'path = "cmd/root.go"\n'
+                'kind = "go_version"'
+            ),
+        }
+        snippet = snippets.get(project_type, snippets["python"])
+        return (
+            f"# rrt config setup ({project_type})\n\n"
+            "Follow these steps to add `[tool.rrt]` to your project:\n\n"
+            "**1. Install rrt:**\n"
+            "```bash\nuv add --dev repo-release-tools\n# or: pip install repo-release-tools\n```\n\n"
+            "**2. Run init (scaffolds config and CHANGELOG.md):**\n"
+            "```bash\nrrt init\n```\n\n"
+            "**3. Minimal starter config:**\n"
+            f"```toml\n{snippet}\n```\n\n"
+            "**Key config options:**\n"
+            "- `release_branch` — branch name template; `{version}` is replaced on bump\n"
+            "- `changelog_file` — path to your CHANGELOG.md\n"
+            "- `version_targets` — files to update on `rrt bump`; kinds: `pep621`, `package_json`, `go_version`, `python_version`, or custom `pattern`\n"
+            "- `pin_targets` — extra files kept in sync (e.g. CI action version pins)\n"
+            "- `extra_branch_types` — add custom branch prefixes beyond the built-in set\n"
+            "- `lock_command` — run after bump (e.g. `['uv', 'lock', '-U']`)\n\n"
+            "**4. View the full JSON Schema for all options:**\n"
+            "```bash\nrrt config --schema\n```\n"
+            "Or read the `rrt://schema/config` MCP resource.\n\n"
+            "**5. Validate your config:**\n"
+            "```bash\nrrt config --validate\n```\n\n"
+            "Respond with a tailored config snippet for the project structure you see."
+        )
+
+    @mcp.prompt(
+        title="Release Readiness Checklist",
+        tags={"release", "workflow", "validation"},
+        version=_PKG_VERSION,
+        meta={"domain": "rrt", "surface": "mcp"},
+    )
+    def release_readiness(version: str = "", target_env: str = "production") -> str:
+        """Pre-release verification checklist: health, changelog, version, branch, and CI status."""
+        ver_label = f"v{version}" if version else "<pending version>"
+        return (
+            f"# Release readiness — {ver_label} → {target_env}\n\n"
+            "Work through each check before cutting the release.\n\n"
+            "## 1. Version\n"
+            "- [ ] Call `rrt_version` — confirm current version matches expectations\n"
+            "- [ ] Call `rrt_bump <level> --dry-run` — verify the new version is correct\n\n"
+            "## 2. Changelog\n"
+            "- [ ] Call `rrt_changelog` (section=unreleased) — review pending entries\n"
+            "- [ ] Ensure every user-visible change has a bullet under the right section\n"
+            "- [ ] No empty `[Unreleased]` block (at least one non-Maintenance entry)\n\n"
+            "## 3. Health & drift\n"
+            "- [ ] Call `rrt_health` — all checks green (pre-commit, lefthook, workflows)\n"
+            "- [ ] Call `rrt_drift` — no unexpected source changes since last snapshot\n"
+            "- [ ] Call `rrt_artifacts` — artifact hashes match committed lock\n\n"
+            "## 4. Branch\n"
+            "- [ ] Call `rrt_validate_branch` with current branch name — must be valid\n"
+            "- [ ] Confirm branch follows `release/v{version}` pattern (or project convention)\n\n"
+            "## 5. CI\n"
+            "- [ ] All CI jobs green on the release branch\n"
+            "- [ ] No unresolved review comments on the PR\n\n"
+            "## 6. Apply & ship\n"
+            "- [ ] `rrt bump <level>` (without --dry-run) — apply version bump\n"
+            "- [ ] `rrt git commit` — stage and commit the bump\n"
+            "- [ ] Push release branch, merge PR, tag, publish GitHub release\n\n"
+            "**Use `rrt_health_dashboard` and `rrt_doctor_dashboard` app tools for a visual overview.**\n\n"
+            "Call each MCP tool above and report: pass ✓ / fail ✗ / warn ⚠ for each check."
+        )

--- a/src/repo_release_tools/mcp/resources.py
+++ b/src/repo_release_tools/mcp/resources.py
@@ -1,0 +1,90 @@
+"""Resource and resource-template registration for the rrt MCP server."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from fastmcp import FastMCP
+
+
+def _path_to_str(obj: Any) -> Any:
+    """Recursively convert Path objects to strings for JSON serialisation."""
+    if isinstance(obj, Path):
+        return str(obj)
+    if isinstance(obj, dict):
+        return {k: _path_to_str(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_path_to_str(i) for i in obj]
+    return obj
+
+
+def register_resources(mcp: FastMCP) -> None:
+    """Register resources and resource templates on *mcp*."""
+    from repo_release_tools.state import (
+        artifacts_lock_path,
+        health_lock_path,
+        read_lock,
+        rrt_dir,
+        tree_lock_path,
+    )
+
+    _LOCK_RESOLVER = {
+        "drift": lambda root: rrt_dir(root) / "drift.lock.toml",
+        "health": health_lock_path,
+        "tree": tree_lock_path,
+        "artifacts": artifacts_lock_path,
+    }
+
+    @mcp.resource("rrt://version", title="RRT Version", tags={"versioning"})
+    def resource_version() -> str:
+        """Current installed version of repo-release-tools."""
+        from repo_release_tools import __version__
+
+        return __version__
+
+    @mcp.resource("rrt://config", mime_type="application/json", title="RRT Config", tags={"config"})
+    def resource_config() -> str:
+        """Resolved rrt configuration as JSON."""
+        from repo_release_tools.config import load_or_autodetect_config
+
+        root = Path.cwd()
+        try:
+            config = load_or_autodetect_config(root)
+            return json.dumps(_path_to_str(asdict(config)), indent=2)
+        except Exception as exc:
+            return json.dumps({"error": str(exc)})
+
+    @mcp.resource(
+        "rrt://schema/config",
+        mime_type="application/json",
+        title="RRT Config Schema",
+        tags={"config", "schema"},
+    )
+    def resource_config_schema() -> str:
+        """JSON Schema for [tool.rrt] configuration — discover valid keys and value types."""
+        from repo_release_tools.commands.config_cmd import _load_schema
+
+        return json.dumps(_load_schema(), indent=2)
+
+    @mcp.resource("rrt://changelog", title="RRT Changelog", tags={"changelog"})
+    def resource_changelog() -> str:
+        """Full content of the repository CHANGELOG.md."""
+        changelog = Path.cwd() / "CHANGELOG.md"
+        if not changelog.exists():
+            return "No CHANGELOG.md found."
+        return changelog.read_text(encoding="utf-8")
+
+    @mcp.resource(
+        "rrt://locks/{name}", mime_type="application/json", title="RRT Lock File", tags={"locks"}
+    )
+    def resource_lock(name: str) -> str:
+        """Read a named rrt lock file. name: drift | health | tree | artifacts."""
+        valid = ", ".join(_LOCK_RESOLVER)
+        resolver = _LOCK_RESOLVER.get(name)
+        if resolver is None:
+            return json.dumps({"error": f"Unknown lock '{name}'. Valid: {valid}"})
+        root = Path.cwd()
+        return json.dumps(read_lock(resolver(root)), indent=2)

--- a/src/repo_release_tools/mcp/resources.py
+++ b/src/repo_release_tools/mcp/resources.py
@@ -23,6 +23,7 @@ def _path_to_str(obj: Any) -> Any:
 
 def register_resources(mcp: FastMCP) -> None:
     """Register resources and resource templates on *mcp*."""
+    from repo_release_tools.mcp.server import _find_repo_root
     from repo_release_tools.state import (
         artifacts_lock_path,
         health_lock_path,
@@ -50,7 +51,7 @@ def register_resources(mcp: FastMCP) -> None:
         """Resolved rrt configuration as JSON."""
         from repo_release_tools.config import load_or_autodetect_config
 
-        root = Path.cwd()
+        root = _find_repo_root()
         try:
             config = load_or_autodetect_config(root)
             return json.dumps(_path_to_str(asdict(config)), indent=2)
@@ -72,7 +73,7 @@ def register_resources(mcp: FastMCP) -> None:
     @mcp.resource("rrt://changelog", title="RRT Changelog", tags={"changelog"})
     def resource_changelog() -> str:
         """Full content of the repository CHANGELOG.md."""
-        changelog = Path.cwd() / "CHANGELOG.md"
+        changelog = _find_repo_root() / "CHANGELOG.md"
         if not changelog.exists():
             return "No CHANGELOG.md found."
         return changelog.read_text(encoding="utf-8")
@@ -86,5 +87,5 @@ def register_resources(mcp: FastMCP) -> None:
         resolver = _LOCK_RESOLVER.get(name)
         if resolver is None:
             return json.dumps({"error": f"Unknown lock '{name}'. Valid: {valid}"})
-        root = Path.cwd()
+        root = _find_repo_root()
         return json.dumps(read_lock(resolver(root)), indent=2)

--- a/src/repo_release_tools/mcp/server.py
+++ b/src/repo_release_tools/mcp/server.py
@@ -54,7 +54,8 @@ def create_server() -> FastMCP[Any]:
             "MCP server for repo-release-tools (rrt). "
             "Exposes version management, changelog, health/drift/tree/artifact lock inspection, "
             "branch and commit validation, and config introspection as MCP tools and resources. "
-            "All mutating tools (rrt_bump) default to dry_run=True for safety."
+            "Mutating tools rrt_bump, rrt_branch_new, and rrt_init_run default to dry_run=True "
+            "for safety."
         ),
         version=__version__,
         lifespan=_lifespan,

--- a/src/repo_release_tools/mcp/server.py
+++ b/src/repo_release_tools/mcp/server.py
@@ -1,0 +1,113 @@
+"""Main FastMCP server for rrt — exposes rrt capabilities as MCP tools, resources, and prompts."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any, AsyncGenerator
+
+from fastmcp import FastMCP
+
+from repo_release_tools import __version__
+
+from .apps import register_apps
+from .prompts import register_prompts
+from .resources import register_resources
+from .tools import register_tools
+
+
+def _find_repo_root() -> Path:
+    """Walk up from cwd to find the repo root (first dir containing .rrt/ or pyproject.toml)."""
+    cwd = Path.cwd()
+    return next(
+        (
+            p
+            for p in [cwd, *cwd.parents]
+            if (p / ".rrt").is_dir() or (p / "pyproject.toml").exists()
+        ),
+        cwd,
+    )
+
+
+@asynccontextmanager
+async def _lifespan(server: FastMCP[Any]) -> AsyncGenerator[dict[str, Any], None]:
+    """Load repo root and resolved config once at server startup."""
+    from repo_release_tools.config import load_or_autodetect_config
+
+    root = _find_repo_root()
+    try:
+        config = load_or_autodetect_config(root)
+    except (FileNotFoundError, ValueError, RuntimeError):
+        config = None
+    yield {"root": root, "config": config}
+
+
+def create_server() -> FastMCP[Any]:
+    """Create and configure the rrt FastMCP server."""
+    mcp: FastMCP[Any] = FastMCP(
+        name="repo-release-tools",
+        instructions=(
+            "MCP server for repo-release-tools (rrt). "
+            "Exposes version management, changelog, health/drift/tree/artifact lock inspection, "
+            "branch and commit validation, and config introspection as MCP tools and resources. "
+            "All mutating tools (rrt_bump) default to dry_run=True for safety."
+        ),
+        version=__version__,
+        lifespan=_lifespan,
+    )
+
+    register_tools(mcp)
+    register_resources(mcp)
+    register_prompts(mcp)
+    register_apps(mcp)
+
+    from fastmcp.apps.generative import GenerativeUI
+
+    mcp.add_provider(GenerativeUI())
+
+    return mcp
+
+
+def main() -> None:
+    """Entry point for the rrt-mcp CLI."""
+    import argparse
+    import sys
+
+    try:
+        import fastmcp  # noqa: F401
+    except ImportError:
+        sys.stderr.write("FastMCP is not installed. Run: pip install repo-release-tools[mcp]\n")
+        sys.exit(1)
+
+    parser = argparse.ArgumentParser(
+        prog="rrt-mcp",
+        description="Run the repo-release-tools MCP server.",
+    )
+    parser.add_argument(
+        "--transport",
+        choices=["stdio", "http"],
+        default="stdio",
+        help="Transport protocol (default: stdio for Claude Desktop)",
+    )
+    parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Bind host for HTTP transport (default: 127.0.0.1)",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=8000,
+        help="Port for HTTP transport (default: 8000)",
+    )
+    args = parser.parse_args()
+
+    server = create_server()
+    if args.transport == "http":
+        server.run(transport="http", host=args.host, port=args.port)
+    else:
+        server.run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/repo_release_tools/mcp/server.py
+++ b/src/repo_release_tools/mcp/server.py
@@ -35,11 +35,15 @@ async def _lifespan(server: FastMCP[Any]) -> AsyncGenerator[dict[str, Any], None
     from repo_release_tools.config import load_or_autodetect_config
 
     root = _find_repo_root()
+    config = None
+    config_error: str | None = None
     try:
         config = load_or_autodetect_config(root)
-    except (FileNotFoundError, ValueError, RuntimeError):
-        config = None
-    yield {"root": root, "config": config}
+    except FileNotFoundError:
+        pass
+    except (ValueError, RuntimeError) as exc:
+        config_error = str(exc)
+    yield {"root": root, "config": config, "config_error": config_error}
 
 
 def create_server() -> FastMCP[Any]:
@@ -109,5 +113,5 @@ def main() -> None:
         server.run(transport="stdio")
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main()

--- a/src/repo_release_tools/mcp/tools/__init__.py
+++ b/src/repo_release_tools/mcp/tools/__init__.py
@@ -1,4 +1,81 @@
-"""Tool registration for the rrt MCP server."""
+"""Tool registration for the rrt MCP server — structured tool modules.
+
+## Overview
+
+This package houses all rrt **MCP tools** — the callable functions that AI assistants
+invoke to inspect and mutate repo state.  Each module corresponds to one functional domain
+and exposes a single `register(mcp)` function that attaches its tools to the FastMCP
+instance.
+
+`register_tools(mcp)` (the public entry-point in this `__init__`) calls all six module
+registrations in dependency order.
+
+## Tool modules
+
+### `config_tools` → `rrt_config`, `rrt_doctor`
+
+- **`rrt_config`** — Returns the current `[tool.rrt]` configuration as a JSON object.
+  When no config is found the tool returns `{"error": "..."}` rather than raising.
+- **`rrt_doctor`** — Checks whether the project's automation tooling is wired correctly:
+  pre-commit hooks, lefthook, husky, and GitHub Actions workflow files.  Returns a
+  `DoctorResponse` with a `CheckResult` per component.
+
+### `lock_tools` → `rrt_health`, `rrt_drift`, `rrt_tree`, `rrt_artifacts`, `rrt_lock`
+
+- **`rrt_health`** — Reads `.rrt/health.lock.toml` and returns all health check entries
+  (status, message, updated_at) as a list.
+- **`rrt_drift`** — Reads `.rrt/drift.lock.toml` and returns source drift entries.
+  Drift indicates that source files have changed since the last `rrt drift update`.
+- **`rrt_tree`** — Reads `.rrt/tree.lock.toml` and returns the tree snapshot metadata
+  (tree_hash, entry_count, updated_at).
+- **`rrt_artifacts`** — Reads `.rrt/artifacts.lock.toml` and returns registered artifact
+  file metadata (path, description, hash, updated_at).
+- **`rrt_lock`** — Generic passthrough that reads any `.rrt/*.lock.toml` file and returns
+  its full parsed content.  Useful for inspecting lock files not covered by the typed tools.
+
+### `version_tools` → `rrt_version`, `rrt_bump`
+
+- **`rrt_version`** — Returns the current version for each configured version group.
+  Safe to call at any time; never modifies files.
+- **`rrt_bump`** — Preview or apply a semver bump across all version targets.  Defaults to
+  `dry_run=True` for safety; set `dry_run=False` only after the user explicitly confirms.
+  Accepts `level` = `"major"`, `"minor"`, or `"patch"`.
+
+### `validation_tools` → `rrt_validate_branch`, `rrt_validate_commit`
+
+- **`rrt_validate_branch`** — Validates a branch name against the project's configured
+  allow-list (conventional branch types + optional `extra_branch_types`).  Returns a
+  `BranchValidationResult` with `valid`, `branch`, and an optional `reason` on failure.
+- **`rrt_validate_commit`** — Validates a commit subject line against the Conventional
+  Commits spec as enforced by rrt's hook.  Returns a `CommitValidationResult`.
+
+### `changelog_tools` → `rrt_changelog`
+
+- **`rrt_changelog`** — Reads `CHANGELOG.md` and returns the entries for a given section
+  (default: `"Unreleased"`).  When `raw=True` the raw section text is returned instead of
+  a parsed entry list.  Returns a `ChangelogResponse`.
+
+### `git_tools` → `rrt_branch_new`
+
+- **`rrt_branch_new`** — Creates (or previews) a conventional branch from a type + slug.
+  Internally calls `rrt branch new <type> <description> [--scope <scope>]`.  Always
+  defaults to `dry_run=True`.  Returns a `BranchResult` with the full branch name and a
+  suggested commit title.
+
+## Response conventions
+
+All tools return Pydantic models (see `mcp.models`) serialised to JSON by FastMCP.
+Tools that can fail return an `error` field rather than raising an exception, so the
+AI assistant can report the failure gracefully without a tool error traceback.
+
+All mutating tools (`rrt_bump`, `rrt_branch_new`) default to `dry_run=True`.
+
+## Adding a new tool module
+
+1. Create `src/repo_release_tools/mcp/tools/my_tools.py` with a `register(mcp)` function.
+2. Import and call it in `register_tools()` here.
+3. Add corresponding tests in `tests/mcp/test_tools.py`.
+"""
 
 from __future__ import annotations
 

--- a/src/repo_release_tools/mcp/tools/__init__.py
+++ b/src/repo_release_tools/mcp/tools/__init__.py
@@ -20,7 +20,7 @@ registrations in dependency order.
   pre-commit hooks, lefthook, husky, and GitHub Actions workflow files.  Returns a
   `DoctorResponse` with a `CheckResult` per component.
 
-### `lock_tools` → `rrt_health`, `rrt_drift`, `rrt_tree`, `rrt_artifacts`, `rrt_lock`
+### `lock_tools` → `rrt_health`, `rrt_drift`, `rrt_tree`, `rrt_artifacts`
 
 - **`rrt_health`** — Reads `.rrt/health.lock.toml` and returns all health check entries
   (status, message, updated_at) as a list.
@@ -30,16 +30,13 @@ registrations in dependency order.
   (tree_hash, entry_count, updated_at).
 - **`rrt_artifacts`** — Reads `.rrt/artifacts.lock.toml` and returns registered artifact
   file metadata (path, description, hash, updated_at).
-- **`rrt_lock`** — Generic passthrough that reads any `.rrt/*.lock.toml` file and returns
-  its full parsed content.  Useful for inspecting lock files not covered by the typed tools.
-
 ### `version_tools` → `rrt_version`, `rrt_bump`
 
 - **`rrt_version`** — Returns the current version for each configured version group.
   Safe to call at any time; never modifies files.
 - **`rrt_bump`** — Preview or apply a semver bump across all version targets.  Defaults to
   `dry_run=True` for safety; set `dry_run=False` only after the user explicitly confirms.
-  Accepts `level` = `"major"`, `"minor"`, or `"patch"`.
+  Accepts `level` = `"major"`, `"minor"`, `"patch"`, `"alpha"`, `"beta"`, or `"rc"`.
 
 ### `validation_tools` → `rrt_validate_branch`, `rrt_validate_commit`
 
@@ -52,15 +49,14 @@ registrations in dependency order.
 ### `changelog_tools` → `rrt_changelog`
 
 - **`rrt_changelog`** — Reads `CHANGELOG.md` and returns the entries for a given section
-  (default: `"Unreleased"`).  When `raw=True` the raw section text is returned instead of
-  a parsed entry list.  Returns a `ChangelogResponse`.
+  (default: `"Unreleased"`). Returns a `ChangelogResponse`.
 
 ### `git_tools` → `rrt_branch_new`
 
 - **`rrt_branch_new`** — Creates (or previews) a conventional branch from a type + slug.
-  Internally calls `rrt branch new <type> <description> [--scope <scope>]`.  Always
-  defaults to `dry_run=True`.  Returns a `BranchResult` with the full branch name and a
-  suggested commit title.
+  Uses rrt branch naming helpers and runs `git checkout -b` when `dry_run=False`.
+  Always defaults to `dry_run=True`. Returns a `BranchResult` with the full branch name
+  and a suggested commit title.
 
 ## Response conventions
 

--- a/src/repo_release_tools/mcp/tools/__init__.py
+++ b/src/repo_release_tools/mcp/tools/__init__.py
@@ -1,0 +1,22 @@
+"""Tool registration for the rrt MCP server."""
+
+from __future__ import annotations
+
+from fastmcp import FastMCP
+
+from .changelog_tools import register as register_changelog
+from .config_tools import register as register_config
+from .git_tools import register as register_git
+from .lock_tools import register as register_locks
+from .validation_tools import register as register_validation
+from .version_tools import register as register_version
+
+
+def register_tools(mcp: FastMCP) -> None:
+    """Register all rrt tools on the given FastMCP instance."""
+    register_config(mcp)
+    register_locks(mcp)
+    register_version(mcp)
+    register_validation(mcp)
+    register_changelog(mcp)
+    register_git(mcp)

--- a/src/repo_release_tools/mcp/tools/changelog_tools.py
+++ b/src/repo_release_tools/mcp/tools/changelog_tools.py
@@ -1,0 +1,48 @@
+"""Changelog tools for the rrt MCP server."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastmcp import Context, FastMCP
+from mcp.types import ToolAnnotations
+
+from repo_release_tools import __version__ as _PKG_VERSION
+from repo_release_tools.mcp.models import ChangelogResponse, LockError
+
+
+def register(mcp: FastMCP) -> None:
+    """Register changelog tools on *mcp*."""
+
+    @mcp.tool(
+        title="RRT Changelog Reader",
+        tags={"changelog"},
+        version=_PKG_VERSION,
+        annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
+        meta={"domain": "rrt", "surface": "mcp"},
+    )
+    def rrt_changelog(ctx: Context, section: str = "unreleased") -> ChangelogResponse | LockError:
+        """Read changelog content. section: 'unreleased' (default) returns pending entries only; 'full' returns everything."""
+        from repo_release_tools.changelog import get_unreleased_entries
+
+        config = ctx.lifespan_context.get("config")
+        root: Path = ctx.lifespan_context.get("root", Path.cwd())
+
+        if config is not None and config.version_groups:
+            changelog_path = config.version_groups[0].changelog_file
+        else:
+            changelog_path = root / "CHANGELOG.md"
+
+        if not changelog_path.exists():
+            return LockError(
+                error=f"Changelog not found at {changelog_path}",
+                hint="Create a CHANGELOG.md or configure changelog_file in [tool.rrt].",
+            )
+
+        text = changelog_path.read_text(encoding="utf-8")
+
+        if section == "full":
+            return ChangelogResponse(path=str(changelog_path), section="full", content=text)
+
+        entries = get_unreleased_entries(text)
+        return ChangelogResponse(path=str(changelog_path), section="unreleased", entries=entries)

--- a/src/repo_release_tools/mcp/tools/config_tools.py
+++ b/src/repo_release_tools/mcp/tools/config_tools.py
@@ -1,0 +1,86 @@
+"""Config and doctor tools for the rrt MCP server."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from fastmcp import Context, FastMCP
+from mcp.types import ToolAnnotations
+
+from repo_release_tools import __version__ as _PKG_VERSION
+from repo_release_tools.mcp.models import CheckResult, ConfigError, DoctorResponse
+
+
+def _path_to_str(obj: Any) -> Any:
+    """Recursively convert Path objects to strings for JSON serialisation."""
+    if isinstance(obj, Path):
+        return str(obj)
+    if isinstance(obj, dict):
+        return {k: _path_to_str(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_path_to_str(i) for i in obj]
+    return obj
+
+
+def register(mcp: FastMCP) -> None:
+    """Register config and doctor tools on *mcp*."""
+
+    @mcp.tool(
+        title="RRT Config Inspector",
+        tags={"config", "inspection"},
+        version=_PKG_VERSION,
+        annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
+        meta={"domain": "rrt", "surface": "mcp"},
+    )
+    def rrt_config(ctx: Context) -> dict[str, Any] | ConfigError:
+        """Return the resolved rrt configuration as a JSON-serialisable dict."""
+        config = ctx.lifespan_context.get("config")
+        if config is None:
+            return ConfigError(error="No rrt configuration found in this repository.")
+        try:
+            return _path_to_str(asdict(config))
+        except Exception as exc:
+            return ConfigError(error=str(exc))
+
+    @mcp.tool(
+        title="RRT Doctor",
+        tags={"config", "inspection"},
+        version=_PKG_VERSION,
+        annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
+        meta={"domain": "rrt", "surface": "mcp"},
+    )
+    def rrt_doctor(ctx: Context) -> DoctorResponse | ConfigError:
+        """Run rrt health checks (pre-commit, lefthook, husky, workflows) and return structured results."""
+        from repo_release_tools.commands.doctor import (
+            _check_github_workflows,
+            _check_husky,
+            _check_text_integration,
+        )
+
+        root: Path = ctx.lifespan_context.get("root", Path.cwd())
+        raw = {
+            "pre_commit": _check_text_integration(
+                root,
+                ".pre-commit-config.yaml",
+                markers=("repo-release-tools", "rrt-"),
+                success_message=".pre-commit-config.yaml includes repo-release-tools hooks",
+                warning_message=".pre-commit-config.yaml exists but no repo-release-tools hooks detected",
+            ),
+            "lefthook": _check_text_integration(
+                root,
+                "lefthook.yml",
+                markers=("rrt-hooks", "repo-release-tools"),
+                success_message="lefthook.yml includes repo-release-tools hooks",
+                warning_message="lefthook.yml exists but no repo-release-tools hooks detected",
+            ),
+            "husky": _check_husky(root),
+            "workflows": _check_github_workflows(root),
+        }
+        return DoctorResponse(
+            **{
+                name: CheckResult(message=msg, ok=ok, severity=sev)
+                for name, (msg, ok, sev) in raw.items()
+            }
+        )

--- a/src/repo_release_tools/mcp/tools/config_tools.py
+++ b/src/repo_release_tools/mcp/tools/config_tools.py
@@ -36,6 +36,9 @@ def register(mcp: FastMCP) -> None:
     )
     def rrt_config(ctx: Context) -> dict[str, Any] | ConfigError:
         """Return the resolved rrt configuration as a JSON-serialisable dict."""
+        config_error = ctx.lifespan_context.get("config_error")
+        if config_error is not None:
+            return ConfigError(error=f"Invalid rrt configuration: {config_error}")
         config = ctx.lifespan_context.get("config")
         if config is None:
             return ConfigError(error="No rrt configuration found in this repository.")

--- a/src/repo_release_tools/mcp/tools/git_tools.py
+++ b/src/repo_release_tools/mcp/tools/git_tools.py
@@ -51,6 +51,8 @@ def register(mcp: FastMCP) -> None:
         await ctx.info(f"Branch target: {branch_name} (suggested title: {commit_title})")
 
         if not dry_run:
+            import subprocess as _sp
+
             await ctx.warning(f"Creating branch '{branch_name}' — this modifies git state")
             if git.branch_exists(root, branch_name):
                 return BranchResult(
@@ -60,9 +62,21 @@ def register(mcp: FastMCP) -> None:
                     suggested_commit_title=commit_title,
                     error=f"Branch '{branch_name}' already exists. Delete it first or choose a different description.",
                 )
-            git.run(
-                ["git", "checkout", "-b", branch_name], root, dry_run=False, label="git checkout -b"
+            _result = _sp.run(
+                ["git", "checkout", "-b", branch_name],
+                cwd=root,
+                capture_output=True,
+                text=True,
             )
+            if _result.returncode != 0:
+                return BranchResult(
+                    branch=branch_name,
+                    created=False,
+                    dry_run=False,
+                    suggested_commit_title=commit_title,
+                    error=f"git checkout -b failed: {(_result.stderr or _result.stdout).strip()}",
+                )
+            await ctx.info(f"Created branch '{branch_name}'")
 
         return BranchResult(
             branch=branch_name,

--- a/src/repo_release_tools/mcp/tools/git_tools.py
+++ b/src/repo_release_tools/mcp/tools/git_tools.py
@@ -1,0 +1,72 @@
+"""Git workflow tools for the rrt MCP server."""
+
+from __future__ import annotations
+
+from fastmcp import Context, FastMCP
+from mcp.types import ToolAnnotations
+
+from repo_release_tools import __version__ as _PKG_VERSION
+from repo_release_tools.mcp.models import BranchResult
+
+
+def register(mcp: FastMCP) -> None:
+    """Register git workflow tools on *mcp*."""
+
+    @mcp.tool(
+        title="RRT Branch New",
+        tags={"git", "branching"},
+        version=_PKG_VERSION,
+        annotations=ToolAnnotations(destructiveHint=True),
+        timeout=10.0,
+        meta={"domain": "rrt", "surface": "mcp"},
+    )
+    async def rrt_branch_new(
+        ctx: Context,
+        commit_type: str,
+        description: str,
+        scope: str | None = None,
+        dry_run: bool = True,
+    ) -> BranchResult:
+        """Create a new conventionally-named branch. commit_type: feat|fix|chore|docs|refactor|test|ci|perf|style|build. dry_run=True by default."""
+        from pathlib import Path
+
+        from repo_release_tools.commands.branch import CONVENTIONAL_TYPES, BranchName
+        from repo_release_tools.workflow import git
+
+        if commit_type not in CONVENTIONAL_TYPES:
+            allowed = ", ".join(CONVENTIONAL_TYPES)
+            return BranchResult(
+                branch="",
+                created=False,
+                dry_run=dry_run,
+                suggested_commit_title="",
+                error=f"Invalid commit type. Choose one of: {allowed}",
+            )
+
+        root: Path = ctx.lifespan_context.get("root", Path.cwd())
+        branch = BranchName(type=commit_type, description=description, scope=scope)
+        branch_name = branch.slug()
+        commit_title = branch.commit_title()
+
+        await ctx.info(f"Branch target: {branch_name} (suggested title: {commit_title})")
+
+        if not dry_run:
+            await ctx.warning(f"Creating branch '{branch_name}' — this modifies git state")
+            if git.branch_exists(root, branch_name):
+                return BranchResult(
+                    branch=branch_name,
+                    created=False,
+                    dry_run=False,
+                    suggested_commit_title=commit_title,
+                    error=f"Branch '{branch_name}' already exists. Delete it first or choose a different description.",
+                )
+            git.run(
+                ["git", "checkout", "-b", branch_name], root, dry_run=False, label="git checkout -b"
+            )
+
+        return BranchResult(
+            branch=branch_name,
+            created=not dry_run,
+            dry_run=dry_run,
+            suggested_commit_title=commit_title,
+        )

--- a/src/repo_release_tools/mcp/tools/git_tools.py
+++ b/src/repo_release_tools/mcp/tools/git_tools.py
@@ -62,12 +62,22 @@ def register(mcp: FastMCP) -> None:
                     suggested_commit_title=commit_title,
                     error=f"Branch '{branch_name}' already exists. Delete it first or choose a different description.",
                 )
-            _result = _sp.run(
-                ["git", "checkout", "-b", branch_name],
-                cwd=root,
-                capture_output=True,
-                text=True,
-            )
+            try:
+                _result = _sp.run(
+                    ["git", "checkout", "-b", branch_name],
+                    cwd=root,
+                    capture_output=True,
+                    text=True,
+                    timeout=8.0,
+                )
+            except _sp.TimeoutExpired:
+                return BranchResult(
+                    branch=branch_name,
+                    created=False,
+                    dry_run=False,
+                    suggested_commit_title=commit_title,
+                    error="git checkout -b timed out after 8 seconds.",
+                )
             if _result.returncode != 0:
                 return BranchResult(
                     branch=branch_name,

--- a/src/repo_release_tools/mcp/tools/lock_tools.py
+++ b/src/repo_release_tools/mcp/tools/lock_tools.py
@@ -1,0 +1,83 @@
+"""Lock file tools for the rrt MCP server."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from fastmcp import Context, FastMCP
+from mcp.types import ToolAnnotations
+
+from repo_release_tools import __version__ as _PKG_VERSION
+
+
+def register(mcp: FastMCP) -> None:
+    """Register lock-file inspection tools on *mcp*."""
+
+    @mcp.tool(
+        title="RRT Health Lock",
+        tags={"locks", "inspection"},
+        version=_PKG_VERSION,
+        annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
+        meta={"domain": "rrt", "surface": "mcp"},
+    )
+    def rrt_health(ctx: Context) -> dict[str, Any]:
+        """Return the health check results from .rrt/health.lock.toml."""
+        from repo_release_tools.state import health_lock_path, read_lock
+
+        root: Path = ctx.lifespan_context.get("root", Path.cwd())
+        data = read_lock(health_lock_path(root))
+        if not data:
+            return {"error": "No health lock found. Run: rrt doctor --snapshot"}
+        return data
+
+    @mcp.tool(
+        title="RRT Drift Lock",
+        tags={"locks", "inspection"},
+        version=_PKG_VERSION,
+        annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
+        meta={"domain": "rrt", "surface": "mcp"},
+    )
+    def rrt_drift(ctx: Context) -> dict[str, Any]:
+        """Return source drift state from .rrt/drift.lock.toml (file hashes and symbols)."""
+        from repo_release_tools.state import read_lock, rrt_dir
+
+        root: Path = ctx.lifespan_context.get("root", Path.cwd())
+        data = read_lock(rrt_dir(root) / "drift.lock.toml")
+        if not data:
+            return {"error": "No drift lock found. Run: rrt drift --snapshot"}
+        return data
+
+    @mcp.tool(
+        title="RRT Tree Lock",
+        tags={"locks", "inspection"},
+        version=_PKG_VERSION,
+        annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
+        meta={"domain": "rrt", "surface": "mcp"},
+    )
+    def rrt_tree(ctx: Context) -> dict[str, Any]:
+        """Return the repository tree snapshot from .rrt/tree.lock.toml."""
+        from repo_release_tools.state import read_lock, tree_lock_path
+
+        root: Path = ctx.lifespan_context.get("root", Path.cwd())
+        data = read_lock(tree_lock_path(root))
+        if not data:
+            return {"error": "No tree lock found. Run: rrt tree --snapshot"}
+        return data
+
+    @mcp.tool(
+        title="RRT Artifacts Lock",
+        tags={"locks", "inspection"},
+        version=_PKG_VERSION,
+        annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
+        meta={"domain": "rrt", "surface": "mcp"},
+    )
+    def rrt_artifacts(ctx: Context) -> dict[str, Any]:
+        """Return the artifact integrity map from .rrt/artifacts.lock.toml."""
+        from repo_release_tools.state import artifacts_lock_path, read_lock
+
+        root: Path = ctx.lifespan_context.get("root", Path.cwd())
+        data = read_lock(artifacts_lock_path(root))
+        if not data:
+            return {"error": "No artifacts lock found. Run: rrt artifacts --snapshot"}
+        return data

--- a/src/repo_release_tools/mcp/tools/validation_tools.py
+++ b/src/repo_release_tools/mcp/tools/validation_tools.py
@@ -29,7 +29,7 @@ def register(mcp: FastMCP) -> None:
         root = ctx.lifespan_context.get("root", Path.cwd())
         try:
             extra = load_extra_branch_types(root)
-        except Exception:
+        except FileNotFoundError:
             extra = ()
         error = validate_branch_name(branch_name, extra_types=extra)
         if error is None:
@@ -51,7 +51,7 @@ def register(mcp: FastMCP) -> None:
         root = ctx.lifespan_context.get("root", Path.cwd())
         try:
             extra = load_extra_branch_types(root)
-        except Exception:
+        except FileNotFoundError:
             extra = ()
         error = validate_commit_subject(subject, extra)
         if error is None:

--- a/src/repo_release_tools/mcp/tools/validation_tools.py
+++ b/src/repo_release_tools/mcp/tools/validation_tools.py
@@ -1,0 +1,59 @@
+"""Branch and commit validation tools for the rrt MCP server."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastmcp import Context, FastMCP
+from mcp.types import ToolAnnotations
+
+from repo_release_tools import __version__ as _PKG_VERSION
+from repo_release_tools.mcp.models import BranchValidationResult, CommitValidationResult
+
+
+def register(mcp: FastMCP) -> None:
+    """Register branch and commit validation tools on *mcp*."""
+
+    @mcp.tool(
+        title="RRT Branch Validator",
+        tags={"validation"},
+        version=_PKG_VERSION,
+        annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
+        meta={"domain": "rrt", "surface": "mcp"},
+    )
+    def rrt_validate_branch(ctx: Context, branch_name: str) -> BranchValidationResult:
+        """Validate a branch name against rrt's conventional naming rules."""
+        from repo_release_tools.config import load_extra_branch_types
+        from repo_release_tools.workflow.hooks import validate_branch_name
+
+        root = ctx.lifespan_context.get("root", Path.cwd())
+        try:
+            extra = load_extra_branch_types(root)
+        except Exception:
+            extra = ()
+        error = validate_branch_name(branch_name, extra_types=extra)
+        if error is None:
+            return BranchValidationResult(valid=True, branch=branch_name)
+        return BranchValidationResult(valid=False, branch=branch_name, reason=error)
+
+    @mcp.tool(
+        title="RRT Commit Validator",
+        tags={"validation"},
+        version=_PKG_VERSION,
+        annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
+        meta={"domain": "rrt", "surface": "mcp"},
+    )
+    def rrt_validate_commit(ctx: Context, subject: str) -> CommitValidationResult:
+        """Validate a commit subject line against Conventional Commits rules."""
+        from repo_release_tools.config import load_extra_branch_types
+        from repo_release_tools.workflow.hooks import validate_commit_subject
+
+        root = ctx.lifespan_context.get("root", Path.cwd())
+        try:
+            extra = load_extra_branch_types(root)
+        except Exception:
+            extra = ()
+        error = validate_commit_subject(subject, extra)
+        if error is None:
+            return CommitValidationResult(valid=True, subject=subject)
+        return CommitValidationResult(valid=False, subject=subject, reason=error)

--- a/src/repo_release_tools/mcp/tools/version_tools.py
+++ b/src/repo_release_tools/mcp/tools/version_tools.py
@@ -1,0 +1,95 @@
+"""Version tools for the rrt MCP server."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastmcp import Context, FastMCP
+from mcp.types import ToolAnnotations
+
+from repo_release_tools import __version__ as _PKG_VERSION
+from repo_release_tools.mcp.models import BumpGroupResult, ConfigError, VersionGroupResult
+
+
+def register(mcp: FastMCP) -> None:
+    """Register version read/bump tools on *mcp*."""
+
+    @mcp.tool(
+        title="RRT Version Reader",
+        tags={"versioning"},
+        version=_PKG_VERSION,
+        annotations=ToolAnnotations(readOnlyHint=True, idempotentHint=True),
+        meta={"domain": "rrt", "surface": "mcp"},
+    )
+    def rrt_version(ctx: Context) -> list[VersionGroupResult] | ConfigError:
+        """Return the current version from each version group's primary target."""
+        from repo_release_tools.version.targets import read_version_string
+
+        config = ctx.lifespan_context.get("config")
+        if config is None:
+            return ConfigError(error="No rrt configuration found.")
+        results: list[VersionGroupResult] = []
+        for group in config.version_groups:
+            try:
+                ver = read_version_string(group.primary_target())
+                results.append(VersionGroupResult(group=group.name, version=ver))
+            except (RuntimeError, OSError) as exc:
+                results.append(VersionGroupResult(group=group.name, version="", error=str(exc)))
+        return results
+
+    @mcp.tool(
+        title="RRT Version Bump",
+        tags={"versioning"},
+        version=_PKG_VERSION,
+        annotations=ToolAnnotations(destructiveHint=True),
+        timeout=30.0,
+        meta={"domain": "rrt", "surface": "mcp"},
+    )
+    async def rrt_bump(
+        ctx: Context,
+        level: str,
+        dry_run: bool = True,
+    ) -> list[BumpGroupResult] | dict[str, Any]:
+        """Preview or apply a version bump. level: major | minor | patch | alpha | beta | rc. dry_run=True by default."""
+        valid_levels = ("major", "minor", "patch", "alpha", "beta", "rc")
+        if level not in valid_levels:
+            return {"error": f"level must be one of: {', '.join(valid_levels)}"}
+
+        config = ctx.lifespan_context.get("config")
+        if config is None:
+            return {"error": "No rrt configuration found."}
+
+        from repo_release_tools.version.semver import Version
+        from repo_release_tools.version.targets import read_version_string
+
+        groups = config.version_groups
+        total = float(len(groups))
+        results: list[BumpGroupResult] = []
+        for i, group in enumerate(groups):
+            await ctx.report_progress(float(i), total)
+            try:
+                current = read_version_string(group.primary_target())
+                new_ver = str(Version.parse(current).bump(level))
+                await ctx.info(
+                    f"{'Would bump' if dry_run else 'Bumping'} {group.name}: {current} → {new_ver}"
+                )
+                applied = False
+                if not dry_run:
+                    from repo_release_tools.version.targets import replace_version_in_file
+
+                    for target in group.version_targets:
+                        replace_version_in_file(target, new_ver, dry_run=False)
+                    applied = True
+                results.append(
+                    BumpGroupResult(
+                        group=group.name,
+                        current=current,
+                        new=new_ver,
+                        dry_run=dry_run,
+                        applied=applied,
+                    )
+                )
+            except (RuntimeError, OSError, ValueError) as exc:
+                results.append(BumpGroupResult(group=group.name, error=str(exc)))
+        await ctx.report_progress(total, total)
+        return results

--- a/src/repo_release_tools/mcp/tools/version_tools.py
+++ b/src/repo_release_tools/mcp/tools/version_tools.py
@@ -72,7 +72,6 @@ def register(mcp: FastMCP) -> None:
         total = float(len(groups))
         results: list[BumpGroupResult] = []
         for i, group in enumerate(groups):
-            await ctx.report_progress(float(i), total)
             try:
                 current = read_version_string(group.primary_target())
                 new_ver = str(Version.parse(current).bump(level))
@@ -102,5 +101,8 @@ def register(mcp: FastMCP) -> None:
                 )
             except (RuntimeError, OSError, ValueError) as exc:
                 results.append(BumpGroupResult(group=group.name, error=str(exc)))
-        await ctx.report_progress(total, total)
+            if total > 0:
+                await ctx.report_progress(float(i + 1), total)
+        if total > 0:
+            await ctx.report_progress(total, total)
         return results

--- a/src/repo_release_tools/mcp/tools/version_tools.py
+++ b/src/repo_release_tools/mcp/tools/version_tools.py
@@ -25,6 +25,9 @@ def register(mcp: FastMCP) -> None:
         """Return the current version from each version group's primary target."""
         from repo_release_tools.version.targets import read_version_string
 
+        config_error = ctx.lifespan_context.get("config_error")
+        if config_error is not None:
+            return ConfigError(error=f"Invalid rrt configuration: {config_error}")
         config = ctx.lifespan_context.get("config")
         if config is None:
             return ConfigError(error="No rrt configuration found.")
@@ -55,6 +58,9 @@ def register(mcp: FastMCP) -> None:
         if level not in valid_levels:
             return {"error": f"level must be one of: {', '.join(valid_levels)}"}
 
+        config_error = ctx.lifespan_context.get("config_error")
+        if config_error is not None:
+            return {"error": f"Invalid rrt configuration: {config_error}"}
         config = ctx.lifespan_context.get("config")
         if config is None:
             return {"error": "No rrt configuration found."}
@@ -75,10 +81,15 @@ def register(mcp: FastMCP) -> None:
                 )
                 applied = False
                 if not dry_run:
+                    import contextlib
+                    import io
+
                     from repo_release_tools.version.targets import replace_version_in_file
 
                     for target in group.version_targets:
-                        replace_version_in_file(target, new_ver, dry_run=False)
+                        with contextlib.redirect_stdout(io.StringIO()):
+                            replace_version_in_file(target, new_ver, dry_run=False)
+                        await ctx.info(f"Updated {target.path}")
                     applied = True
                 results.append(
                     BumpGroupResult(

--- a/tests/commands/test_skill.py
+++ b/tests/commands/test_skill.py
@@ -26,6 +26,7 @@ EXPECTED_SKILL_NAMES = {
     "rrt-user-config-safety",
     "rrt-user-ci-readiness",
     "rrt-user-migration-uvx-to-installed",
+    "rrt-user-mcp-server",
 }
 
 

--- a/tests/mcp/conftest.py
+++ b/tests/mcp/conftest.py
@@ -1,0 +1,69 @@
+"""Shared fixtures and helpers for MCP tests.
+
+All tests in this package require the [mcp] optional extra.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+fastmcp = pytest.importorskip("fastmcp", reason="[mcp] extra not installed")
+
+pytestmark = pytest.mark.mcp
+
+
+class _CaptureMCP:
+    """Minimal FastMCP shim that captures inner decorated functions for unit testing.
+
+    Replaces FastMCP in registration calls so that each inner tool/resource/prompt
+    function can be extracted and called directly with a mocked Context.
+    """
+
+    def __init__(self) -> None:
+        self._tools: dict[str, Any] = {}
+        self._resources: dict[str, Any] = {}
+        self._prompts: dict[str, Any] = {}
+
+    def tool(self, *args: Any, **kwargs: Any) -> Any:
+        def decorator(fn: Any) -> Any:
+            self._tools[fn.__name__] = fn
+            return fn
+
+        return decorator
+
+    def resource(self, *args: Any, **kwargs: Any) -> Any:
+        def decorator(fn: Any) -> Any:
+            self._resources[fn.__name__] = fn
+            return fn
+
+        return decorator
+
+    def prompt(self, *args: Any, **kwargs: Any) -> Any:
+        def decorator(fn: Any) -> Any:
+            self._prompts[fn.__name__] = fn
+            return fn
+
+        return decorator
+
+    def add_provider(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+
+@pytest.fixture
+def capture_mcp() -> _CaptureMCP:
+    """Return a fresh _CaptureMCP instance."""
+    return _CaptureMCP()
+
+
+@pytest.fixture
+def mock_ctx(tmp_path: Any) -> MagicMock:
+    """Return a MagicMock Context with a tmp_path root and no config."""
+    ctx = MagicMock()
+    ctx.lifespan_context = {"root": tmp_path, "config": None}
+    ctx.info = AsyncMock()
+    ctx.warning = AsyncMock()
+    ctx.report_progress = AsyncMock()
+    return ctx

--- a/tests/mcp/conftest.py
+++ b/tests/mcp/conftest.py
@@ -10,7 +10,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-fastmcp = pytest.importorskip("fastmcp", reason="[mcp] extra not installed")
+pytest.importorskip("fastmcp", reason="[mcp] extra not installed")
 
 pytestmark = pytest.mark.mcp
 

--- a/tests/mcp/test_apps.py
+++ b/tests/mcp/test_apps.py
@@ -350,13 +350,16 @@ def test_rrt_init_run_dry_run(tmp_path: Path) -> None:
     tools = _registered(tmp_path)
     ctx = _ctx(tmp_path)
     fake_proc = MagicMock(stdout="Would write .rrt.toml", stderr="", returncode=0)
+    mock_run = MagicMock(return_value=fake_proc)
 
     async def _run() -> str:
-        with patch("subprocess.run", return_value=fake_proc):
+        with patch("subprocess.run", mock_run):
             return await tools["rrt_init_run"](ctx)
 
     result = asyncio.run(_run())
     assert "Would write" in result
+    mock_run.assert_called_once()
+    assert mock_run.call_args.kwargs["timeout"] == 20.0
 
 
 def test_rrt_init_run_apply(tmp_path: Path) -> None:
@@ -382,7 +385,8 @@ def test_rrt_init_run_with_stderr(tmp_path: Path) -> None:
             return await tools["rrt_init_run"](ctx)
 
     result = asyncio.run(_run())
-    assert "[stderr]" in result
+    assert "[error]" in result
+    assert "some warning" in result
 
 
 def test_rrt_init_run_empty_output(tmp_path: Path) -> None:
@@ -410,6 +414,21 @@ def test_rrt_init_run_nonzero_no_output(tmp_path: Path) -> None:
     result = asyncio.run(_run())
     assert "[error]" in result
     assert "1" in result
+
+
+def test_rrt_init_run_timeout(tmp_path: Path) -> None:
+    tools = _registered(tmp_path)
+    ctx = _ctx(tmp_path)
+
+    async def _run() -> str:
+        with patch(
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd=["python", "-m", "repo_release_tools.cli"], timeout=20),
+        ):
+            return await tools["rrt_init_run"](ctx)
+
+    result = asyncio.run(_run())
+    assert result == "[error]: rrt init timed out after 20 seconds"
 
 
 # ── rrt_locks_overview ────────────────────────────────────────────────────────

--- a/tests/mcp/test_apps.py
+++ b/tests/mcp/test_apps.py
@@ -1,0 +1,468 @@
+"""Tests for MCP PrefabApp dashboards and helper functions (apps.py)."""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytest.importorskip("fastmcp", reason="[mcp] extra not installed")
+
+from prefab_ui.app import PrefabApp
+
+from repo_release_tools.mcp.apps import (
+    RrtInitForm,
+    _badge_variant,
+    _overall_badge,
+    _severity_icon,
+    register_apps,
+)
+
+pytestmark = pytest.mark.mcp
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+class _CaptureMCP:
+    def __init__(self) -> None:
+        self._tools: dict[str, Any] = {}
+
+    def tool(self, *args: Any, **kwargs: Any) -> Any:
+        def decorator(fn: Any) -> Any:
+            self._tools[fn.__name__] = fn
+            return fn
+
+        return decorator
+
+    def add_provider(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+
+def _ctx(tmp_path: Path, config: Any = None) -> MagicMock:
+    ctx = MagicMock()
+    ctx.lifespan_context = {"root": tmp_path, "config": config}
+    ctx.info = AsyncMock()
+    ctx.warning = AsyncMock()
+    ctx.report_progress = AsyncMock()
+    return ctx
+
+
+def _registered(tmp_path: Path) -> dict[str, Any]:
+    mcp: _CaptureMCP = _CaptureMCP()
+    register_apps(mcp)  # ty: ignore[invalid-argument-type]
+    return mcp._tools
+
+
+# ── _severity_icon ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "sev, expected",
+    [("ok", "✓"), ("warning", "⚠"), ("error", "✗"), ("unknown", "?")],
+)
+def test_severity_icon(sev: str, expected: str) -> None:
+    assert _severity_icon(sev) == expected
+
+
+# ── _badge_variant ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "sev, expected",
+    [("ok", "success"), ("warning", "warning"), ("error", "destructive"), ("other", "secondary")],
+)
+def test_badge_variant(sev: str, expected: str) -> None:
+    assert _badge_variant(sev) == expected
+
+
+# ── _overall_badge ────────────────────────────────────────────────────────────
+
+
+def test_overall_badge_empty() -> None:
+    label, variant = _overall_badge([])
+    assert label == "All Healthy"
+    assert variant == "success"
+
+
+def test_overall_badge_all_ok() -> None:
+    label, variant = _overall_badge(["ok", "ok"])
+    assert label == "All Healthy"
+
+
+def test_overall_badge_warning() -> None:
+    label, variant = _overall_badge(["ok", "warning"])
+    assert label == "Warnings"
+    assert variant == "warning"
+
+
+def test_overall_badge_error() -> None:
+    label, variant = _overall_badge(["ok", "error"])
+    assert label == "Errors"
+    assert variant == "destructive"
+
+
+# ── RrtInitForm ───────────────────────────────────────────────────────────────
+
+
+def test_rrt_init_form_defaults() -> None:
+    form = RrtInitForm()
+    assert form.target == "rrt-toml"
+    assert form.dry_run is True
+    assert form.force is False
+
+
+def test_rrt_init_form_custom() -> None:
+    form = RrtInitForm(target="pyproject", dry_run=False, force=True)
+    assert form.target == "pyproject"
+    assert form.dry_run is False
+    assert form.force is True
+
+
+# ── register_apps ─────────────────────────────────────────────────────────────
+
+
+def test_register_apps_registers_all_tools(tmp_path: Path) -> None:
+    tools = _registered(tmp_path)
+    expected = {
+        "rrt_health_dashboard",
+        "rrt_version_overview",
+        "rrt_doctor_dashboard",
+        "rrt_tree_dashboard",
+        "rrt_init",
+        "rrt_init_run",
+        "rrt_locks_overview",
+    }
+    assert expected <= set(tools.keys())
+
+
+# ── rrt_health_dashboard ──────────────────────────────────────────────────────
+
+
+def test_health_dashboard_empty_state(tmp_path: Path) -> None:
+    tools = _registered(tmp_path)
+    ctx = _ctx(tmp_path)
+    with patch("repo_release_tools.state.read_lock", return_value={}):
+        result = tools["rrt_health_dashboard"](ctx)
+    assert isinstance(result, PrefabApp)
+
+
+def test_health_dashboard_ok_checks(tmp_path: Path) -> None:
+    tools = _registered(tmp_path)
+    rrt = tmp_path / ".rrt"
+    rrt.mkdir()
+    (rrt / "health.lock.toml").write_text(
+        '[checks]\n[checks.lint]\nstatus = "ok"\nmessage = "pass"\nupdated_at = "now"\n'
+    )
+    (rrt / "tree.lock.toml").write_text(
+        '[snapshot]\ntree_hash = "abc123xyz"\nentry_count = 10\nupdated_at = "now"\n'
+    )
+    ctx = _ctx(tmp_path)
+    result = tools["rrt_health_dashboard"](ctx)
+    assert isinstance(result, PrefabApp)
+
+
+def test_health_dashboard_error_checks(tmp_path: Path) -> None:
+    tools = _registered(tmp_path)
+    rrt = tmp_path / ".rrt"
+    rrt.mkdir()
+    (rrt / "health.lock.toml").write_text(
+        '[checks]\n[checks.lint]\nstatus = "error"\nmessage = "fail"\n'
+    )
+    ctx = _ctx(tmp_path)
+    result = tools["rrt_health_dashboard"](ctx)
+    assert isinstance(result, PrefabApp)
+
+
+def test_health_dashboard_warning_checks(tmp_path: Path) -> None:
+    tools = _registered(tmp_path)
+    rrt = tmp_path / ".rrt"
+    rrt.mkdir()
+    (rrt / "health.lock.toml").write_text(
+        '[checks]\n[checks.lint]\nstatus = "warning"\nmessage = "warn"\n'
+    )
+    (rrt / "artifacts.lock.toml").write_text(
+        '[files]\n[files."dist/pkg.whl"]\ndescription = "wheel"\nupdated_at = "now"\n'
+    )
+    (rrt / "drift.lock.toml").write_text(
+        '[sources]\n[sources.src]\nlang = "python"\nupdated_at = "now"\n'
+    )
+    ctx = _ctx(tmp_path)
+    result = tools["rrt_health_dashboard"](ctx)
+    assert isinstance(result, PrefabApp)
+
+
+# ── rrt_version_overview ──────────────────────────────────────────────────────
+
+
+def test_version_overview_no_config(tmp_path: Path) -> None:
+    tools = _registered(tmp_path)
+    ctx = _ctx(tmp_path, config=None)
+    result = tools["rrt_version_overview"](ctx)
+    assert isinstance(result, PrefabApp)
+
+
+def test_version_overview_with_config(tmp_path: Path) -> None:
+    tools = _registered(tmp_path)
+    mock_target = MagicMock()
+    mock_target.path = tmp_path / "pyproject.toml"
+    mock_target.kind = "pep621"
+    mock_group = MagicMock()
+    mock_group.version_targets = [mock_target]
+    mock_config = MagicMock()
+    mock_config.version_groups = [mock_group]
+    ctx = _ctx(tmp_path, config=mock_config)
+
+    with patch("repo_release_tools.version.targets.read_version_string", return_value="1.2.3"):
+        result = tools["rrt_version_overview"](ctx)
+    assert isinstance(result, PrefabApp)
+
+
+def test_version_overview_read_error(tmp_path: Path) -> None:
+    tools = _registered(tmp_path)
+    mock_target = MagicMock()
+    mock_target.path = tmp_path / "pyproject.toml"
+    mock_target.kind = "pep621"
+    mock_group = MagicMock()
+    mock_group.version_targets = [mock_target]
+    mock_config = MagicMock()
+    mock_config.version_groups = [mock_group]
+    ctx = _ctx(tmp_path, config=mock_config)
+
+    with patch(
+        "repo_release_tools.version.targets.read_version_string",
+        side_effect=RuntimeError("no file"),
+    ):
+        result = tools["rrt_version_overview"](ctx)
+    assert isinstance(result, PrefabApp)
+
+
+# ── rrt_doctor_dashboard ──────────────────────────────────────────────────────
+
+
+def test_doctor_dashboard_empty(tmp_path: Path) -> None:
+    tools = _registered(tmp_path)
+    ctx = _ctx(tmp_path)
+    with patch("repo_release_tools.state.read_lock", return_value={}):
+        result = tools["rrt_doctor_dashboard"](ctx)
+    assert isinstance(result, PrefabApp)
+
+
+def test_doctor_dashboard_all_ok(tmp_path: Path) -> None:
+    tools = _registered(tmp_path)
+    ctx = _ctx(tmp_path)
+    health_data = {
+        "checks": {
+            "lint": {"status": "ok", "message": "pass"},
+            "test": {"status": "ok", "message": "pass"},
+        }
+    }
+    with patch("repo_release_tools.state.read_lock", return_value=health_data):
+        result = tools["rrt_doctor_dashboard"](ctx)
+    assert isinstance(result, PrefabApp)
+
+
+def test_doctor_dashboard_partial_ok(tmp_path: Path) -> None:
+    tools = _registered(tmp_path)
+    ctx = _ctx(tmp_path)
+    health_data = {
+        "checks": {
+            "lint": {"status": "ok", "message": "pass"},
+            "test": {"status": "warning", "message": "slow"},
+        }
+    }
+    with patch("repo_release_tools.state.read_lock", return_value=health_data):
+        result = tools["rrt_doctor_dashboard"](ctx)
+    assert isinstance(result, PrefabApp)
+
+
+def test_doctor_dashboard_all_fail(tmp_path: Path) -> None:
+    tools = _registered(tmp_path)
+    ctx = _ctx(tmp_path)
+    health_data = {"checks": {"lint": {"status": "error", "message": "fail"}}}
+    with patch("repo_release_tools.state.read_lock", return_value=health_data):
+        result = tools["rrt_doctor_dashboard"](ctx)
+    assert isinstance(result, PrefabApp)
+
+
+# ── rrt_tree_dashboard ────────────────────────────────────────────────────────
+
+
+def test_tree_dashboard_with_snapshot_git_ok(tmp_path: Path) -> None:
+    tools = _registered(tmp_path)
+    ctx = _ctx(tmp_path)
+    tree_data = {
+        "snapshot": {
+            "tree_hash": "deadbeef12345678",
+            "entry_count": 42,
+            "updated_at": "2024-01-01",
+        }
+    }
+    fake_proc = MagicMock(stdout="src/foo.py\nsrc/bar.py\n")
+    with (
+        patch("repo_release_tools.state.read_lock", return_value=tree_data),
+        patch("subprocess.run", return_value=fake_proc),
+    ):
+        result = tools["rrt_tree_dashboard"](ctx)
+    assert isinstance(result, PrefabApp)
+
+
+def test_tree_dashboard_no_snapshot_git_ok(tmp_path: Path) -> None:
+    tools = _registered(tmp_path)
+    ctx = _ctx(tmp_path)
+    fake_proc = MagicMock(stdout="src/a.py\ntests/b.py\n")
+    with (
+        patch("repo_release_tools.state.read_lock", return_value={}),
+        patch("subprocess.run", return_value=fake_proc),
+    ):
+        result = tools["rrt_tree_dashboard"](ctx)
+    assert isinstance(result, PrefabApp)
+
+
+def test_tree_dashboard_git_fails(tmp_path: Path) -> None:
+    tools = _registered(tmp_path)
+    ctx = _ctx(tmp_path)
+    with (
+        patch("repo_release_tools.state.read_lock", return_value={}),
+        patch("subprocess.run", side_effect=subprocess.SubprocessError("git not found")),
+    ):
+        result = tools["rrt_tree_dashboard"](ctx)
+    assert isinstance(result, PrefabApp)
+
+
+# ── rrt_init ─────────────────────────────────────────────────────────────────
+
+
+def test_rrt_init(tmp_path: Path) -> None:
+    tools = _registered(tmp_path)
+    ctx = _ctx(tmp_path)
+    result = tools["rrt_init"](ctx)
+    assert isinstance(result, PrefabApp)
+
+
+# ── rrt_init_run ──────────────────────────────────────────────────────────────
+
+
+def test_rrt_init_run_dry_run(tmp_path: Path) -> None:
+    tools = _registered(tmp_path)
+    ctx = _ctx(tmp_path)
+    fake_proc = MagicMock(stdout="Would write .rrt.toml", stderr="", returncode=0)
+
+    async def _run() -> str:
+        with patch("subprocess.run", return_value=fake_proc):
+            return await tools["rrt_init_run"](ctx)
+
+    result = asyncio.run(_run())
+    assert "Would write" in result
+
+
+def test_rrt_init_run_apply(tmp_path: Path) -> None:
+    tools = _registered(tmp_path)
+    ctx = _ctx(tmp_path)
+    fake_proc = MagicMock(stdout="Wrote .rrt.toml", stderr="", returncode=0)
+
+    async def _run() -> str:
+        with patch("subprocess.run", return_value=fake_proc):
+            return await tools["rrt_init_run"](ctx, target="rrt-toml", dry_run=False, force=False)
+
+    result = asyncio.run(_run())
+    assert "Wrote" in result
+
+
+def test_rrt_init_run_with_stderr(tmp_path: Path) -> None:
+    tools = _registered(tmp_path)
+    ctx = _ctx(tmp_path)
+    fake_proc = MagicMock(stdout="", stderr="some warning", returncode=1)
+
+    async def _run() -> str:
+        with patch("subprocess.run", return_value=fake_proc):
+            return await tools["rrt_init_run"](ctx)
+
+    result = asyncio.run(_run())
+    assert "[stderr]" in result
+
+
+def test_rrt_init_run_empty_output(tmp_path: Path) -> None:
+    tools = _registered(tmp_path)
+    ctx = _ctx(tmp_path)
+    fake_proc = MagicMock(stdout="", stderr="", returncode=0)
+
+    async def _run() -> str:
+        with patch("subprocess.run", return_value=fake_proc):
+            return await tools["rrt_init_run"](ctx, force=True)
+
+    result = asyncio.run(_run())
+    assert result == "Init complete."
+
+
+def test_rrt_init_run_nonzero_no_output(tmp_path: Path) -> None:
+    tools = _registered(tmp_path)
+    ctx = _ctx(tmp_path)
+    fake_proc = MagicMock(stdout="", stderr="", returncode=1)
+
+    async def _run() -> str:
+        with patch("subprocess.run", return_value=fake_proc):
+            return await tools["rrt_init_run"](ctx)
+
+    result = asyncio.run(_run())
+    assert "[error]" in result
+    assert "1" in result
+
+
+# ── rrt_locks_overview ────────────────────────────────────────────────────────
+
+
+def test_locks_overview_empty(tmp_path: Path) -> None:
+    tools = _registered(tmp_path)
+    ctx = _ctx(tmp_path)
+    with patch("repo_release_tools.state.read_lock", return_value={}):
+        result = tools["rrt_locks_overview"](ctx)
+    assert isinstance(result, PrefabApp)
+
+
+def test_locks_overview_full_state(tmp_path: Path) -> None:
+    tools = _registered(tmp_path)
+    ctx = _ctx(tmp_path)
+    health_data = {
+        "checks": {
+            "lint": {"status": "ok", "message": "pass", "updated_at": "now"},
+            "ci": {"status": "error", "message": "fail", "updated_at": "now"},
+        }
+    }
+    tree_data = {"snapshot": {"tree_hash": "abc12345", "entry_count": 5, "updated_at": "now"}}
+    artifacts_data = {"files": {"dist/x.whl": {"description": "wheel", "updated_at": "now"}}}
+    drift_data = {"sources": {"src": {"lang": "python", "updated_at": "now"}}}
+
+    def fake_read_lock(path: Any) -> dict[str, Any]:
+        name = str(path)
+        if "health" in name:
+            return health_data
+        if "tree" in name:
+            return tree_data
+        if "artifact" in name:
+            return artifacts_data
+        if "drift" in name:
+            return drift_data
+        return {}
+
+    with patch("repo_release_tools.state.read_lock", side_effect=fake_read_lock):
+        result = tools["rrt_locks_overview"](ctx)
+    assert isinstance(result, PrefabApp)
+
+
+def test_locks_overview_warning_only(tmp_path: Path) -> None:
+    tools = _registered(tmp_path)
+    ctx = _ctx(tmp_path)
+    health_data = {
+        "checks": {"lint": {"status": "warning", "message": "slow", "updated_at": "now"}}
+    }
+
+    with patch(
+        "repo_release_tools.state.read_lock",
+        side_effect=lambda p: health_data if "health" in str(p) else {},
+    ):
+        result = tools["rrt_locks_overview"](ctx)
+    assert isinstance(result, PrefabApp)

--- a/tests/mcp/test_apps.py
+++ b/tests/mcp/test_apps.py
@@ -423,7 +423,9 @@ def test_rrt_init_run_timeout(tmp_path: Path) -> None:
     async def _run() -> str:
         with patch(
             "subprocess.run",
-            side_effect=subprocess.TimeoutExpired(cmd=["python", "-m", "repo_release_tools.cli"], timeout=20),
+            side_effect=subprocess.TimeoutExpired(
+                cmd=["python", "-m", "repo_release_tools.cli"], timeout=20
+            ),
         ):
             return await tools["rrt_init_run"](ctx)
 

--- a/tests/mcp/test_models.py
+++ b/tests/mcp/test_models.py
@@ -1,0 +1,131 @@
+"""Tests for MCP Pydantic response models."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("fastmcp", reason="[mcp] extra not installed")
+
+from repo_release_tools.mcp.models import (
+    BranchResult,
+    BranchValidationResult,
+    BumpGroupResult,
+    ChangelogResponse,
+    CheckResult,
+    CommitValidationResult,
+    ConfigError,
+    DoctorResponse,
+    LockError,
+    RawLockData,
+    VersionGroupResult,
+)
+
+pytestmark = pytest.mark.mcp
+
+
+class TestCheckResult:
+    def test_defaults(self) -> None:
+        r = CheckResult(message="ok", ok=True, severity="ok")
+        assert r.message == "ok"
+        assert r.ok is True
+        assert r.severity == "ok"
+
+    def test_failed(self) -> None:
+        r = CheckResult(message="missing", ok=False, severity="error")
+        assert not r.ok
+
+
+class TestDoctorResponse:
+    def test_all_ok(self) -> None:
+        ok = CheckResult(message="ok", ok=True, severity="ok")
+        dr = DoctorResponse(pre_commit=ok, lefthook=ok, husky=ok, workflows=ok)
+        assert dr.pre_commit.ok
+
+
+class TestVersionGroupResult:
+    def test_no_error(self) -> None:
+        r = VersionGroupResult(group="main", version="1.2.3")
+        assert r.error is None
+
+    def test_with_error(self) -> None:
+        r = VersionGroupResult(group="main", version="", error="file not found")
+        assert r.error == "file not found"
+
+
+class TestBumpGroupResult:
+    def test_defaults(self) -> None:
+        r = BumpGroupResult(group="main")
+        assert r.dry_run is True
+        assert r.applied is False
+        assert r.current is None
+
+    def test_applied(self) -> None:
+        r = BumpGroupResult(group="main", current="1.0.0", new="1.1.0", dry_run=False, applied=True)
+        assert r.applied is True
+
+
+class TestBranchValidationResult:
+    def test_valid(self) -> None:
+        r = BranchValidationResult(valid=True, branch="feat/foo")
+        assert r.reason is None
+
+    def test_invalid(self) -> None:
+        r = BranchValidationResult(valid=False, branch="bad", reason="no type prefix")
+        assert r.reason == "no type prefix"
+
+
+class TestCommitValidationResult:
+    def test_valid(self) -> None:
+        r = CommitValidationResult(valid=True, subject="feat: add thing")
+        assert r.reason is None
+
+    def test_invalid(self) -> None:
+        r = CommitValidationResult(valid=False, subject="bad", reason="no colon")
+        assert r.reason == "no colon"
+
+
+class TestChangelogResponse:
+    def test_defaults(self) -> None:
+        r = ChangelogResponse(path="CHANGELOG.md", section="unreleased")
+        assert r.entries == []
+        assert r.content is None
+
+    def test_with_entries(self) -> None:
+        r = ChangelogResponse(path="CHANGELOG.md", section="unreleased", entries=["Added: foo"])
+        assert len(r.entries) == 1
+
+
+class TestLockError:
+    def test_no_hint(self) -> None:
+        r = LockError(error="not found")
+        assert r.hint == ""
+
+    def test_with_hint(self) -> None:
+        r = LockError(error="not found", hint="run rrt doctor")
+        assert r.hint == "run rrt doctor"
+
+
+class TestConfigError:
+    def test_error(self) -> None:
+        r = ConfigError(error="no config")
+        assert r.error == "no config"
+
+
+class TestBranchResult:
+    def test_dry_run(self) -> None:
+        r = BranchResult(
+            branch="feat/foo", created=False, dry_run=True, suggested_commit_title="feat: foo"
+        )
+        assert r.error is None
+
+    def test_error(self) -> None:
+        r = BranchResult(
+            branch="", created=False, dry_run=True, suggested_commit_title="", error="oops"
+        )
+        assert r.error == "oops"
+
+
+class TestRawLockData:
+    def test_to_flat(self) -> None:
+        r = RawLockData(data={"a": 1, "b": 2})
+        assert r.to_flat() == {"a": 1, "b": 2}

--- a/tests/mcp/test_prompts.py
+++ b/tests/mcp/test_prompts.py
@@ -1,0 +1,181 @@
+"""Tests for MCP prompt registrations (prompts.py)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+pytest.importorskip("fastmcp", reason="[mcp] extra not installed")
+
+from repo_release_tools.mcp.prompts import register_prompts
+
+pytestmark = pytest.mark.mcp
+
+
+class _CaptureMCP:
+    def __init__(self) -> None:
+        self._prompts: dict[str, Any] = {}
+
+    def prompt(self, *args: Any, **kwargs: Any) -> Any:
+        def decorator(fn: Any) -> Any:
+            self._prompts[fn.__name__] = fn
+            return fn
+
+        return decorator
+
+
+def _registered() -> dict[str, Any]:
+    mcp = _CaptureMCP()
+    register_prompts(mcp)  # ty: ignore[invalid-argument-type]
+    return mcp._prompts
+
+
+# ── registration ──────────────────────────────────────────────────────────────
+
+
+def test_register_prompts_all_present() -> None:
+    prompts = _registered()
+    expected = {
+        "release_workflow",
+        "version_strategy",
+        "branch_strategy",
+        "commit_message_guide",
+        "changelog_entry",
+        "config_setup",
+        "release_readiness",
+    }
+    assert expected == set(prompts.keys())
+
+
+# ── release_workflow ──────────────────────────────────────────────────────────
+
+
+def test_release_workflow_default() -> None:
+    p = _registered()["release_workflow"]
+    result = p()
+    assert "minor" in result
+    assert "rrt bump" in result
+
+
+def test_release_workflow_custom() -> None:
+    p = _registered()["release_workflow"]
+    result = p(version_level="major", repo_name="my-repo")
+    assert "major" in result
+    assert "my-repo" in result
+
+
+# ── version_strategy ──────────────────────────────────────────────────────────
+
+
+def test_version_strategy_default() -> None:
+    p = _registered()["version_strategy"]
+    result = p()
+    assert "semver" in result.lower() or "bump" in result.lower()
+
+
+def test_version_strategy_with_summary() -> None:
+    p = _registered()["version_strategy"]
+    result = p(change_summary="added new API endpoint")
+    assert "added new API endpoint" in result
+
+
+# ── branch_strategy ───────────────────────────────────────────────────────────
+
+
+def test_branch_strategy_default() -> None:
+    p = _registered()["branch_strategy"]
+    result = p()
+    assert "feat" in result
+
+
+def test_branch_strategy_with_context() -> None:
+    p = _registered()["branch_strategy"]
+    result = p(task_description="fix login bug", context_hint="auth module")
+    assert "fix login bug" in result
+    assert "auth module" in result
+
+
+def test_branch_strategy_no_context_hint() -> None:
+    p = _registered()["branch_strategy"]
+    result = p(task_description="add feature")
+    assert "add feature" in result
+
+
+# ── commit_message_guide ──────────────────────────────────────────────────────
+
+
+def test_commit_message_guide_default() -> None:
+    p = _registered()["commit_message_guide"]
+    result = p()
+    assert "Conventional" in result
+
+
+def test_commit_message_guide_with_info() -> None:
+    p = _registered()["commit_message_guide"]
+    result = p(staged_summary="updated README", branch_name="docs/readme")
+    assert "updated README" in result
+    assert "docs/readme" in result
+
+
+# ── changelog_entry ───────────────────────────────────────────────────────────
+
+
+def test_changelog_entry_default() -> None:
+    p = _registered()["changelog_entry"]
+    result = p()
+    assert "Changelog" in result or "changelog" in result
+
+
+def test_changelog_entry_with_summary() -> None:
+    p = _registered()["changelog_entry"]
+    result = p(commit_summary="add MCP server", section_hint="Added")
+    assert "add MCP server" in result
+    assert "Added" in result
+
+
+# ── config_setup ──────────────────────────────────────────────────────────────
+
+
+def test_config_setup_python() -> None:
+    p = _registered()["config_setup"]
+    result = p(project_type="python")
+    assert "pep621" in result
+
+
+def test_config_setup_node() -> None:
+    p = _registered()["config_setup"]
+    result = p(project_type="node")
+    assert "package.json" in result or "package_json" in result
+
+
+def test_config_setup_go() -> None:
+    p = _registered()["config_setup"]
+    result = p(project_type="go")
+    assert "go" in result.lower()
+
+
+def test_config_setup_unknown_falls_back_to_python() -> None:
+    p = _registered()["config_setup"]
+    result = p(project_type="rust")
+    assert "pep621" in result
+
+
+# ── release_readiness ─────────────────────────────────────────────────────────
+
+
+def test_release_readiness_default() -> None:
+    p = _registered()["release_readiness"]
+    result = p()
+    assert (
+        "readiness" in result.lower()
+        or "checklist" in result.lower()
+        or "release" in result.lower()
+    )
+
+
+def test_release_readiness_with_version() -> None:
+    p = _registered()["release_readiness"]
+    result = p(version="2.0.0", target_env="staging")
+    assert "v2.0.0" in result
+    assert "staging" in result

--- a/tests/mcp/test_resources.py
+++ b/tests/mcp/test_resources.py
@@ -1,0 +1,205 @@
+"""Tests for MCP resource registrations (resources.py)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("fastmcp", reason="[mcp] extra not installed")
+
+from repo_release_tools.mcp.resources import _path_to_str, register_resources
+
+pytestmark = pytest.mark.mcp
+
+
+class _CaptureMCP:
+    def __init__(self) -> None:
+        self._resources: dict[str, Any] = {}
+
+    def resource(self, *args: Any, **kwargs: Any) -> Any:
+        def decorator(fn: Any) -> Any:
+            self._resources[fn.__name__] = fn
+            return fn
+
+        return decorator
+
+
+def _registered() -> dict[str, Any]:
+    mcp = _CaptureMCP()
+    register_resources(mcp)  # ty: ignore[invalid-argument-type]
+    return mcp._resources
+
+
+# ── _path_to_str ──────────────────────────────────────────────────────────────
+
+
+def test_path_to_str_path() -> None:
+    assert _path_to_str(Path("/tmp/foo")) == "/tmp/foo"
+
+
+def test_path_to_str_dict() -> None:
+    result = _path_to_str({"a": Path("/x"), "b": 1})
+    assert result == {"a": "/x", "b": 1}
+
+
+def test_path_to_str_list() -> None:
+    result = _path_to_str([Path("/a"), Path("/b")])
+    assert result == ["/a", "/b"]
+
+
+def test_path_to_str_tuple() -> None:
+    result = _path_to_str((Path("/a"),))
+    assert result == ["/a"]
+
+
+def test_path_to_str_primitive() -> None:
+    assert _path_to_str(42) == 42
+    assert _path_to_str("hello") == "hello"
+    assert _path_to_str(None) is None
+
+
+# ── registration ──────────────────────────────────────────────────────────────
+
+
+def test_register_resources_all_present() -> None:
+    resources = _registered()
+    expected = {
+        "resource_version",
+        "resource_config",
+        "resource_config_schema",
+        "resource_changelog",
+        "resource_lock",
+    }
+    assert expected == set(resources.keys())
+
+
+# ── resource_version ──────────────────────────────────────────────────────────
+
+
+def test_resource_version() -> None:
+    resources = _registered()
+    result = resources["resource_version"]()
+    assert isinstance(result, str)
+    assert len(result) > 0
+
+
+# ── resource_config ───────────────────────────────────────────────────────────
+
+
+def test_resource_config_success(tmp_path: Path) -> None:
+    mock_config = MagicMock()
+    mock_config.version_groups = []
+    with (
+        patch("repo_release_tools.mcp.server._find_repo_root", return_value=tmp_path),
+        patch("repo_release_tools.config.load_or_autodetect_config", return_value=mock_config),
+        patch("dataclasses.asdict", return_value={"version": "1.0.0"}),
+    ):
+        resources = _registered()
+        result = resources["resource_config"]()
+    parsed = json.loads(result)
+    assert isinstance(parsed, dict)
+
+
+def test_resource_config_error(tmp_path: Path) -> None:
+    with (
+        patch("repo_release_tools.mcp.server._find_repo_root", return_value=tmp_path),
+        patch(
+            "repo_release_tools.config.load_or_autodetect_config",
+            side_effect=FileNotFoundError("not found"),
+        ),
+    ):
+        resources = _registered()
+        result = resources["resource_config"]()
+    parsed = json.loads(result)
+    assert "error" in parsed
+
+
+# ── resource_config_schema ────────────────────────────────────────────────────
+
+
+def test_resource_config_schema() -> None:
+    resources = _registered()
+    with patch(
+        "repo_release_tools.commands.config_cmd._load_schema", return_value={"type": "object"}
+    ):
+        result = resources["resource_config_schema"]()
+    parsed = json.loads(result)
+    assert parsed == {"type": "object"}
+
+
+# ── resource_changelog ────────────────────────────────────────────────────────
+
+
+def test_resource_changelog_exists(tmp_path: Path) -> None:
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text("# Changelog\n## Unreleased\n- Added: thing")
+    with patch("repo_release_tools.mcp.server._find_repo_root", return_value=tmp_path):
+        resources = _registered()
+        result = resources["resource_changelog"]()
+    assert "Changelog" in result
+
+
+def test_resource_changelog_missing(tmp_path: Path) -> None:
+    with patch("repo_release_tools.mcp.server._find_repo_root", return_value=tmp_path):
+        resources = _registered()
+        result = resources["resource_changelog"]()
+    assert "No CHANGELOG.md" in result
+
+
+# ── resource_lock ─────────────────────────────────────────────────────────────
+
+
+def _make_lock_dir(tmp_path: Path) -> Path:
+    rrt = tmp_path / ".rrt"
+    rrt.mkdir()
+    return rrt
+
+
+def test_resource_lock_valid_drift(tmp_path: Path) -> None:
+    rrt = _make_lock_dir(tmp_path)
+    (rrt / "drift.lock.toml").write_text("[sources]\n")
+    with patch("repo_release_tools.mcp.server._find_repo_root", return_value=tmp_path):
+        resources = _registered()
+        result = resources["resource_lock"](name="drift")
+    parsed = json.loads(result)
+    assert isinstance(parsed, dict)
+
+
+def test_resource_lock_valid_health(tmp_path: Path) -> None:
+    rrt = _make_lock_dir(tmp_path)
+    (rrt / "health.lock.toml").write_text("[checks]\n")
+    with patch("repo_release_tools.mcp.server._find_repo_root", return_value=tmp_path):
+        resources = _registered()
+        result = resources["resource_lock"](name="health")
+    parsed = json.loads(result)
+    assert isinstance(parsed, dict)
+
+
+def test_resource_lock_valid_tree(tmp_path: Path) -> None:
+    _make_lock_dir(tmp_path)
+    with patch("repo_release_tools.mcp.server._find_repo_root", return_value=tmp_path):
+        resources = _registered()
+        result = resources["resource_lock"](name="tree")
+    assert isinstance(json.loads(result), dict)
+
+
+def test_resource_lock_valid_artifacts(tmp_path: Path) -> None:
+    rrt = _make_lock_dir(tmp_path)
+    (rrt / "artifacts.lock.toml").write_text("[files]\n")
+    with patch("repo_release_tools.mcp.server._find_repo_root", return_value=tmp_path):
+        resources = _registered()
+        result = resources["resource_lock"](name="artifacts")
+    parsed = json.loads(result)
+    assert isinstance(parsed, dict)
+
+
+def test_resource_lock_invalid_name() -> None:
+    resources = _registered()
+    result = resources["resource_lock"](name="bogus")
+    parsed = json.loads(result)
+    assert "error" in parsed
+    assert "bogus" in parsed["error"]

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -1,0 +1,161 @@
+"""Tests for the rrt FastMCP server lifecycle (server.py)."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("fastmcp", reason="[mcp] extra not installed")
+
+from fastmcp import FastMCP
+
+from repo_release_tools.mcp.server import _find_repo_root, _lifespan, create_server, main
+
+pytestmark = pytest.mark.mcp
+
+
+# ── _find_repo_root ───────────────────────────────────────────────────────────
+
+
+def test_find_repo_root_via_rrt_dir(tmp_path: Path, monkeypatch: Any) -> None:
+    (tmp_path / ".rrt").mkdir()
+    monkeypatch.chdir(tmp_path)
+    assert _find_repo_root() == tmp_path
+
+
+def test_find_repo_root_via_pyproject(tmp_path: Path, monkeypatch: Any) -> None:
+    (tmp_path / "pyproject.toml").write_text("[tool.rrt]")
+    monkeypatch.chdir(tmp_path)
+    assert _find_repo_root() == tmp_path
+
+
+def test_find_repo_root_fallback_to_cwd(tmp_path: Path, monkeypatch: Any) -> None:
+    # Subdirectory with no markers; parents are all temp (no pyproject.toml above tmp_path)
+    sub = tmp_path / "a" / "b" / "c"
+    sub.mkdir(parents=True)
+    monkeypatch.chdir(sub)
+    root = _find_repo_root()
+    # Should fall back to cwd (sub) since no marker found in ancestors under tmp_path
+    assert root == sub
+
+
+# ── _lifespan ─────────────────────────────────────────────────────────────────
+
+
+def test_lifespan_config_success(tmp_path: Path, monkeypatch: Any) -> None:
+    (tmp_path / "pyproject.toml").write_text("[tool.rrt]")
+    monkeypatch.chdir(tmp_path)
+
+    async def _run() -> dict[str, Any]:
+        server: MagicMock = MagicMock()
+        mock_config = MagicMock()
+        with patch("repo_release_tools.config.load_or_autodetect_config", return_value=mock_config):
+            async with _lifespan(server) as ctx:
+                return ctx
+
+    ctx = asyncio.run(_run())
+    assert "root" in ctx
+    assert "config" in ctx
+    assert ctx["config"] is not None
+    assert ctx["config_error"] is None
+
+
+def test_lifespan_config_failure(tmp_path: Path, monkeypatch: Any) -> None:
+    (tmp_path / "pyproject.toml").write_text("[tool.rrt]")
+    monkeypatch.chdir(tmp_path)
+
+    async def _run() -> dict[str, Any]:
+        server: MagicMock = MagicMock()
+        with patch(
+            "repo_release_tools.config.load_or_autodetect_config",
+            side_effect=FileNotFoundError("no config"),
+        ):
+            async with _lifespan(server) as ctx:
+                return ctx
+
+    ctx = asyncio.run(_run())
+    assert ctx["config"] is None
+    assert ctx["config_error"] is None
+
+
+def test_lifespan_value_error(tmp_path: Path, monkeypatch: Any) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    async def _run() -> dict[str, Any]:
+        server: MagicMock = MagicMock()
+        with patch(
+            "repo_release_tools.config.load_or_autodetect_config",
+            side_effect=ValueError("bad config"),
+        ):
+            async with _lifespan(server) as ctx:
+                return ctx
+
+    ctx = asyncio.run(_run())
+    assert ctx["config"] is None
+    assert ctx["config_error"] is not None
+    assert "bad config" in ctx["config_error"]
+
+
+def test_lifespan_runtime_error(tmp_path: Path, monkeypatch: Any) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    async def _run() -> dict[str, Any]:
+        server: MagicMock = MagicMock()
+        with patch(
+            "repo_release_tools.config.load_or_autodetect_config",
+            side_effect=RuntimeError("runtime"),
+        ):
+            async with _lifespan(server) as ctx:
+                return ctx
+
+    ctx = asyncio.run(_run())
+    assert ctx["config"] is None
+    assert ctx["config_error"] is not None
+    assert "runtime" in ctx["config_error"]
+
+
+# ── create_server ─────────────────────────────────────────────────────────────
+
+
+def test_create_server_returns_fastmcp() -> None:
+    server = create_server()
+    assert isinstance(server, FastMCP)
+
+
+# ── main ──────────────────────────────────────────────────────────────────────
+
+
+def test_main_no_fastmcp(monkeypatch: Any) -> None:
+    """main() exits with code 1 when fastmcp is not importable."""
+    orig_import = __builtins__.__import__ if hasattr(__builtins__, "__import__") else __import__
+
+    def fail_fastmcp(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "fastmcp":
+            raise ImportError("no module")
+        return orig_import(name, *args, **kwargs)
+
+    with patch("builtins.__import__", side_effect=fail_fastmcp):
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+    assert exc_info.value.code == 1
+
+
+def test_main_stdio(monkeypatch: Any) -> None:
+    monkeypatch.setattr(sys, "argv", ["rrt-mcp"])
+    mock_server = MagicMock()
+    with patch("repo_release_tools.mcp.server.create_server", return_value=mock_server):
+        main()
+    mock_server.run.assert_called_once_with(transport="stdio")
+
+
+def test_main_http(monkeypatch: Any) -> None:
+    monkeypatch.setattr(sys, "argv", ["rrt-mcp", "--transport", "http", "--port", "9000"])
+    mock_server = MagicMock()
+    with patch("repo_release_tools.mcp.server.create_server", return_value=mock_server):
+        main()
+    mock_server.run.assert_called_once_with(transport="http", host="127.0.0.1", port=9000)

--- a/tests/mcp/test_tools.py
+++ b/tests/mcp/test_tools.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import subprocess
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -327,6 +328,20 @@ def test_rrt_bump_no_config(tmp_path: Path) -> None:
     assert "error" in result
 
 
+def test_rrt_bump_empty_groups_skips_progress(tmp_path: Path) -> None:
+    tools = _ver_tools(tmp_path)
+    mock_config = MagicMock()
+    mock_config.version_groups = []
+    ctx = _ctx(tmp_path, config=mock_config)
+
+    async def _run() -> Any:
+        return await tools["rrt_bump"](ctx, level="patch")
+
+    result = asyncio.run(_run())
+    assert result == []
+    ctx.report_progress.assert_not_called()
+
+
 def test_rrt_bump_dry_run(tmp_path: Path) -> None:
     tools = _ver_tools(tmp_path)
     mock_group = MagicMock()
@@ -573,12 +588,12 @@ def test_rrt_branch_new_with_scope(tmp_path: Path) -> None:
 def test_rrt_branch_new_apply_success(tmp_path: Path) -> None:
     tools = _git_tools(tmp_path)
     ctx = _ctx(tmp_path)
+    mock_run = MagicMock(return_value=MagicMock(returncode=0, stdout="", stderr=""))
 
     async def _run() -> BranchResult:
-        fake_proc = MagicMock(returncode=0, stdout="", stderr="")
         with (
             patch("repo_release_tools.workflow.git.branch_exists", return_value=False),
-            patch("subprocess.run", return_value=fake_proc),
+            patch("subprocess.run", mock_run),
         ):
             return await tools["rrt_branch_new"](
                 ctx, commit_type="feat", description="new feature", dry_run=False
@@ -586,6 +601,8 @@ def test_rrt_branch_new_apply_success(tmp_path: Path) -> None:
 
     result = asyncio.run(_run())
     assert result.created is True
+    mock_run.assert_called_once()
+    assert mock_run.call_args.kwargs["timeout"] == 8.0
 
 
 def test_rrt_branch_new_apply_git_fails(tmp_path: Path) -> None:
@@ -621,3 +638,24 @@ def test_rrt_branch_new_apply_already_exists(tmp_path: Path) -> None:
     result = asyncio.run(_run())
     assert result.created is False
     assert result.error is not None
+
+
+def test_rrt_branch_new_apply_timeout(tmp_path: Path) -> None:
+    tools = _git_tools(tmp_path)
+    ctx = _ctx(tmp_path)
+
+    async def _run() -> BranchResult:
+        with (
+            patch("repo_release_tools.workflow.git.branch_exists", return_value=False),
+            patch(
+                "subprocess.run",
+                side_effect=subprocess.TimeoutExpired(cmd=["git", "checkout", "-b"], timeout=8.0),
+            ),
+        ):
+            return await tools["rrt_branch_new"](
+                ctx, commit_type="feat", description="slow branch", dry_run=False
+            )
+
+    result = asyncio.run(_run())
+    assert result.created is False
+    assert result.error == "git checkout -b timed out after 8 seconds."

--- a/tests/mcp/test_tools.py
+++ b/tests/mcp/test_tools.py
@@ -359,6 +359,7 @@ def test_rrt_bump_dry_run(tmp_path: Path) -> None:
     assert isinstance(result, list)
     assert result[0].dry_run is True
     assert result[0].applied is False
+    assert ctx.report_progress.await_count >= 1
 
 
 def test_rrt_bump_applied(tmp_path: Path) -> None:
@@ -602,7 +603,10 @@ def test_rrt_branch_new_apply_success(tmp_path: Path) -> None:
     result = asyncio.run(_run())
     assert result.created is True
     mock_run.assert_called_once()
+    assert mock_run.call_args.args[0] == ["git", "checkout", "-b", result.branch]
     assert mock_run.call_args.kwargs["timeout"] == 8.0
+    assert mock_run.call_args.kwargs["capture_output"] is True
+    assert mock_run.call_args.kwargs["text"] is True
 
 
 def test_rrt_branch_new_apply_git_fails(tmp_path: Path) -> None:

--- a/tests/mcp/test_tools.py
+++ b/tests/mcp/test_tools.py
@@ -1,0 +1,623 @@
+"""Tests for all MCP tool registrations (tools/*.py and tools/__init__.py)."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytest.importorskip("fastmcp", reason="[mcp] extra not installed")
+
+from repo_release_tools.mcp.models import (
+    BranchResult,
+    BranchValidationResult,
+    ChangelogResponse,
+    CommitValidationResult,
+    ConfigError,
+    DoctorResponse,
+    LockError,
+)
+from repo_release_tools.mcp.tools import register_tools
+from repo_release_tools.mcp.tools.changelog_tools import register as register_changelog
+from repo_release_tools.mcp.tools.config_tools import _path_to_str
+from repo_release_tools.mcp.tools.config_tools import register as register_config
+from repo_release_tools.mcp.tools.git_tools import register as register_git
+from repo_release_tools.mcp.tools.lock_tools import register as register_locks
+from repo_release_tools.mcp.tools.validation_tools import register as register_validation
+from repo_release_tools.mcp.tools.version_tools import register as register_version
+
+pytestmark = pytest.mark.mcp
+
+
+# ── shared ────────────────────────────────────────────────────────────────────
+
+
+class _CaptureMCP:
+    def __init__(self) -> None:
+        self._tools: dict[str, Any] = {}
+
+    def tool(self, *args: Any, **kwargs: Any) -> Any:
+        def decorator(fn: Any) -> Any:
+            self._tools[fn.__name__] = fn
+            return fn
+
+        return decorator
+
+
+def _ctx(tmp_path: Path, config: Any = None) -> MagicMock:
+    ctx = MagicMock()
+    ctx.lifespan_context = {"root": tmp_path, "config": config}
+    ctx.info = AsyncMock()
+    ctx.warning = AsyncMock()
+    ctx.report_progress = AsyncMock()
+    return ctx
+
+
+# ── register_tools ────────────────────────────────────────────────────────────
+
+
+def test_register_tools_all_present() -> None:
+    mcp = _CaptureMCP()
+    register_tools(mcp)  # ty: ignore[invalid-argument-type]
+    expected = {
+        "rrt_config",
+        "rrt_doctor",
+        "rrt_health",
+        "rrt_drift",
+        "rrt_tree",
+        "rrt_artifacts",
+        "rrt_version",
+        "rrt_bump",
+        "rrt_validate_branch",
+        "rrt_validate_commit",
+        "rrt_changelog",
+        "rrt_branch_new",
+    }
+    assert expected <= set(mcp._tools.keys())
+
+
+# ── config_tools._path_to_str ─────────────────────────────────────────────────
+
+
+def test_path_to_str_config_path() -> None:
+    assert _path_to_str(Path("/tmp")) == "/tmp"
+
+
+def test_path_to_str_config_dict() -> None:
+    assert _path_to_str({"k": Path("/x")}) == {"k": "/x"}
+
+
+def test_path_to_str_config_list() -> None:
+    assert _path_to_str([Path("/a"), "b"]) == ["/a", "b"]
+
+
+def test_path_to_str_config_tuple() -> None:
+    assert _path_to_str((Path("/a"),)) == ["/a"]
+
+
+def test_path_to_str_config_primitive() -> None:
+    assert _path_to_str(99) == 99
+
+
+# ── rrt_config ────────────────────────────────────────────────────────────────
+
+
+def test_rrt_config_config_error(tmp_path: Path) -> None:
+    mcp = _CaptureMCP()
+    register_config(mcp)  # ty: ignore[invalid-argument-type]
+    ctx = _ctx(tmp_path, config=None)
+    ctx.lifespan_context["config_error"] = "bad TOML"
+    result = mcp._tools["rrt_config"](ctx)
+    assert isinstance(result, ConfigError)
+    assert "bad TOML" in result.error
+
+
+def test_rrt_config_no_config(tmp_path: Path) -> None:
+    mcp = _CaptureMCP()
+    register_config(mcp)  # ty: ignore[invalid-argument-type]
+    ctx = _ctx(tmp_path, config=None)
+    result = mcp._tools["rrt_config"](ctx)
+    assert isinstance(result, ConfigError)
+
+
+def test_rrt_config_success(tmp_path: Path) -> None:
+    mcp = _CaptureMCP()
+    register_config(mcp)  # ty: ignore[invalid-argument-type]
+    mock_config = MagicMock()
+    ctx = _ctx(tmp_path, config=mock_config)
+    with patch(
+        "repo_release_tools.mcp.tools.config_tools.asdict", return_value={"version": "1.0.0"}
+    ):
+        result = mcp._tools["rrt_config"](ctx)
+    assert isinstance(result, dict)
+
+
+def test_rrt_config_error(tmp_path: Path) -> None:
+    mcp = _CaptureMCP()
+    register_config(mcp)  # ty: ignore[invalid-argument-type]
+    mock_config = MagicMock()  # Not a dataclass → asdict() raises TypeError → ConfigError
+    ctx = _ctx(tmp_path, config=mock_config)
+    with patch("repo_release_tools.mcp.tools.config_tools.asdict", side_effect=Exception("boom")):
+        result = mcp._tools["rrt_config"](ctx)
+    assert isinstance(result, ConfigError)
+
+
+# ── rrt_doctor ────────────────────────────────────────────────────────────────
+
+
+def test_rrt_doctor(tmp_path: Path) -> None:
+    mcp = _CaptureMCP()
+    register_config(mcp)  # ty: ignore[invalid-argument-type]
+    ctx = _ctx(tmp_path)
+    ok_check = ("all good", True, "ok")
+    with (
+        patch("repo_release_tools.commands.doctor._check_text_integration", return_value=ok_check),
+        patch("repo_release_tools.commands.doctor._check_husky", return_value=ok_check),
+        patch("repo_release_tools.commands.doctor._check_github_workflows", return_value=ok_check),
+    ):
+        result = mcp._tools["rrt_doctor"](ctx)
+    assert isinstance(result, DoctorResponse)
+    assert result.pre_commit.ok
+
+
+# ── lock tools ────────────────────────────────────────────────────────────────
+
+
+def _lock_tools(tmp_path: Path) -> dict[str, Any]:
+    mcp = _CaptureMCP()
+    register_locks(mcp)  # ty: ignore[invalid-argument-type]
+    return mcp._tools
+
+
+def test_rrt_health_empty(tmp_path: Path) -> None:
+    tools = _lock_tools(tmp_path)
+    ctx = _ctx(tmp_path)
+    with patch("repo_release_tools.state.read_lock", return_value={}):
+        result = tools["rrt_health"](ctx)
+    assert "error" in result
+
+
+def test_rrt_health_data(tmp_path: Path) -> None:
+    tools = _lock_tools(tmp_path)
+    ctx = _ctx(tmp_path)
+    data = {"checks": {"lint": {"status": "ok"}}}
+    with patch("repo_release_tools.state.read_lock", return_value=data):
+        result = tools["rrt_health"](ctx)
+    assert "checks" in result
+
+
+def test_rrt_drift_empty(tmp_path: Path) -> None:
+    tools = _lock_tools(tmp_path)
+    ctx = _ctx(tmp_path)
+    with patch("repo_release_tools.state.read_lock", return_value={}):
+        result = tools["rrt_drift"](ctx)
+    assert "error" in result
+
+
+def test_rrt_drift_data(tmp_path: Path) -> None:
+    tools = _lock_tools(tmp_path)
+    ctx = _ctx(tmp_path)
+    with patch("repo_release_tools.state.read_lock", return_value={"sources": {}}):
+        result = tools["rrt_drift"](ctx)
+    assert "sources" in result
+
+
+def test_rrt_tree_empty(tmp_path: Path) -> None:
+    tools = _lock_tools(tmp_path)
+    ctx = _ctx(tmp_path)
+    with patch("repo_release_tools.state.read_lock", return_value={}):
+        result = tools["rrt_tree"](ctx)
+    assert "error" in result
+
+
+def test_rrt_tree_data(tmp_path: Path) -> None:
+    tools = _lock_tools(tmp_path)
+    ctx = _ctx(tmp_path)
+    with patch("repo_release_tools.state.read_lock", return_value={"snapshot": {}}):
+        result = tools["rrt_tree"](ctx)
+    assert "snapshot" in result
+
+
+def test_rrt_artifacts_empty(tmp_path: Path) -> None:
+    tools = _lock_tools(tmp_path)
+    ctx = _ctx(tmp_path)
+    with patch("repo_release_tools.state.read_lock", return_value={}):
+        result = tools["rrt_artifacts"](ctx)
+    assert "error" in result
+
+
+def test_rrt_artifacts_data(tmp_path: Path) -> None:
+    tools = _lock_tools(tmp_path)
+    ctx = _ctx(tmp_path)
+    with patch("repo_release_tools.state.read_lock", return_value={"files": {}}):
+        result = tools["rrt_artifacts"](ctx)
+    assert "files" in result
+
+
+# ── version tools ─────────────────────────────────────────────────────────────
+
+
+def _ver_tools(tmp_path: Path) -> dict[str, Any]:
+    mcp = _CaptureMCP()
+    register_version(mcp)  # ty: ignore[invalid-argument-type]
+    return mcp._tools
+
+
+def test_rrt_version_config_error(tmp_path: Path) -> None:
+    tools = _ver_tools(tmp_path)
+    ctx = _ctx(tmp_path, config=None)
+    ctx.lifespan_context["config_error"] = "broken config"
+    result = tools["rrt_version"](ctx)
+    assert isinstance(result, ConfigError)
+    assert "broken config" in result.error
+
+
+def test_rrt_version_no_config(tmp_path: Path) -> None:
+    tools = _ver_tools(tmp_path)
+    ctx = _ctx(tmp_path, config=None)
+    result = tools["rrt_version"](ctx)
+    assert isinstance(result, ConfigError)
+
+
+def test_rrt_version_with_config(tmp_path: Path) -> None:
+    tools = _ver_tools(tmp_path)
+    mock_target = MagicMock()
+    mock_group = MagicMock()
+    mock_group.name = "main"
+    mock_group.primary_target.return_value = mock_target
+    mock_config = MagicMock()
+    mock_config.version_groups = [mock_group]
+    ctx = _ctx(tmp_path, config=mock_config)
+    with patch("repo_release_tools.version.targets.read_version_string", return_value="1.0.0"):
+        result = tools["rrt_version"](ctx)
+    assert isinstance(result, list)
+    assert result[0].version == "1.0.0"
+
+
+def test_rrt_version_read_error(tmp_path: Path) -> None:
+    tools = _ver_tools(tmp_path)
+    mock_group = MagicMock()
+    mock_group.name = "main"
+    mock_group.primary_target.return_value = MagicMock()
+    mock_config = MagicMock()
+    mock_config.version_groups = [mock_group]
+    ctx = _ctx(tmp_path, config=mock_config)
+    with patch(
+        "repo_release_tools.version.targets.read_version_string", side_effect=RuntimeError("oops")
+    ):
+        result = tools["rrt_version"](ctx)
+    assert result[0].error is not None
+
+
+def test_rrt_bump_config_error(tmp_path: Path) -> None:
+    tools = _ver_tools(tmp_path)
+    ctx = _ctx(tmp_path, config=None)
+    ctx.lifespan_context["config_error"] = "broken config"
+
+    async def _run() -> Any:
+        return await tools["rrt_bump"](ctx, level="patch")
+
+    result = asyncio.run(_run())
+    assert "error" in result
+    assert "broken config" in result["error"]
+
+
+def test_rrt_bump_invalid_level(tmp_path: Path) -> None:
+    tools = _ver_tools(tmp_path)
+    ctx = _ctx(tmp_path)
+
+    async def _run() -> Any:
+        return await tools["rrt_bump"](ctx, level="invalid")
+
+    result = asyncio.run(_run())
+    assert "error" in result
+
+
+def test_rrt_bump_no_config(tmp_path: Path) -> None:
+    tools = _ver_tools(tmp_path)
+    ctx = _ctx(tmp_path, config=None)
+
+    async def _run() -> Any:
+        return await tools["rrt_bump"](ctx, level="patch")
+
+    result = asyncio.run(_run())
+    assert "error" in result
+
+
+def test_rrt_bump_dry_run(tmp_path: Path) -> None:
+    tools = _ver_tools(tmp_path)
+    mock_group = MagicMock()
+    mock_group.name = "main"
+    mock_group.primary_target.return_value = MagicMock()
+    mock_config = MagicMock()
+    mock_config.version_groups = [mock_group]
+    ctx = _ctx(tmp_path, config=mock_config)
+
+    async def _run() -> Any:
+        with patch("repo_release_tools.version.targets.read_version_string", return_value="1.0.0"):
+            return await tools["rrt_bump"](ctx, level="patch", dry_run=True)
+
+    result = asyncio.run(_run())
+    assert isinstance(result, list)
+    assert result[0].dry_run is True
+    assert result[0].applied is False
+
+
+def test_rrt_bump_applied(tmp_path: Path) -> None:
+    tools = _ver_tools(tmp_path)
+    mock_group = MagicMock()
+    mock_group.name = "main"
+    mock_group.primary_target.return_value = MagicMock()
+    mock_group.version_targets = [MagicMock()]
+    mock_config = MagicMock()
+    mock_config.version_groups = [mock_group]
+    ctx = _ctx(tmp_path, config=mock_config)
+
+    async def _run() -> Any:
+        with (
+            patch("repo_release_tools.version.targets.read_version_string", return_value="1.0.0"),
+            patch("repo_release_tools.version.targets.replace_version_in_file"),
+        ):
+            return await tools["rrt_bump"](ctx, level="patch", dry_run=False)
+
+    result = asyncio.run(_run())
+    assert result[0].applied is True
+
+
+def test_rrt_bump_version_error(tmp_path: Path) -> None:
+    tools = _ver_tools(tmp_path)
+    mock_group = MagicMock()
+    mock_group.name = "main"
+    mock_group.primary_target.return_value = MagicMock()
+    mock_config = MagicMock()
+    mock_config.version_groups = [mock_group]
+    ctx = _ctx(tmp_path, config=mock_config)
+
+    async def _run() -> Any:
+        with patch(
+            "repo_release_tools.version.targets.read_version_string", side_effect=OSError("no file")
+        ):
+            return await tools["rrt_bump"](ctx, level="minor")
+
+    result = asyncio.run(_run())
+    assert result[0].error is not None
+
+
+# ── validation tools ──────────────────────────────────────────────────────────
+
+
+def _val_tools(tmp_path: Path) -> dict[str, Any]:
+    mcp = _CaptureMCP()
+    register_validation(mcp)  # ty: ignore[invalid-argument-type]
+    return mcp._tools
+
+
+def test_rrt_validate_branch_valid(tmp_path: Path) -> None:
+    tools = _val_tools(tmp_path)
+    ctx = _ctx(tmp_path)
+    with (
+        patch("repo_release_tools.config.load_extra_branch_types", return_value=()),
+        patch("repo_release_tools.workflow.hooks.validate_branch_name", return_value=None),
+    ):
+        result = tools["rrt_validate_branch"](ctx, branch_name="feat/foo")
+    assert isinstance(result, BranchValidationResult)
+    assert result.valid is True
+
+
+def test_rrt_validate_branch_invalid(tmp_path: Path) -> None:
+    tools = _val_tools(tmp_path)
+    ctx = _ctx(tmp_path)
+    with (
+        patch("repo_release_tools.config.load_extra_branch_types", return_value=()),
+        patch("repo_release_tools.workflow.hooks.validate_branch_name", return_value="bad format"),
+    ):
+        result = tools["rrt_validate_branch"](ctx, branch_name="bad")
+    assert result.valid is False
+    assert result.reason == "bad format"
+
+
+def test_rrt_validate_branch_load_error(tmp_path: Path) -> None:
+    tools = _val_tools(tmp_path)
+    ctx = _ctx(tmp_path)
+    with (
+        patch(
+            "repo_release_tools.config.load_extra_branch_types",
+            side_effect=FileNotFoundError("no file"),
+        ),
+        patch("repo_release_tools.workflow.hooks.validate_branch_name", return_value=None),
+    ):
+        result = tools["rrt_validate_branch"](ctx, branch_name="feat/ok")
+    assert result.valid is True
+
+
+def test_rrt_validate_commit_valid(tmp_path: Path) -> None:
+    tools = _val_tools(tmp_path)
+    ctx = _ctx(tmp_path)
+    with (
+        patch("repo_release_tools.config.load_extra_branch_types", return_value=()),
+        patch("repo_release_tools.workflow.hooks.validate_commit_subject", return_value=None),
+    ):
+        result = tools["rrt_validate_commit"](ctx, subject="feat: add thing")
+    assert isinstance(result, CommitValidationResult)
+    assert result.valid is True
+
+
+def test_rrt_validate_commit_invalid(tmp_path: Path) -> None:
+    tools = _val_tools(tmp_path)
+    ctx = _ctx(tmp_path)
+    with (
+        patch("repo_release_tools.config.load_extra_branch_types", return_value=()),
+        patch("repo_release_tools.workflow.hooks.validate_commit_subject", return_value="no colon"),
+    ):
+        result = tools["rrt_validate_commit"](ctx, subject="bad")
+    assert result.valid is False
+
+
+def test_rrt_validate_commit_load_error(tmp_path: Path) -> None:
+    tools = _val_tools(tmp_path)
+    ctx = _ctx(tmp_path)
+    with (
+        patch(
+            "repo_release_tools.config.load_extra_branch_types",
+            side_effect=FileNotFoundError("no file"),
+        ),
+        patch("repo_release_tools.workflow.hooks.validate_commit_subject", return_value=None),
+    ):
+        result = tools["rrt_validate_commit"](ctx, subject="feat: good")
+    assert result.valid is True
+
+
+# ── changelog tools ───────────────────────────────────────────────────────────
+
+
+def _changelog_tools(tmp_path: Path) -> dict[str, Any]:
+    mcp = _CaptureMCP()
+    register_changelog(mcp)  # ty: ignore[invalid-argument-type]
+    return mcp._tools
+
+
+def test_rrt_changelog_no_config_no_file(tmp_path: Path) -> None:
+    tools = _changelog_tools(tmp_path)
+    ctx = _ctx(tmp_path, config=None)
+    result = tools["rrt_changelog"](ctx)
+    assert isinstance(result, LockError)
+
+
+def test_rrt_changelog_no_config_with_file(tmp_path: Path) -> None:
+    tools = _changelog_tools(tmp_path)
+    (tmp_path / "CHANGELOG.md").write_text("## Unreleased\n- Added: foo")
+    ctx = _ctx(tmp_path, config=None)
+    with patch("repo_release_tools.changelog.get_unreleased_entries", return_value=["Added: foo"]):
+        result = tools["rrt_changelog"](ctx)
+    assert isinstance(result, ChangelogResponse)
+    assert result.section == "unreleased"
+
+
+def test_rrt_changelog_full_section(tmp_path: Path) -> None:
+    tools = _changelog_tools(tmp_path)
+    (tmp_path / "CHANGELOG.md").write_text("# Full changelog")
+    ctx = _ctx(tmp_path, config=None)
+    result = tools["rrt_changelog"](ctx, section="full")
+    assert isinstance(result, ChangelogResponse)
+    assert result.section == "full"
+    assert result.content is not None
+
+
+def test_rrt_changelog_with_config(tmp_path: Path) -> None:
+    tools = _changelog_tools(tmp_path)
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text("## Unreleased\n- Added: bar")
+    mock_group = MagicMock()
+    mock_group.changelog_file = changelog
+    mock_config = MagicMock()
+    mock_config.version_groups = [mock_group]
+    ctx = _ctx(tmp_path, config=mock_config)
+    with patch("repo_release_tools.changelog.get_unreleased_entries", return_value=["Added: bar"]):
+        result = tools["rrt_changelog"](ctx)
+    assert isinstance(result, ChangelogResponse)
+
+
+# ── git tools ─────────────────────────────────────────────────────────────────
+
+
+def _git_tools(tmp_path: Path) -> dict[str, Any]:
+    mcp = _CaptureMCP()
+    register_git(mcp)  # ty: ignore[invalid-argument-type]
+    return mcp._tools
+
+
+def test_rrt_branch_new_invalid_type(tmp_path: Path) -> None:
+    tools = _git_tools(tmp_path)
+    ctx = _ctx(tmp_path)
+
+    async def _run() -> BranchResult:
+        return await tools["rrt_branch_new"](ctx, commit_type="invalid", description="foo")
+
+    result = asyncio.run(_run())
+    assert result.created is False
+    assert result.error is not None
+
+
+def test_rrt_branch_new_dry_run(tmp_path: Path) -> None:
+    tools = _git_tools(tmp_path)
+    ctx = _ctx(tmp_path)
+
+    async def _run() -> BranchResult:
+        return await tools["rrt_branch_new"](
+            ctx, commit_type="feat", description="add thing", dry_run=True
+        )
+
+    result = asyncio.run(_run())
+    assert result.dry_run is True
+    assert result.created is False
+    assert "feat" in result.branch
+
+
+def test_rrt_branch_new_with_scope(tmp_path: Path) -> None:
+    tools = _git_tools(tmp_path)
+    ctx = _ctx(tmp_path)
+
+    async def _run() -> BranchResult:
+        return await tools["rrt_branch_new"](
+            ctx, commit_type="fix", description="crash on load", scope="cli", dry_run=True
+        )
+
+    result = asyncio.run(_run())
+    assert result.dry_run is True
+    assert "fix" in result.branch
+
+
+def test_rrt_branch_new_apply_success(tmp_path: Path) -> None:
+    tools = _git_tools(tmp_path)
+    ctx = _ctx(tmp_path)
+
+    async def _run() -> BranchResult:
+        fake_proc = MagicMock(returncode=0, stdout="", stderr="")
+        with (
+            patch("repo_release_tools.workflow.git.branch_exists", return_value=False),
+            patch("subprocess.run", return_value=fake_proc),
+        ):
+            return await tools["rrt_branch_new"](
+                ctx, commit_type="feat", description="new feature", dry_run=False
+            )
+
+    result = asyncio.run(_run())
+    assert result.created is True
+
+
+def test_rrt_branch_new_apply_git_fails(tmp_path: Path) -> None:
+    tools = _git_tools(tmp_path)
+    ctx = _ctx(tmp_path)
+
+    async def _run() -> BranchResult:
+        fake_proc = MagicMock(returncode=1, stdout="", stderr="branch error")
+        with (
+            patch("repo_release_tools.workflow.git.branch_exists", return_value=False),
+            patch("subprocess.run", return_value=fake_proc),
+        ):
+            return await tools["rrt_branch_new"](
+                ctx, commit_type="feat", description="bad branch", dry_run=False
+            )
+
+    result = asyncio.run(_run())
+    assert result.created is False
+    assert result.error is not None
+    assert "git checkout -b failed" in result.error
+
+
+def test_rrt_branch_new_apply_already_exists(tmp_path: Path) -> None:
+    tools = _git_tools(tmp_path)
+    ctx = _ctx(tmp_path)
+
+    async def _run() -> BranchResult:
+        with patch("repo_release_tools.workflow.git.branch_exists", return_value=True):
+            return await tools["rrt_branch_new"](
+                ctx, commit_type="feat", description="dup", dry_run=False
+            )
+
+    result = asyncio.run(_run())
+    assert result.created is False
+    assert result.error is not None

--- a/uv.lock
+++ b/uv.lock
@@ -1182,6 +1182,7 @@ mcp = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "fastmcp", extra = ["apps"] },
     { name = "pillow" },
     { name = "poethepoet" },
     { name = "pytest" },
@@ -1196,6 +1197,7 @@ provides-extras = ["mcp"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "fastmcp", extras = ["apps"], specifier = ">=3.3.0" },
     { name = "pillow", specifier = ">=11.0" },
     { name = "poethepoet", specifier = ">=0.45.0" },
     { name = "pytest", specifier = ">=8.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,179 @@ revision = 3
 requires-python = ">=3.12"
 
 [[package]]
+name = "aiofile"
+version = "3.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "caio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/41/2fea7e193e061ce54eacc3b7bc0e6a99e4fcff43c78cf0a76dd781ed8334/aiofile-3.11.1.tar.gz", hash = "sha256:1f91912c6643d2a4e49ca4ae3514f0bf3867ce948a36d99a6411b8f4755f4cf9", size = 19342, upload-time = "2026-05-16T08:18:33.538Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/cd/0d76dfc5de72bde52f55f53e925c7d152d9c7906634ec1e0cbc7e8d4ad93/aiofile-3.11.1-py3-none-any.whl", hash = "sha256:ce77d14ac07f77bc2b757834a5c129321f3f705c474593deed5ab209079a52c9", size = 20446, upload-time = "2026-05-16T08:18:32.051Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "authlib"
+version = "1.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "joserfc" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/98/7d93f30d029643c0275dbc0bd6d5a6f670661ee6c9a94d93af7ab4887600/authlib-1.7.2.tar.gz", hash = "sha256:2cea25fefcd4e7173bdf1372c0afc265c8034b23a8cd5dcb6a9164b826c64231", size = 176511, upload-time = "2026-05-06T08:10:23.116Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/95/adcb68e20c34162e9135f370d6e31737719c2b6f94bc953fe7ed1f10fe21/authlib-1.7.2-py2.py3-none-any.whl", hash = "sha256:3e1faedc9d87e7d56a164eca3ccb6ace0d61b94abe83e92242f8dc8bba9b4a9f", size = 259548, upload-time = "2026-05-06T08:10:21.436Z" },
+]
+
+[[package]]
+name = "beartype"
+version = "0.22.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/94/1009e248bbfbab11397abca7193bea6626806be9a327d399810d523a07cb/beartype-0.22.9.tar.gz", hash = "sha256:8f82b54aa723a2848a56008d18875f91c1db02c32ef6a62319a002e3e25a975f", size = 1608866, upload-time = "2025-12-13T06:50:30.72Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl", hash = "sha256:d16c9bbc61ea14637596c5f6fbff2ee99cbe3573e46a716401734ef50c3060c2", size = 1333658, upload-time = "2025-12-13T06:50:28.266Z" },
+]
+
+[[package]]
+name = "cachetools"
+version = "7.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/8b/0d3945a13955303b81272f759a0331e54c5c793da455e6f5706b89d2639c/cachetools-7.1.4.tar.gz", hash = "sha256:437f55a4e0c1b01a4f3077cc470e6991d47430970e36fbcb77e2be0df4fc1cd6", size = 40085, upload-time = "2026-05-21T22:40:43.376Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/7b/1fc1c09cc0756cf25861a3be10565915953876da48bb228fb9a672b20a42/cachetools-7.1.4-py3-none-any.whl", hash = "sha256:323dc4127934744db5b54eb4924482d7edafbf9554e820d1531c2e08c0e4ef54", size = 16761, upload-time = "2026-05-21T22:40:41.845Z" },
+]
+
+[[package]]
+name = "caio"
+version = "0.9.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/88/b8527e1b00c1811db339a1df8bd1ae49d146fcea9d6a5c40e3a80aaeb38d/caio-0.9.25.tar.gz", hash = "sha256:16498e7f81d1d0f5a4c0ad3f2540e65fe25691376e0a5bd367f558067113ed10", size = 26781, upload-time = "2025-12-26T15:21:36.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/25/79c98ebe12df31548ba4eaf44db11b7cad6b3e7b4203718335620939083c/caio-0.9.25-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fb7ff95af4c31ad3f03179149aab61097a71fd85e05f89b4786de0359dffd044", size = 36983, upload-time = "2025-12-26T15:21:36.075Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/2b/21288691f16d479945968a0a4f2856818c1c5be56881d51d4dac9b255d26/caio-0.9.25-cp312-cp312-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:97084e4e30dfa598449d874c4d8e0c8d5ea17d2f752ef5e48e150ff9d240cd64", size = 82012, upload-time = "2025-12-26T15:22:20.983Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c4/8a1b580875303500a9c12b9e0af58cb82e47f5bcf888c2457742a138273c/caio-0.9.25-cp312-cp312-manylinux_2_34_aarch64.whl", hash = "sha256:4fa69eba47e0f041b9d4f336e2ad40740681c43e686b18b191b6c5f4c5544bfb", size = 81502, upload-time = "2026-03-04T22:08:22.381Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/1c/0fe770b8ffc8362c48134d1592d653a81a3d8748d764bec33864db36319d/caio-0.9.25-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:6bebf6f079f1341d19f7386db9b8b1f07e8cc15ae13bfdaff573371ba0575d69", size = 80200, upload-time = "2026-03-04T22:08:23.382Z" },
+    { url = "https://files.pythonhosted.org/packages/31/57/5e6ff127e6f62c9f15d989560435c642144aa4210882f9494204bc892305/caio-0.9.25-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d6c2a3411af97762a2b03840c3cec2f7f728921ff8adda53d7ea2315a8563451", size = 36979, upload-time = "2025-12-26T15:21:35.484Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/9f/f21af50e72117eb528c422d4276cbac11fb941b1b812b182e0a9c70d19c5/caio-0.9.25-cp313-cp313-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0998210a4d5cd5cb565b32ccfe4e53d67303f868a76f212e002a8554692870e6", size = 81900, upload-time = "2025-12-26T15:22:21.919Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/12/c39ae2a4037cb10ad5eb3578eb4d5f8c1a2575c62bba675f3406b7ef0824/caio-0.9.25-cp313-cp313-manylinux_2_34_aarch64.whl", hash = "sha256:1a177d4777141b96f175fe2c37a3d96dec7911ed9ad5f02bac38aaa1c936611f", size = 81523, upload-time = "2026-03-04T22:08:25.187Z" },
+    { url = "https://files.pythonhosted.org/packages/22/59/f8f2e950eb4f1a5a3883e198dca514b9d475415cb6cd7b78b9213a0dd45a/caio-0.9.25-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:9ed3cfb28c0e99fec5e208c934e5c157d0866aa9c32aa4dc5e9b6034af6286b7", size = 80243, upload-time = "2026-03-04T22:08:26.449Z" },
+    { url = "https://files.pythonhosted.org/packages/69/ca/a08fdc7efdcc24e6a6131a93c85be1f204d41c58f474c42b0670af8c016b/caio-0.9.25-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fab6078b9348e883c80a5e14b382e6ad6aabbc4429ca034e76e730cf464269db", size = 36978, upload-time = "2025-12-26T15:21:41.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/6c/d4d24f65e690213c097174d26eda6831f45f4734d9d036d81790a27e7b78/caio-0.9.25-cp314-cp314-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:44a6b58e52d488c75cfaa5ecaa404b2b41cc965e6c417e03251e868ecd5b6d77", size = 81832, upload-time = "2025-12-26T15:22:22.757Z" },
+    { url = "https://files.pythonhosted.org/packages/87/a4/e534cf7d2d0e8d880e25dd61e8d921ffcfe15bd696734589826f5a2df727/caio-0.9.25-cp314-cp314-manylinux_2_34_aarch64.whl", hash = "sha256:628a630eb7fb22381dd8e3c8ab7f59e854b9c806639811fc3f4310c6bd711d79", size = 81565, upload-time = "2026-03-04T22:08:27.483Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ed/bf81aeac1d290017e5e5ac3e880fd56ee15e50a6d0353986799d1bc5cfd5/caio-0.9.25-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:0ba16aa605ccb174665357fc729cf500679c2d94d5f1458a6f0d5ca48f2060a7", size = 80071, upload-time = "2026-03-04T22:08:28.751Z" },
+    { url = "https://files.pythonhosted.org/packages/86/93/1f76c8d1bafe3b0614e06b2195784a3765bbf7b0a067661af9e2dd47fc33/caio-0.9.25-py3-none-any.whl", hash = "sha256:06c0bb02d6b929119b1cfbe1ca403c768b2013a369e2db46bfa2a5761cf82e40", size = 19087, upload-time = "2025-12-26T15:22:00.221Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.5.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639, upload-time = "2026-05-22T04:08:35.26Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -96,12 +269,456 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "48.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984, upload-time = "2026-05-04T22:59:38.133Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/3d/01f6dd9190170a5a241e0e98c2d04be3664a9e6f5b9b872cde63aff1c3dd/cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6", size = 8001587, upload-time = "2026-05-04T22:57:36.803Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c", size = 4690433, upload-time = "2026-05-04T22:57:40.373Z" },
+    { url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3", size = 4710620, upload-time = "2026-05-04T22:57:42.935Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5", size = 4696283, upload-time = "2026-05-04T22:57:45.294Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/29/174b9dfb60b12d59ecfc6cfa04bc88c21b42a54f01b8aae09bb6e51e4c7f/cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c", size = 5296573, upload-time = "2026-05-04T22:57:47.933Z" },
+    { url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f", size = 4743677, upload-time = "2026-05-04T22:57:50.067Z" },
+    { url = "https://files.pythonhosted.org/packages/30/be/eef653013d5c63b6a490529e0316f9ac14a37602965d4903efed1399f32b/cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25", size = 4330808, upload-time = "2026-05-04T22:57:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602", size = 4695941, upload-time = "2026-05-04T22:57:54.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/dc/7303087450c2ec9e7fbb750e17c2abfbc658f23cbd0e54009509b7cc4091/cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c", size = 5252579, upload-time = "2026-05-04T22:57:57.207Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5", size = 4743326, upload-time = "2026-05-04T22:57:59.535Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321", size = 4826672, upload-time = "2026-05-04T22:58:01.996Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74", size = 4972574, upload-time = "2026-05-04T22:58:03.968Z" },
+    { url = "https://files.pythonhosted.org/packages/04/70/e5a1b41d325f797f39427aa44ef8baf0be500065ab6d8e10369d850d4a4f/cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4", size = 3294868, upload-time = "2026-05-04T22:58:06.467Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ac/8ac51b4a5fc5932eb7ee5c517ba7dc8cd834f0048962b6b352f00f41ebf9/cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7", size = 3817107, upload-time = "2026-05-04T22:58:08.845Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/84/70e3feea9feea87fd7cbe77efb2712ae1e3e6edf10749dc6e95f4e60e455/cryptography-48.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:3cb07a3ed6431663cd321ea8a000a1314c74211f823e4177fefa2255e057d1ec", size = 7986556, upload-time = "2026-05-04T22:58:11.172Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6e/18e07a618bb5442ba10cf4df16e99c071365528aa570dfcb8c02e25a303b/cryptography-48.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c7378637d7d88016fa6791c159f698b3d3eed28ebf844ac36b9dc04a14dae18", size = 4684776, upload-time = "2026-05-04T22:58:13.712Z" },
+    { url = "https://files.pythonhosted.org/packages/be/6a/4ea3b4c6c6759794d5ee2103c304a5076dc4b19ae1f9fe47dba439e159e9/cryptography-48.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc90c0b39b2e3c65ef52c804b72e3c58f8a04ab2a1871272798e5f9572c17d20", size = 4698121, upload-time = "2026-05-04T22:58:16.448Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/59/6ff6ad6cae03bb887da2a5860b2c9805f8dac969ef01ce563336c49bd1d1/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:76341972e1eff8b4bea859f09c0d3e64b96ce931b084f9b9b7db8ef364c30eff", size = 4690042, upload-time = "2026-05-04T22:58:18.544Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/b4/fc334ed8cfd705aca282fe4d8f5ae64a8e0f74932e9feecb344610cf6e4d/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:55b7718303bf06a5753dcdccf2f3945cf18ad7bffde41b61226e4db31ab89a9c", size = 5282526, upload-time = "2026-05-04T22:58:20.75Z" },
+    { url = "https://files.pythonhosted.org/packages/11/08/9f8c5386cc4cd90d8255c7cdd0f5baf459a08502a09de30dc51f553d38dc/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a64697c641c7b1b2178e573cbc31c7c6684cd56883a478d75143dbb7118036db", size = 4733116, upload-time = "2026-05-04T22:58:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/77/99307d7574045699f8805aa500fa0fb83422d115b5400a064ddd306d7750/cryptography-48.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:561215ea3879cb1cbbf272867e2efda62476f240fb58c64de6b393ae19246741", size = 4316030, upload-time = "2026-05-04T22:58:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/36/a608b98337af3cb2aff4818e406649d30572b7031918b04c87d979495348/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ad64688338ed4bc1a6618076ba75fd7194a5f1797ac60b47afe926285adb3166", size = 4689640, upload-time = "2026-05-04T22:58:27.747Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a6/825010a291b4438aecc1f568bc428189fc1175515223632477c07dc0a6df/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:906cbf0670286c6e0044156bc7d4af9cbb0ef6db9f73e52c3ec56ba6bdde5336", size = 5237657, upload-time = "2026-05-04T22:58:29.848Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/09/4e76a09b4caa29aad535ddc806f5d4c5d01885bd978bd984fbc6ca032cae/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:ea8990436d914540a40ab24b6a77c0969695ed52f4a4874c5137ccf7045a7057", size = 4732362, upload-time = "2026-05-04T22:58:32.009Z" },
+    { url = "https://files.pythonhosted.org/packages/18/78/444fa04a77d0cb95f417dda20d450e13c56ba8e5220fc892a1658f44f882/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c18684a7f0cc9a3cb60328f496b8e3372def7c5d2df39ac267878b05565aaaae", size = 4819580, upload-time = "2026-05-04T22:58:34.254Z" },
+    { url = "https://files.pythonhosted.org/packages/38/85/ea67067c70a1fd4be2c63d35eeed82658023021affccc7b17705f8527dd2/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9be5aafa5736574f8f15f262adc81b2a9869e2cfe9014d52a44633905b40d52c", size = 4963283, upload-time = "2026-05-04T22:58:36.376Z" },
+    { url = "https://files.pythonhosted.org/packages/75/54/cc6d0f3deac3e81c7f847e8a189a12b6cdd65059b43dad25d4316abd849a/cryptography-48.0.0-cp314-cp314t-win32.whl", hash = "sha256:c17dfe85494deaeddc5ce251aebd1d60bbe6afc8b62071bb0b469431a000124f", size = 3270954, upload-time = "2026-05-04T22:58:38.791Z" },
+    { url = "https://files.pythonhosted.org/packages/49/67/cc947e288c0758a4e5473d1dcb743037ab7785541265a969240b8885441a/cryptography-48.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27241b1dc9962e056062a8eef1991d02c3a24569c95975bd2322a8a52c6e5e12", size = 3797313, upload-time = "2026-05-04T22:58:40.746Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/63/61d4a4e1c6b6bab6ce1e213cd36a24c415d90e76d78c5eb8577c5541d2e8/cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86", size = 7983482, upload-time = "2026-05-04T22:58:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e", size = 4683266, upload-time = "2026-05-04T22:58:46.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f", size = 4696228, upload-time = "2026-05-04T22:58:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7", size = 4689097, upload-time = "2026-05-04T22:58:50.9Z" },
+    { url = "https://files.pythonhosted.org/packages/93/01/d86632d7d28db8ae83221995752eeb6639ffb374c2d22955648cf8d52797/cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832", size = 5283582, upload-time = "2026-05-04T22:58:53.017Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c", size = 4730479, upload-time = "2026-05-04T22:58:55.611Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/af/99a582b1b1641ff5911ac559beb45097cf79efd4ead4657f578ef1af2d47/cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a", size = 4326481, upload-time = "2026-05-04T22:58:57.607Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a", size = 4688713, upload-time = "2026-05-04T22:59:00.077Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ba/bcb1b0bb7a33d4c7c0c4d4c7874b4a62ae4f56113a5f4baefa362dfb1f0f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a", size = 5238165, upload-time = "2026-05-04T22:59:02.317Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239", size = 4729947, upload-time = "2026-05-04T22:59:05.255Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c", size = 4822059, upload-time = "2026-05-04T22:59:07.802Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
+]
+
+[[package]]
+name = "cyclopts"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "docstring-parser" },
+    { name = "rich" },
+    { name = "rich-rst" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/fe/da593db56d872f53fd1abfeb0c801310d3b7629a3b50873c2e13c5a3cac4/cyclopts-4.15.0.tar.gz", hash = "sha256:3b5655581bcb759880abf1aeebf6fd370a3a4da8cf1248dd71061e357a525a34", size = 177765, upload-time = "2026-05-21T12:23:22.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/85/72020c6d9c185ea36742e005d9e8f3b47ff8a4181ced8ff03d66e655de6b/cyclopts-4.15.0-py3-none-any.whl", hash = "sha256:0eb784abb4ea8893099429e903193ff31edcb5fe17a619fa93c6eaf60bf51f1f", size = 215341, upload-time = "2026-05-21T12:23:23.549Z" },
+]
+
+[[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "fastmcp"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fastmcp-slim", extra = ["client", "server"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/a9/5c5a01b6abd5346bf60b97cfd29e4a86661940c27dd562bfcda07fd03519/fastmcp-3.3.1.tar.gz", hash = "sha256:979362ea557de42a5f40342563c7e4b236bcc8e7cd192715f50030695d1a71cd", size = 28681699, upload-time = "2026-05-15T15:50:39.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/11/6b1bdada6ccfe647d615ae63f9106f8136aec17971e9361546af01c7d38e/fastmcp-3.3.1-py3-none-any.whl", hash = "sha256:862440c5c4d281363a5995eee59d77f0f7cac1f18869038729cecf03b02fc522", size = 7903, upload-time = "2026-05-15T15:50:36.424Z" },
+]
+
+[package.optional-dependencies]
+apps = [
+    { name = "fastmcp-slim", extra = ["apps"] },
+]
+
+[[package]]
+name = "fastmcp-slim"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "platformdirs" },
+    { name = "pydantic", extra = ["email"] },
+    { name = "pydantic-settings" },
+    { name = "python-dotenv" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/a0/627103e517e1d0d6f1eec633d5662d13e776f01b45ad188e4f5f7478b438/fastmcp_slim-3.3.1.tar.gz", hash = "sha256:0957835fc59452e143ab2f4b7836d2d2df9b2d9958408edc79ba8b56232b2a88", size = 567007, upload-time = "2026-05-15T15:50:10.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/ee/97047f4cc2d7b1d46670d08d8ad01a96e7a748cc01c0b4b351ad8eddbc7a/fastmcp_slim-3.3.1-py3-none-any.whl", hash = "sha256:6cf1c2d77e3adb0d409d6825ed6b0b2a999062973e00b8eea03bd48bf9b4c043", size = 738644, upload-time = "2026-05-15T15:50:08.336Z" },
+]
+
+[package.optional-dependencies]
+apps = [
+    { name = "prefab-ui" },
+]
+client = [
+    { name = "authlib" },
+    { name = "exceptiongroup" },
+    { name = "httpx" },
+    { name = "mcp" },
+    { name = "opentelemetry-api" },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+]
+server = [
+    { name = "authlib" },
+    { name = "cyclopts" },
+    { name = "exceptiongroup" },
+    { name = "griffelib" },
+    { name = "httpx" },
+    { name = "jsonref" },
+    { name = "jsonschema-path" },
+    { name = "mcp" },
+    { name = "openapi-pydantic" },
+    { name = "opentelemetry-api" },
+    { name = "packaging" },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+    { name = "pyperclip" },
+    { name = "python-multipart" },
+    { name = "pyyaml" },
+    { name = "uncalled-for" },
+    { name = "uvicorn" },
+    { name = "watchfiles" },
+    { name = "websockets" },
+]
+
+[[package]]
+name = "griffelib"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/82/74f4a3310cdabfbb10da554c3a672847f1ed33c6f61dd472681ce7f1fe67/griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e", size = 166461, upload-time = "2026-03-27T11:34:51.091Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/8c/c9138d881c79aa0ea9ed83cbd58d5ca75624378b38cee225dcf5c42cc91f/griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1", size = 142357, upload-time = "2026-03-27T11:34:46.275Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload-time = "2024-03-31T07:27:34.792Z" },
+]
+
+[[package]]
+name = "jaraco-context"
+version = "6.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3", size = 16801, upload-time = "2026-03-20T22:13:33.922Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535", size = 7871, upload-time = "2026-03-20T22:13:32.808Z" },
+]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/cf/ea4ef2920830dea3f5ab2ea4da6fb67724e6dca80ee2553788c3607243d0/jaraco_functools-4.5.0.tar.gz", hash = "sha256:3bb5665ea4a020cf78a7040e89154c77edadb3ca74f366479669c5999aa70b03", size = 20272, upload-time = "2026-05-15T21:34:10.025Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/9a/982e48afcffcd727a9144506720ffd4224b6b7e355c98641866f38b7c043/jaraco_functools-4.5.0-py3-none-any.whl", hash = "sha256:79ce39246eddbde4b3a03b77ea5f0f7878dc669b166a66cf3fa8e266aa3fa2f4", size = 10594, upload-time = "2026-05-15T21:34:08.595Z" },
+]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
+]
+
+[[package]]
+name = "joserfc"
+version = "1.6.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1b/cb/52e479f20804904f5df20ac4539d292dcecd1287aaa33cba1d1def1d9d8e/joserfc-1.6.7.tar.gz", hash = "sha256:6999fe89457069ecacd8cc797c88a805f83054dd883333fa0409f74b46479fd7", size = 232158, upload-time = "2026-05-23T01:46:44.069Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/e4/bcf6718b5662894c6831f46296b73cd4b1a2e90c20b6d437e20c4997388c/joserfc-1.6.7-py3-none-any.whl", hash = "sha256:9e51e4a64840aa1734a058258e80a4480e2ff2d5686e480e7c92c954a92fbe05", size = 70603, upload-time = "2026-05-23T01:46:42.129Z" },
+]
+
+[[package]]
+name = "jsonref"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/0d/c1f3277e90ccdb50d33ed5ba1ec5b3f0a242ed8c1b1a85d3afeb68464dca/jsonref-1.1.0.tar.gz", hash = "sha256:32fe8e1d85af0fdefbebce950af85590b22b60f9e95443176adbde4e1ecea552", size = 8814, upload-time = "2023-01-16T16:10:04.455Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/ec/e1db9922bceb168197a558a2b8c03a7963f1afe93517ddd3cf99f202f996/jsonref-1.1.0-py3-none-any.whl", hash = "sha256:590dc7773df6c21cbf948b5dac07a72a251db28b0238ceecce0a2abfa8ec30a9", size = 9425, upload-time = "2023-01-16T16:10:02.255Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-path"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "pathable" },
+    { name = "pyyaml" },
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/79/cd02a4df6d9270efdc7d3feefe6edd730b0820c39eeaa107a2faee8322d5/jsonschema_path-0.5.0.tar.gz", hash = "sha256:493b156ba895c97602655b620a8456caa2ce08c1aa389f5a7addec065e6e855c", size = 19597, upload-time = "2026-05-19T20:45:00.971Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/2c/9e69d73c4297508be9e3b64a970ea3971b3eb8db64ffc5802d40bd25981f/jsonschema_path-0.5.0-py3-none-any.whl", hash = "sha256:2790a070bc7abb08ea3dbe4d340ece4efadf639223001f020c7503229ba068e2", size = 24077, upload-time = "2026-05-19T20:44:59.225Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "keyring"
+version = "25.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jaraco-classes" },
+    { name = "jaraco-context" },
+    { name = "jaraco-functools" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "secretstorage", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
+name = "mcp"
+version = "1.27.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/83/d1efe7c2980d8a3afa476f4e3d42d53dd54c0ab94c27bee5d755b45c8b73/mcp-1.27.1.tar.gz", hash = "sha256:0f47e1820f8f8f941466b39749eb1d1839a04caddca2bc60e9d46e8a99914924", size = 608458, upload-time = "2026-05-08T16:50:12.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/73/42d9596facebdb533b7f0b86c1b0364ef350d1f8ba78b1052e8a58b48b65/mcp-1.27.1-py3-none-any.whl", hash = "sha256:1af3c4203b329430fde7a87b4fcb6392a041f5cb851fd68fc674016ab4e7c06f", size = 216260, upload-time = "2026-05-08T16:50:10.547Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "more-itertools"
+version = "11.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/1d/f4da6f02cdffe04d6362210b807146a26044c88d839208aec273bb0d9184/more_itertools-11.1.0.tar.gz", hash = "sha256:48e8f4d9e7e5878571ecf6f2b4e57634f93cd474cc8cfbd2376f2d11b396e30d", size = 145772, upload-time = "2026-05-22T14:14:29.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl", hash = "sha256:4b65538ae22f6fed0ce4874efd317463a7489796a0939fa66824dd542125a192", size = 72226, upload-time = "2026-05-22T14:14:28.824Z" },
+]
+
+[[package]]
+name = "openapi-pydantic"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/2e/58d83848dd1a79cb92ed8e63f6ba901ca282c5f09d04af9423ec26c56fd7/openapi_pydantic-0.5.1.tar.gz", hash = "sha256:ff6835af6bde7a459fb93eb93bb92b8749b754fc6e51b2f1590a19dc3005ee0d", size = 60892, upload-time = "2025-01-08T19:29:27.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/cf/03675d8bd8ecbf4445504d8071adab19f5f993676795708e36402ab38263/openapi_pydantic-0.5.1-py3-none-any.whl", hash = "sha256:a3a09ef4586f5bd760a8df7f43028b60cafb6d9f61de2acba9574766255ab146", size = 96381, upload-time = "2025-01-08T19:29:25.275Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.42.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/1c/125e1c936c0873796771b7f04f6c93b9f1bf5d424cea90fda94a99f61da8/opentelemetry_api-1.42.1.tar.gz", hash = "sha256:56c63bea9f77b62856be8c47600474acad853b2924b99b1687c4cb6297166716", size = 72296, upload-time = "2026-05-21T16:32:49.335Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/ca/9520cc1f3dfbbd03ac5903bbf55833e257bc64b1cf30fa8b0d6df374d821/opentelemetry_api-1.42.1-py3-none-any.whl", hash = "sha256:51a69edacadbc03a8950ace1c4c21099cacc538820ac2c9e36277e78cebba714", size = 61311, upload-time = "2026-05-21T16:32:28.822Z" },
 ]
 
 [[package]]
@@ -120,6 +737,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/76/f1/4594f5e0fcddb6953e5b8fe00da8c317b8b41b547e2b3ae2da7512943c62/pastel-0.2.1.tar.gz", hash = "sha256:e6581ac04e973cac858828c6202c1e1e81fee1dc7de7683f3e1ffe0bfd8a573d", size = 7555, upload-time = "2020-09-16T19:21:12.43Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/aa/18/a8444036c6dd65ba3624c63b734d3ba95ba63ace513078e1580590075d21/pastel-0.2.1-py2.py3-none-any.whl", hash = "sha256:4349225fcdf6c2bb34d483e523475de5bb04a5c10ef711263452cb37d7dd4364", size = 5955, upload-time = "2020-09-16T19:21:11.409Z" },
+]
+
+[[package]]
+name = "pathable"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/f3/5a20387de9bcd0607871bfc2198ee0e15836da7baa4592ccd7f24c27c986/pathable-0.6.0.tar.gz", hash = "sha256:6404b8b82aef5ff0fd478934137128b99b12212ba35afdde5525ca4f8388ea58", size = 18970, upload-time = "2026-05-19T18:15:11.911Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/e8/6d75ffd9784bce2e93d1ae4415649427e39a53bb172d4672b2b59c6f0a7b/pathable-0.6.0-py3-none-any.whl", hash = "sha256:82c4ca6c98c502ad12e0d4e9779b6210afee93c38990988c8c5d1b49bdcdf566", size = 18983, upload-time = "2026-05-19T18:15:10.728Z" },
 ]
 
 [[package]]
@@ -192,6 +818,15 @@ wheels = [
 ]
 
 [[package]]
+name = "platformdirs"
+version = "4.9.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -214,12 +849,192 @@ wheels = [
 ]
 
 [[package]]
+name = "prefab-ui"
+version = "0.20.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cyclopts" },
+    { name = "pydantic" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/24/2a/6a36448f567b252ead422880928c784cfaf4806dde56dd40d4acab06324f/prefab_ui-0.20.1.tar.gz", hash = "sha256:8508c62386835fdd259875042610b7b2eab5e4df23d253b412dd5a6f078d2311", size = 4100703, upload-time = "2026-05-23T15:12:49.445Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/d3/84be58c44ae1b567729f11dfc52f4392fdc25b185d730179c8867809aadd/prefab_ui-0.20.1-py3-none-any.whl", hash = "sha256:4a212b695cb2d9e1540e63b6faf008b0d73aefbbe2d7245f852ca1933ac76a1c", size = 1852273, upload-time = "2026-05-23T15:12:47.991Z" },
+]
+
+[[package]]
+name = "py-key-value-aio"
+version = "0.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beartype" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/3c/0397c072a38d4bc580994b42e0c90c5f44f679303489e4376289534735e5/py_key_value_aio-0.4.4.tar.gz", hash = "sha256:e3012e6243ed7cc09bb05457bd4d03b1ba5c2b1ca8700096b3927db79ffbbe55", size = 92300, upload-time = "2026-02-16T21:21:43.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/69/f1b537ee70b7def42d63124a539ed3026a11a3ffc3086947a1ca6e861868/py_key_value_aio-0.4.4-py3-none-any.whl", hash = "sha256:18e17564ecae61b987f909fc2cd41ee2012c84b4b1dcb8c055cf8b4bc1bf3f5d", size = 152291, upload-time = "2026-02-16T21:21:44.241Z" },
+]
+
+[package.optional-dependencies]
+filetree = [
+    { name = "aiofile" },
+    { name = "anyio" },
+]
+keyring = [
+    { name = "keyring" },
+]
+memory = [
+    { name = "cachetools" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[package.optional-dependencies]
+email = [
+    { name = "email-validator" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
+name = "pyperclip"
+version = "1.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/52/d87eba7cb129b81563019d1679026e7a112ef76855d6159d24754dbd2a51/pyperclip-1.11.0.tar.gz", hash = "sha256:244035963e4428530d9e3a6101a1ef97209c6825edab1567beac148ccc1db1b6", size = 12185, upload-time = "2025-09-26T14:40:37.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl", hash = "sha256:299403e9ff44581cb9ba2ffeed69c7aa96a008622ad0c46cb575ca75b5b84273", size = 11063, upload-time = "2025-09-26T14:40:36.069Z" },
 ]
 
 [[package]]
@@ -250,6 +1065,49 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.29"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/fe/70bd71a6738b09a0bdf6480ca6436b167469ca4578b2a0efbe390b4b0e70/python_multipart-0.0.29.tar.gz", hash = "sha256:643e93849196645e2dbdd81a0f8829a23123ad7f797a84a364c6fb3563f18904", size = 45678, upload-time = "2026-05-17T17:29:47.654Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/cb/769cfc37177252872a45a71f3fbdde9d51b471a3f3c14bfe95dde3407386/python_multipart-0.0.29-py3-none-any.whl", hash = "sha256:2ddcc971cef266225f54f552d8fa10bcfbb1f14446caec199060daac59ff2d69", size = 29640, upload-time = "2026-05-17T17:29:45.69Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543, upload-time = "2025-07-14T20:13:20.765Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040, upload-time = "2025-07-14T20:13:22.543Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102, upload-time = "2025-07-14T20:13:24.682Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
+]
+
+[[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
 ]
 
 [[package]]
@@ -299,9 +1157,28 @@ wheels = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "repo-release-tools"
 version = "1.6.2"
 source = { editable = "." }
+
+[package.optional-dependencies]
+mcp = [
+    { name = "fastmcp", extra = ["apps"] },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -314,6 +1191,8 @@ dev = [
 ]
 
 [package.metadata]
+requires-dist = [{ name = "fastmcp", extras = ["apps"], marker = "extra == 'mcp'", specifier = ">=3.3.0" }]
+provides-extras = ["mcp"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -323,6 +1202,113 @@ dev = [
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "ruff", specifier = ">=0.14.0" },
     { name = "ty", specifier = ">=0.0.26" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "rich-rst"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pygments" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/56/3191bae66b08ccc637ea8120426068bcb361cc323c96404c310886937067/rich_rst-2.0.1.tar.gz", hash = "sha256:cbe236ed0901d1ec8427cc6a50bf0a34353ba28ad014dc24def68bfe7f3b9e68", size = 300570, upload-time = "2026-05-16T00:47:57.362Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/3d/55c17d3ebdf3cd81356002afe5bef9bb8af631db2819785b6eac845b925b/rich_rst-2.0.1-py3-none-any.whl", hash = "sha256:7ee15f345ce25fa02b582c272a6cdbaf0c21243e38061cea273cff659bf3ef61", size = 272922, upload-time = "2026-05-16T00:47:55.508Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e7/98a2f4ac921d82f33e03f3835f5bf3a4a40aa1bfdc57975e74a97b2b4bdd/rpds_py-0.30.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a161f20d9a43006833cd7068375a94d035714d73a172b681d8881820600abfad", size = 375086, upload-time = "2025-11-30T20:22:17.93Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a1/bca7fd3d452b272e13335db8d6b0b3ecde0f90ad6f16f3328c6fb150c889/rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05", size = 359053, upload-time = "2025-11-30T20:22:19.297Z" },
+    { url = "https://files.pythonhosted.org/packages/65/1c/ae157e83a6357eceff62ba7e52113e3ec4834a84cfe07fa4b0757a7d105f/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca28829ae5f5d569bb62a79512c842a03a12576375d5ece7d2cadf8abe96ec28", size = 390763, upload-time = "2025-11-30T20:22:21.661Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/36/eb2eb8515e2ad24c0bd43c3ee9cd74c33f7ca6430755ccdb240fd3144c44/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a1010ed9524c73b94d15919ca4d41d8780980e1765babf85f9a2f90d247153dd", size = 408951, upload-time = "2025-11-30T20:22:23.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/65/ad8dc1784a331fabbd740ef6f71ce2198c7ed0890dab595adb9ea2d775a1/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8d1736cfb49381ba528cd5baa46f82fdc65c06e843dab24dd70b63d09121b3f", size = 514622, upload-time = "2025-11-30T20:22:25.16Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8e/0cfa7ae158e15e143fe03993b5bcd743a59f541f5952e1546b1ac1b5fd45/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d948b135c4693daff7bc2dcfc4ec57237a29bd37e60c2fabf5aff2bbacf3e2f1", size = 414492, upload-time = "2025-11-30T20:22:26.505Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47f236970bccb2233267d89173d3ad2703cd36a0e2a6e92d0560d333871a3d23", size = 394080, upload-time = "2025-11-30T20:22:27.934Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d5/a266341051a7a3ca2f4b750a3aa4abc986378431fc2da508c5034d081b70/rpds_py-0.30.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2e6ecb5a5bcacf59c3f912155044479af1d0b6681280048b338b28e364aca1f6", size = 408680, upload-time = "2025-11-30T20:22:29.341Z" },
+    { url = "https://files.pythonhosted.org/packages/10/3b/71b725851df9ab7a7a4e33cf36d241933da66040d195a84781f49c50490c/rpds_py-0.30.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a8fa71a2e078c527c3e9dc9fc5a98c9db40bcc8a92b4e8858e36d329f8684b51", size = 423589, upload-time = "2025-11-30T20:22:31.469Z" },
+    { url = "https://files.pythonhosted.org/packages/00/2b/e59e58c544dc9bd8bd8384ecdb8ea91f6727f0e37a7131baeff8d6f51661/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73c67f2db7bc334e518d097c6d1e6fed021bbc9b7d678d6cc433478365d1d5f5", size = 573289, upload-time = "2025-11-30T20:22:32.997Z" },
+    { url = "https://files.pythonhosted.org/packages/da/3e/a18e6f5b460893172a7d6a680e86d3b6bc87a54c1f0b03446a3c8c7b588f/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5ba103fb455be00f3b1c2076c9d4264bfcb037c976167a6047ed82f23153f02e", size = 599737, upload-time = "2025-11-30T20:22:34.419Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e2/714694e4b87b85a18e2c243614974413c60aa107fd815b8cbc42b873d1d7/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7cee9c752c0364588353e627da8a7e808a66873672bcb5f52890c33fd965b394", size = 563120, upload-time = "2025-11-30T20:22:35.903Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ab/d5d5e3bcedb0a77f4f613706b750e50a5a3ba1c15ccd3665ecc636c968fd/rpds_py-0.30.0-cp312-cp312-win32.whl", hash = "sha256:1ab5b83dbcf55acc8b08fc62b796ef672c457b17dbd7820a11d6c52c06839bdf", size = 223782, upload-time = "2025-11-30T20:22:37.271Z" },
+    { url = "https://files.pythonhosted.org/packages/39/3b/f786af9957306fdc38a74cef405b7b93180f481fb48453a114bb6465744a/rpds_py-0.30.0-cp312-cp312-win_amd64.whl", hash = "sha256:a090322ca841abd453d43456ac34db46e8b05fd9b3b4ac0c78bcde8b089f959b", size = 240463, upload-time = "2025-11-30T20:22:39.021Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d2/b91dc748126c1559042cfe41990deb92c4ee3e2b415f6b5234969ffaf0cc/rpds_py-0.30.0-cp312-cp312-win_arm64.whl", hash = "sha256:669b1805bd639dd2989b281be2cfd951c6121b65e729d9b843e9639ef1fd555e", size = 230868, upload-time = "2025-11-30T20:22:40.493Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/dc/d61221eb88ff410de3c49143407f6f3147acf2538c86f2ab7ce65ae7d5f9/rpds_py-0.30.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2", size = 374887, upload-time = "2025-11-30T20:22:41.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/32/55fb50ae104061dbc564ef15cc43c013dc4a9f4527a1f4d99baddf56fe5f/rpds_py-0.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8", size = 358904, upload-time = "2025-11-30T20:22:43.479Z" },
+    { url = "https://files.pythonhosted.org/packages/58/70/faed8186300e3b9bdd138d0273109784eea2396c68458ed580f885dfe7ad/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4", size = 389945, upload-time = "2025-11-30T20:22:44.819Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a8/073cac3ed2c6387df38f71296d002ab43496a96b92c823e76f46b8af0543/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136", size = 407783, upload-time = "2025-11-30T20:22:46.103Z" },
+    { url = "https://files.pythonhosted.org/packages/77/57/5999eb8c58671f1c11eba084115e77a8899d6e694d2a18f69f0ba471ec8b/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7", size = 515021, upload-time = "2025-11-30T20:22:47.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/af/5ab4833eadc36c0a8ed2bc5c0de0493c04f6c06de223170bd0798ff98ced/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2", size = 414589, upload-time = "2025-11-30T20:22:48.872Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/de/f7192e12b21b9e9a68a6d0f249b4af3fdcdff8418be0767a627564afa1f1/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6", size = 394025, upload-time = "2025-11-30T20:22:50.196Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c4/fc70cd0249496493500e7cc2de87504f5aa6509de1e88623431fec76d4b6/rpds_py-0.30.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e", size = 408895, upload-time = "2025-11-30T20:22:51.87Z" },
+    { url = "https://files.pythonhosted.org/packages/58/95/d9275b05ab96556fefff73a385813eb66032e4c99f411d0795372d9abcea/rpds_py-0.30.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d", size = 422799, upload-time = "2025-11-30T20:22:53.341Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c1/3088fc04b6624eb12a57eb814f0d4997a44b0d208d6cace713033ff1a6ba/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7", size = 572731, upload-time = "2025-11-30T20:22:54.778Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/42/c612a833183b39774e8ac8fecae81263a68b9583ee343db33ab571a7ce55/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31", size = 599027, upload-time = "2025-11-30T20:22:56.212Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/60/525a50f45b01d70005403ae0e25f43c0384369ad24ffe46e8d9068b50086/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95", size = 563020, upload-time = "2025-11-30T20:22:58.2Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/5d/47c4655e9bcd5ca907148535c10e7d489044243cc9941c16ed7cd53be91d/rpds_py-0.30.0-cp313-cp313-win32.whl", hash = "sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d", size = 223139, upload-time = "2025-11-30T20:23:00.209Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/e1/485132437d20aa4d3e1d8b3fb5a5e65aa8139f1e097080c2a8443201742c/rpds_py-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15", size = 240224, upload-time = "2025-11-30T20:23:02.008Z" },
+    { url = "https://files.pythonhosted.org/packages/24/95/ffd128ed1146a153d928617b0ef673960130be0009c77d8fbf0abe306713/rpds_py-0.30.0-cp313-cp313-win_arm64.whl", hash = "sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1", size = 230645, upload-time = "2025-11-30T20:23:03.43Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1b/b10de890a0def2a319a2626334a7f0ae388215eb60914dbac8a3bae54435/rpds_py-0.30.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a", size = 364443, upload-time = "2025-11-30T20:23:04.878Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bf/27e39f5971dc4f305a4fb9c672ca06f290f7c4e261c568f3dea16a410d47/rpds_py-0.30.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e", size = 353375, upload-time = "2025-11-30T20:23:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/40/58/442ada3bba6e8e6615fc00483135c14a7538d2ffac30e2d933ccf6852232/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000", size = 383850, upload-time = "2025-11-30T20:23:07.825Z" },
+    { url = "https://files.pythonhosted.org/packages/14/14/f59b0127409a33c6ef6f5c1ebd5ad8e32d7861c9c7adfa9a624fc3889f6c/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db", size = 392812, upload-time = "2025-11-30T20:23:09.228Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/66/e0be3e162ac299b3a22527e8913767d869e6cc75c46bd844aa43fb81ab62/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2", size = 517841, upload-time = "2025-11-30T20:23:11.186Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/55/fa3b9cf31d0c963ecf1ba777f7cf4b2a2c976795ac430d24a1f43d25a6ba/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa", size = 408149, upload-time = "2025-11-30T20:23:12.864Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ca/780cf3b1a32b18c0f05c441958d3758f02544f1d613abf9488cd78876378/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083", size = 383843, upload-time = "2025-11-30T20:23:14.638Z" },
+    { url = "https://files.pythonhosted.org/packages/82/86/d5f2e04f2aa6247c613da0c1dd87fcd08fa17107e858193566048a1e2f0a/rpds_py-0.30.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9", size = 396507, upload-time = "2025-11-30T20:23:16.105Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/9a/453255d2f769fe44e07ea9785c8347edaf867f7026872e76c1ad9f7bed92/rpds_py-0.30.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0", size = 414949, upload-time = "2025-11-30T20:23:17.539Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/31/622a86cdc0c45d6df0e9ccb6becdba5074735e7033c20e401a6d9d0e2ca0/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94", size = 565790, upload-time = "2025-11-30T20:23:19.029Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/5d/15bbf0fb4a3f58a3b1c67855ec1efcc4ceaef4e86644665fff03e1b66d8d/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08", size = 590217, upload-time = "2025-11-30T20:23:20.885Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/61/21b8c41f68e60c8cc3b2e25644f0e3681926020f11d06ab0b78e3c6bbff1/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27", size = 555806, upload-time = "2025-11-30T20:23:22.488Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/39/7e067bb06c31de48de3eb200f9fc7c58982a4d3db44b07e73963e10d3be9/rpds_py-0.30.0-cp313-cp313t-win32.whl", hash = "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6", size = 211341, upload-time = "2025-11-30T20:23:24.449Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4d/222ef0b46443cf4cf46764d9c630f3fe4abaa7245be9417e56e9f52b8f65/rpds_py-0.30.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d", size = 225768, upload-time = "2025-11-30T20:23:25.908Z" },
+    { url = "https://files.pythonhosted.org/packages/86/81/dad16382ebbd3d0e0328776d8fd7ca94220e4fa0798d1dc5e7da48cb3201/rpds_py-0.30.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0", size = 362099, upload-time = "2025-11-30T20:23:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/60/19f7884db5d5603edf3c6bce35408f45ad3e97e10007df0e17dd57af18f8/rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be", size = 353192, upload-time = "2025-11-30T20:23:29.151Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c4/76eb0e1e72d1a9c4703c69607cec123c29028bff28ce41588792417098ac/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f", size = 384080, upload-time = "2025-11-30T20:23:30.785Z" },
+    { url = "https://files.pythonhosted.org/packages/72/87/87ea665e92f3298d1b26d78814721dc39ed8d2c74b86e83348d6b48a6f31/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f", size = 394841, upload-time = "2025-11-30T20:23:32.209Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ad/7783a89ca0587c15dcbf139b4a8364a872a25f861bdb88ed99f9b0dec985/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87", size = 516670, upload-time = "2025-11-30T20:23:33.742Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/2882bdac942bd2172f3da574eab16f309ae10a3925644e969536553cb4ee/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18", size = 408005, upload-time = "2025-11-30T20:23:35.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/81/9a91c0111ce1758c92516a3e44776920b579d9a7c09b2b06b642d4de3f0f/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad", size = 382112, upload-time = "2025-11-30T20:23:36.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8e/1da49d4a107027e5fbc64daeab96a0706361a2918da10cb41769244b805d/rpds_py-0.30.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07", size = 399049, upload-time = "2025-11-30T20:23:38.343Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5a/7ee239b1aa48a127570ec03becbb29c9d5a9eb092febbd1699d567cae859/rpds_py-0.30.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f", size = 415661, upload-time = "2025-11-30T20:23:40.263Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/caa143cf6b772f823bc7929a45da1fa83569ee49b11d18d0ada7f5ee6fd6/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65", size = 565606, upload-time = "2025-11-30T20:23:42.186Z" },
+    { url = "https://files.pythonhosted.org/packages/64/91/ac20ba2d69303f961ad8cf55bf7dbdb4763f627291ba3d0d7d67333cced9/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f", size = 591126, upload-time = "2025-11-30T20:23:44.086Z" },
+    { url = "https://files.pythonhosted.org/packages/21/20/7ff5f3c8b00c8a95f75985128c26ba44503fb35b8e0259d812766ea966c7/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53", size = 553371, upload-time = "2025-11-30T20:23:46.004Z" },
+    { url = "https://files.pythonhosted.org/packages/72/c7/81dadd7b27c8ee391c132a6b192111ca58d866577ce2d9b0ca157552cce0/rpds_py-0.30.0-cp314-cp314-win32.whl", hash = "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed", size = 215298, upload-time = "2025-11-30T20:23:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/1aaac33287e8cfb07aab2e6b8ac1deca62f6f65411344f1433c55e6f3eb8/rpds_py-0.30.0-cp314-cp314-win_amd64.whl", hash = "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950", size = 228604, upload-time = "2025-11-30T20:23:49.501Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/95/ab005315818cc519ad074cb7784dae60d939163108bd2b394e60dc7b5461/rpds_py-0.30.0-cp314-cp314-win_arm64.whl", hash = "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6", size = 222391, upload-time = "2025-11-30T20:23:50.96Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/68/154fe0194d83b973cdedcdcc88947a2752411165930182ae41d983dcefa6/rpds_py-0.30.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb", size = 364868, upload-time = "2025-11-30T20:23:52.494Z" },
+    { url = "https://files.pythonhosted.org/packages/83/69/8bbc8b07ec854d92a8b75668c24d2abcb1719ebf890f5604c61c9369a16f/rpds_py-0.30.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8", size = 353747, upload-time = "2025-11-30T20:23:54.036Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/00/ba2e50183dbd9abcce9497fa5149c62b4ff3e22d338a30d690f9af970561/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7", size = 383795, upload-time = "2025-11-30T20:23:55.556Z" },
+    { url = "https://files.pythonhosted.org/packages/05/6f/86f0272b84926bcb0e4c972262f54223e8ecc556b3224d281e6598fc9268/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898", size = 393330, upload-time = "2025-11-30T20:23:57.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e9/0e02bb2e6dc63d212641da45df2b0bf29699d01715913e0d0f017ee29438/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e", size = 518194, upload-time = "2025-11-30T20:23:58.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ca/be7bca14cf21513bdf9c0606aba17d1f389ea2b6987035eb4f62bd923f25/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419", size = 408340, upload-time = "2025-11-30T20:24:00.2Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c7/736e00ebf39ed81d75544c0da6ef7b0998f8201b369acf842f9a90dc8fce/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551", size = 383765, upload-time = "2025-11-30T20:24:01.759Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/3f/da50dfde9956aaf365c4adc9533b100008ed31aea635f2b8d7b627e25b49/rpds_py-0.30.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8", size = 396834, upload-time = "2025-11-30T20:24:03.687Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/00/34bcc2565b6020eab2623349efbdec810676ad571995911f1abdae62a3a0/rpds_py-0.30.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5", size = 415470, upload-time = "2025-11-30T20:24:05.232Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/28/882e72b5b3e6f718d5453bd4d0d9cf8df36fddeb4ddbbab17869d5868616/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404", size = 565630, upload-time = "2025-11-30T20:24:06.878Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/97/04a65539c17692de5b85c6e293520fd01317fd878ea1995f0367d4532fb1/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856", size = 591148, upload-time = "2025-11-30T20:24:08.445Z" },
+    { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
+    { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
 ]
 
 [[package]]
@@ -351,6 +1337,45 @@ wheels = [
 ]
 
 [[package]]
+name = "secretstorage"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "jeepney" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/2b/58abc2d1fd397e7dde08e947e05c884d8ef2f78d5e2588c17a12d42d6994/sse_starlette-3.4.4.tar.gz", hash = "sha256:07e0fa0460138baf25cdd5fb28683472c3995dc1642225191b3832d62526bcb0", size = 31819, upload-time = "2026-05-12T17:37:17.019Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/67/805710444ea8cc75fbf70b920ed431a560c4bf9c57f7d5a3117213189399/sse_starlette-3.4.4-py3-none-any.whl", hash = "sha256:3f4dd50d8aed2771a091f3a83000323fc3844541c16b4fe585ae2420cc6df973", size = 16514, upload-time = "2026-05-12T17:37:15.601Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/66/4d20cdf39a8d6a51e663b7038e3b828ff211d3891a43a713fe7e4643f3a8/starlette-1.1.0.tar.gz", hash = "sha256:e83c7fe0ddecd8719c5b840080325aec0260acec86e9832899e377b91d65e90f", size = 2660060, upload-time = "2026-05-23T16:55:41.376Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/79/920b8e0a8b20f793e8d64855095cb8febabf6175b8550b6f7a547d813891/starlette-1.1.0-py3-none-any.whl", hash = "sha256:7f0dfd38e428aad5cb6f9f667f0ca1d2d8ca3f3385dccac8305f79ec98458382", size = 72899, upload-time = "2026-05-23T16:55:39.201Z" },
+]
+
+[[package]]
 name = "ty"
 version = "0.0.38"
 source = { registry = "https://pypi.org/simple" }
@@ -373,4 +1398,178 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/4a/beefade12d109b4f7793d61b04b4478b1ad4d1465a719e7ff55b2d42461a/ty-0.0.38-py3-none-win32.whl", hash = "sha256:36fc5dd5dc09207ff3004b1560a79a3fb8d12456daeec914a7b802a918da654c", size = 10548583, upload-time = "2026-05-20T00:15:07.892Z" },
     { url = "https://files.pythonhosted.org/packages/15/64/941b205e2e46cc2297c245c64aa7691410b7454fa4d07a6cb3cf59487833/ty-0.0.38-py3-none-win_amd64.whl", hash = "sha256:eef0a8956ba14514076b1a963d13eb32986d9ebad7f0527b3cc01cb68bf35147", size = 11650542, upload-time = "2026-05-20T00:15:01.441Z" },
     { url = "https://files.pythonhosted.org/packages/59/02/c1c4f9ec4b94d95190636fa13f79c32f65165fbe3a0503882d4df164d2ac/ty-0.0.38-py3-none-win_arm64.whl", hash = "sha256:79abfc8658a026c30b1c955613437dab3ef4b12feca56a3e6df50903cc39e07f", size = 11010307, upload-time = "2026-05-20T00:15:04.567Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "uncalled-for"
+version = "0.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/82/345cc927f7fbdae6065e7768759932fcc827fc20b29b45dfbafa2f1f7da4/uncalled_for-0.3.2.tar.gz", hash = "sha256:89f5dbcd71e2b8f47c030b1fa302e6cce2ec795d1ac565eeb6525c5fe55cb8a2", size = 50032, upload-time = "2026-05-06T13:38:25.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/25/2c87754f3a9e692315f7b811244090e68f362979fc8886b3fbd2985a1d8c/uncalled_for-0.3.2-py3-none-any.whl", hash = "sha256:0ff60b142c7d1f8070bde9d42afaa70aedc77dcc10998c227687e9c15713418e", size = 11444, upload-time = "2026-05-06T13:38:24.025Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.48.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e6/bf/f6544ba992ddb9a6077343a576f9844f7f8f06ab819aefd00206e9255f18/uvicorn-0.48.0.tar.gz", hash = "sha256:a5504207195d08c2511bf9125ede5ac4a4b71725d519e758d01dcf0bc2d31c37", size = 91074, upload-time = "2026-05-24T12:08:41.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/be/72532be3da7acc5fdfbccdb95215cd04f995a0886532a5b423f929cda4cc/uvicorn-0.48.0-py3-none-any.whl", hash = "sha256:48097851328b87ec36117d3d575234519eb58c2b22d79666e9bbc6c49a761dad", size = 71410, upload-time = "2026-05-24T12:08:40.258Z" },
+]
+
+[[package]]
+name = "watchfiles"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/41/5e1a4bb12aac5f1493fa1bdc11154eca3b258ca4eba65d39c473fe19d8e9/watchfiles-1.2.0.tar.gz", hash = "sha256:c995fba777f1ea992f090f9236e9284cf7a5d1a0130dd5a3d82c598cacd76838", size = 108252, upload-time = "2026-05-18T04:32:04.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/2f/e42c992d2afda3108ea1c02acecc991b9f31d05c14adc2a7cee9ee211fc4/watchfiles-1.2.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:bc13eb17538be00c874699dc0abe4ee2bc8d50bb1166a6b9e175ef3fd7eb8f26", size = 400115, upload-time = "2026-05-18T04:32:02.06Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/8f/6af2ea19065c91d8b0ea3516fdfc8c0d349f407e8e9fbf4e5a17360de8ad/watchfiles-1.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2d95ddc1eb6914154253d239089900813f6a767e174b8e6a50e7fdacb7e4236c", size = 393659, upload-time = "2026-05-18T04:30:50.951Z" },
+    { url = "https://files.pythonhosted.org/packages/13/01/b32a967c56fb3e3e5be3db52c3d3b87fa4513aa367d8ed1ad96d42952e5f/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f70d8b291ef6e88d19b1f297a6905ddb978888d9272b0d05e6f53309856bcfc", size = 453207, upload-time = "2026-05-18T04:31:04.231Z" },
+    { url = "https://files.pythonhosted.org/packages/04/98/97557a812180338cb1abd32e1cffcc4588f59b5f23e0cb006b2ba95ba64a/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:56d8641cf834c2836922899105bd3ce3d0dfc69291d52edf0b4d0436829b34c0", size = 459273, upload-time = "2026-05-18T04:31:50.377Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/a8/b4b08dcb7653b8087c6586f7ce649505900e866bbcfe40dc9587af02e686/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2581a94056e55d7d0a31a823ea92bf73749c489ca2285bfdc0fbe6b2bb49d50c", size = 489927, upload-time = "2026-05-18T04:31:42.485Z" },
+    { url = "https://files.pythonhosted.org/packages/50/94/3dceea03545d2e5ddfd839f0ddd5e1cecbf1697b5a428d5ba11cef6af95d/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:41bc1199f7523b3f82843c88cbb979180c949caef0342cf90968f178e5d49b01", size = 570476, upload-time = "2026-05-18T04:31:03.071Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f2/d39a5450c3532092b91f81d274360e613c2371bc874a89c7a1a3c5e8d138/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7571e4464cb6e434958f867f7f730b8ab0b75e3f8e5eac0499168486ab3c33a8", size = 465650, upload-time = "2026-05-18T04:30:12.701Z" },
+    { url = "https://files.pythonhosted.org/packages/22/24/ed72f68cbc1333ca9b9f2200aa048bb6658ae41709bc1caad4310f4bdffd/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e53a384f76b631c3ae5334ce6a52f0baa3a911eb94a4eac7f160079868b716d5", size = 456398, upload-time = "2026-05-18T04:30:13.784Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/64/982ef4a4e5bab5b6e5b6becc8cd5e732f6130a78b855f0abec6439a9a135/watchfiles-1.2.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:d20029a60a71a052a24c4db7673bc4de39ab89adbaccbfb5d67987c5d73f424d", size = 465140, upload-time = "2026-05-18T04:31:52.111Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/0c/95282abf4ed680b6096010bcfc30c5fa7a041fc5aa5a2ad17a2cc6c75bba/watchfiles-1.2.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:2cb93af48550faf1cea04c303107c8b75833de7013e57ce27d3b8d21d8d0f58c", size = 630259, upload-time = "2026-05-18T04:31:25.676Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/607c1de1530c4bdcf2cf1d1ecc2505ddba5d96bd43ba9f2b0e79876f850f/watchfiles-1.2.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2995c176de7692b86a2e4c58d9ec718f753150a979cb4a754e2b4ffa38e70906", size = 659859, upload-time = "2026-05-18T04:30:24.333Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/08/d9e2e0f9e8e6791d33aefc694ad7eefa7f901f63caff84a81ded38692f9c/watchfiles-1.2.0-cp312-cp312-win32.whl", hash = "sha256:7a2cffd17d27d2ecbb310c2b1d8174f222a5495b1a721894afa88ec11e25b898", size = 275480, upload-time = "2026-05-18T04:30:31.307Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e6/9d42569c0102645cc8cea5d8c7d8a1e9d4ada2cb7f05f75e554b8aa2202a/watchfiles-1.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:f155b3a1b2a5fc89cdc70d47ee5d54e3b75e88efa34982028a35daef9ba00379", size = 288718, upload-time = "2026-05-18T04:32:10.745Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/26/88e0dc6ee3898169d7fa22bb6a69cabf2502d2ee25cb8c876d1262d204f8/watchfiles-1.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:8fa585ede612ee9f9e91b18bebf9ba11b9ae29a4e3a0d0cf6fca3e382133f0d5", size = 281026, upload-time = "2026-05-18T04:30:22.23Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/4d/70a7feced9f87e2ff26dba42667290f41694fc64646c67261fbb8cab5d5c/watchfiles-1.2.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:01ea8d66f0693b9b60a6541c8d10263091ca9a9060d242f3c1f3143f9aad2c98", size = 399730, upload-time = "2026-05-18T04:31:38.162Z" },
+    { url = "https://files.pythonhosted.org/packages/31/3a/0da302f2307aee316922806ebd5726c542cbd787c938271cf14a074c7daf/watchfiles-1.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7ba0480b9a74af058f43b337e937a451e109295c420916d68ad24e3dc02f5e44", size = 392842, upload-time = "2026-05-18T04:30:27.051Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ef/d5bdb705c224dbc256aa0c1ec47bf4e61ec52558f2afb44a71a1fe4d7015/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f34e26a19f91f710c08e0183429f0d1d15df734e6bc78c31e77b9ea9c433658", size = 452989, upload-time = "2026-05-18T04:31:11.945Z" },
+    { url = "https://files.pythonhosted.org/packages/71/29/5495f2c1661949ef7a35e4d71111d129cfe7606414a26887a919d0a55406/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b4e77f6a55f858504069abd35d336a637555c09bca453dde1ee1e5ada8a6a1fb", size = 458978, upload-time = "2026-05-18T04:30:52.606Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/8c/7f9c07c433811c2fffd93e13fdfb7135de9aab5f2ae41be08960fa0047dc/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0cb4d80e212f116474a545c21c912b445f16bb0cef9e6a73a498164223e14e2f", size = 490248, upload-time = "2026-05-18T04:31:36.003Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/11/d93632febc52fbc21be90231bb7c17fd5387f46c9076fd40a5f9c2ae6910/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b974946a10af379d425e2eef5b62f5c6ebeaccf91d45eaad6f5b27ecd4f91aa0", size = 571847, upload-time = "2026-05-18T04:31:10.862Z" },
+    { url = "https://files.pythonhosted.org/packages/55/b4/383173e73aabb07ad1d9c7aa859d95437ac46a6d6a1e11005facda0c9d19/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:86bc13c25a8d1fcd70b51d0ce7c9b65e90de5666fcbfd3e34957cc73ee19aeb5", size = 465974, upload-time = "2026-05-18T04:30:17.006Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/6c/89b1a230a78f57c52dd8893adb1f92f94411721b6ec12596c56d98c74356/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca148d73dea36c9763aaa351e4d7a51780ec1584217c45276f4fe8239c768b71", size = 454782, upload-time = "2026-05-18T04:30:35.656Z" },
+    { url = "https://files.pythonhosted.org/packages/24/62/1732118367cfff0a9fce3bf62ff4bfded09ef5df21d9d446b858b3f70a96/watchfiles-1.2.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:c525543d91961c6955b2636b308569e84a1d1c5f5f2932041ab9ef46422f43e3", size = 465182, upload-time = "2026-05-18T04:30:20.846Z" },
+    { url = "https://files.pythonhosted.org/packages/28/96/716f7e5f51339bf22963f3345f9f27d7f3b30e2eadc597e257c881dd3c53/watchfiles-1.2.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:a204794696ffb8f9b10fba6f7cb5216d42f3b2b71860ccac6b6e42f5f10973b0", size = 629841, upload-time = "2026-05-18T04:31:05.397Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/c40783950fd771ccf66ab3ec2722d188a9af1c7f96c6e811f36e40c6e03f/watchfiles-1.2.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:10d86db20695afe7997ac9e1717637d6714a8d0220458c33f3d2061f54cec427", size = 658028, upload-time = "2026-05-18T04:31:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/71/72/4508db1856d1d87fcbb3b63f4839bab1b5682cb0e8d224d122263c09654a/watchfiles-1.2.0-cp313-cp313-win32.whl", hash = "sha256:eb283ee99e21ad6443c8cdb06ac5b34b1308c329cbdf03fa02b445363714c799", size = 275183, upload-time = "2026-05-18T04:30:59.57Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/36/14b76ca57652e5cc5fd1c11f32a261292c08a0d19a00351013c2549cbfb2/watchfiles-1.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:a0f27f01bee51861392bb6b7c4fdb290b27d1eb194e9e28788d68102a0e898d9", size = 288059, upload-time = "2026-05-18T04:32:07.937Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/8d/0a85e395398d8d20fadfe5c5d32c726eee17a519e78fb356f2cf7531bffe/watchfiles-1.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:3651aa7058595e9cfb75d35dd5ada2bf9f48a5b8a0f3562821d3e210c507e077", size = 280186, upload-time = "2026-05-18T04:31:54.484Z" },
+    { url = "https://files.pythonhosted.org/packages/37/68/36db056f1fdcc5f07302f56e631774d6835bcd6fa3ace402304621d5f9e5/watchfiles-1.2.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:faea288b6f0ab1902ef08f4ca6de005dccf856c4e0c4f21b8c5fce02d90a1b08", size = 399031, upload-time = "2026-05-18T04:30:44.576Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/64/01a9d6f66a82a5c101ce939274106cc72759d62427e153f01edd2b9f87c2/watchfiles-1.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:01859b11fd9fbca670f4d5da00fbac282cfea9bd67a2125d8b2833a3b5617ea9", size = 391205, upload-time = "2026-05-18T04:30:25.413Z" },
+    { url = "https://files.pythonhosted.org/packages/84/2c/0a44fe058cb4bb7b8ede6b6670698bbb7c0400740e378d00022189b7b31d/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fff610d7bb2256a317bb1e96f0d7862c7aa8076733ee5df0fd41bbe76a24a4f4", size = 451892, upload-time = "2026-05-18T04:32:14.005Z" },
+    { url = "https://files.pythonhosted.org/packages/67/a1/351e0d56cd35e6488b5c8b4fb11a809a5bc923e8fe8fed9faf8920be0c89/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b141a4891c995a039cd89e9a49e62df1dc8a559a5d1a6e4c7106d16c12777a55", size = 458867, upload-time = "2026-05-18T04:31:22.279Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/7d/9d09605187f1b838998624049fcf8bf47b73c1a3b76901fcac1782f62277/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f22943b7770483f6ea0721c6b11d022947a98eb0acae14694de034f4d0d38925", size = 490217, upload-time = "2026-05-18T04:31:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5d/a17a16eccb182f04188cd308ec24b1a71a9b5c4e7098269cf35d9fa56d02/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1bc6195825b7dcd217968bb1f801a60fd4c16e8eeab5bedc7fe917d7d5995ab4", size = 571458, upload-time = "2026-05-18T04:32:11.875Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/3d/4dd457062083ab1938e5dfd45032eb425cee2ac817287ca8ff4356183e5d/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d4a4b147f5dca2a5d325a06a832fb43f345751adfbc63204aec30e0d9ca965a2", size = 464707, upload-time = "2026-05-18T04:30:43.492Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/71/ea8c57b128f5383de74d0c7d2d9c57ad7c9a65a930c451bd25d524b295b7/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4543579a9bdb0c9560039b4ffddbdb39545707659fbc430ce4c10f3f68d557f9", size = 454663, upload-time = "2026-05-18T04:30:16.061Z" },
+    { url = "https://files.pythonhosted.org/packages/53/fd/2e812bf938406d7db351f0703ddd3fc6c061cf30d96153a77bc79a943a44/watchfiles-1.2.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:20aa0e708b920bde876a4aa82dc7dd6ebea228a63a67cda6632c2fc87b787efa", size = 463537, upload-time = "2026-05-18T04:31:44.9Z" },
+    { url = "https://files.pythonhosted.org/packages/86/56/d17a7f1dd1bc3035f1072694a551301272f1739c2d8e319c927cb9e29b38/watchfiles-1.2.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:d413349d565dab74297f2a63e84a097936be69bf8f3b3801f27f380e32040f44", size = 629194, upload-time = "2026-05-18T04:31:14.141Z" },
+    { url = "https://files.pythonhosted.org/packages/be/06/f1ff66bf5cae50aa4062779a0ecd0bbaf15e466195719074078947d9a17d/watchfiles-1.2.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f28b2725eb8cce327b9b3ab02415c853011dc55c95832fe90de6bc56f5315f72", size = 656194, upload-time = "2026-05-18T04:31:47.14Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/54/a9c7ea9a82a4ac65e7004c0a03920b5cdd2f9c3b678757d9cd425aa51d53/watchfiles-1.2.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b8c8358484d5fa12ef34f05b7f4168eaf1932f408725ff6d023c33ec17bd79d4", size = 400205, upload-time = "2026-05-18T04:32:05.153Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5d/c9ab3534374a4a67450696905d6ef16a04405448b8dc52bd752ae50423d4/watchfiles-1.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9f04b092229ad2c50126dd3c922c8822e51e605993764a33058d4a791ab42281", size = 392508, upload-time = "2026-05-18T04:30:54.849Z" },
+    { url = "https://files.pythonhosted.org/packages/26/ca/1ad30103535cf0cecd7b993e8d50edc5351b1820e38f2d22e3df58962feb/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a7ce236284f002a156f70add88efe5c70879cccbb658be0822c54b1306fc09d", size = 452448, upload-time = "2026-05-18T04:30:53.727Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a1/ceee2cdf2afbd715fa07758d39c9859513eae411b23196f7fd039e5feedd/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b9909cc2b48468b575eefa944919e1fe8a36c5849d5c7c168f80a8c1db69398e", size = 459605, upload-time = "2026-05-18T04:30:23.312Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/f6/421e30fd1cb3907a84ed92ab3f1983e37ba2dca015e9a894a048418417a2/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a37faaed405c67e28e6be45a1fa4f206ef5a2860f27c237db9fa30704c38242", size = 490757, upload-time = "2026-05-18T04:30:47.358Z" },
+    { url = "https://files.pythonhosted.org/packages/41/b0/55ed1b97ed08be7bba6f9a541cac15f2a858e1d74d2b07b6da70a82aab00/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9649193aa27bd9ff2e80ff29bfaa93085496c7a3a377592823cc58b77ee88add", size = 568672, upload-time = "2026-05-18T04:30:38.915Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/cf/d8ae8a80dd7bafab395ea7681c10237311bbf34d37704a8c744e7cf31fc7/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e4ff8e37f99cf1da89e255e07c9c4b37c214038c4283707bdec308cb1b0ea1f", size = 464197, upload-time = "2026-05-18T04:30:09.914Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/8a/3076c496ca8dafe0e8cd03fcebdfc47be4b1174b4e5b24ff6e396e6b3af2/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:054dc20fd2e3132b4c3883b4a00d72fd6e1f56fdaf89fccd12e8057d74cd74d7", size = 453181, upload-time = "2026-05-18T04:30:14.829Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/10/9745e17c98e7b8a86454df0a3c7b5686bd650383f1e9f26e4ebcbd6cc0c0/watchfiles-1.2.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e140ed30ebde76796b686e67c182cff10ea2fbab186fafd1560f74bb5a473a6e", size = 465109, upload-time = "2026-05-18T04:30:28.123Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/95/8ef4a95481d3e0cb52d62a06fa6e972e81424be2d9698b91a2fecca9904c/watchfiles-1.2.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:bb7e52ecf68ba46d22df23467b87cffeb2146908aa523ebfe803019618cfda06", size = 630653, upload-time = "2026-05-18T04:31:49.304Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/e4/3b3bf36b0f829b50c6ebcb8d031583863c59f923d6a6af3d485e470d0fac/watchfiles-1.2.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:23282a321c8baf9b3a3c4afff673f9fe65eb7fdc2338d765ccad9d3d1916a5ba", size = 657838, upload-time = "2026-05-18T04:31:06.497Z" },
+    { url = "https://files.pythonhosted.org/packages/21/b1/6cbbb50c1f3002ab568777d44aa21206dfb8807a840990c4037523b51812/watchfiles-1.2.0-cp314-cp314-win32.whl", hash = "sha256:c0db965c5f79aa49fe672d297cf1febc5ad149b658594944f49a54a2b96270a7", size = 275108, upload-time = "2026-05-18T04:30:06.891Z" },
+    { url = "https://files.pythonhosted.org/packages/92/45/190ce6db8dcb4536682cf75d3889ff1a27182a58cb519d343cb6d9ea63d8/watchfiles-1.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:71283b39fd17e5408eb123bd37aeecfd9d54c81fc184421943208aadb879d103", size = 288441, upload-time = "2026-05-18T04:32:12.901Z" },
+    { url = "https://files.pythonhosted.org/packages/74/0d/3eae1c2313ab08378431d907c3f8095ecca00f3eda33111cf4f0f2591799/watchfiles-1.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:c5c19526f4e54a00f2666a6c0e9e40d582c09e865055ea7378bf0009aab857b3", size = 280684, upload-time = "2026-05-18T04:31:26.902Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/75/fb64e6c25d6b5ca636d03df34ffb1c6e9873303e76d27967e045f8df088f/watchfiles-1.2.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:d73a585accffa5ae39c17264c36ec3166d2fad7000c780f5ef83b2722afb9dd2", size = 398857, upload-time = "2026-05-18T04:32:17.108Z" },
+    { url = "https://files.pythonhosted.org/packages/73/4e/9f7adf01754cbf81843722ccfec169d8f26c69778281a302855cecd2ee08/watchfiles-1.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ae99b14c5f21e026e0e9d96f40e07d8570ebee6cafd9d8fc318354606daa7a28", size = 392413, upload-time = "2026-05-18T04:31:07.911Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c8/bec626bcc2d69f44b9acb24ce7d60ed7b16b73628eea747fcbd169d8edda/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4429f3b105524a10b72c3a819b091c495d2811d419c1e1e8df773a5a5974f831", size = 452409, upload-time = "2026-05-18T04:31:20.142Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b7/b6362068e81e7c556d155a34c35d40ac3ef42d747b06d7f6e5bf58e359c2/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:43d818978d06062d9b22c4fab2ebe44cf5213d42dc8e62bda8c2760cfa2eeb33", size = 458827, upload-time = "2026-05-18T04:32:06.219Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f8/9a813fa42afb1e0b4625e75f0479826644d3ee8dc287e093799bc01f390c/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b9f732dc58b2dbe69e464ccf8fff7a03b0dd0be439da4c0720d3558527d3d6b4", size = 490104, upload-time = "2026-05-18T04:31:56.034Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/bf/27dfb6094ca4c9aad21298b5525b6c53cb36121ee454331d05161e58d130/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8f200104103feb097de4cab8fe4f5dd18a2026934c7dea98c55a2f5fd6d5a33b", size = 571360, upload-time = "2026-05-18T04:31:57.133Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/39/44a096d67270ea93df91d33877dbe91fbda3aa4f8ec2edf799d93eda8736/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:63ac26eefbf4af1741247d6fb68b11c49a25b2f7413fbd318a83a12aaa9cf666", size = 464644, upload-time = "2026-05-18T04:30:57.33Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/80/c7472203bad6268e3ef1ad260739704847898938ad7ea8b63a5131f46b50/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c4997d4e4a55f0d02b6cde327322daf3a0400e5df6c6b15948994bf72497925", size = 454771, upload-time = "2026-05-18T04:30:48.736Z" },
+    { url = "https://files.pythonhosted.org/packages/51/cf/3b10b268b4b7f0fc26e9debb5eef1998b515887840f444cd3ec80c688755/watchfiles-1.2.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:4c887eba18b7945ac73067a8b4a66f21cd46c2539b2bc68588f7be6c7eb6d26b", size = 463494, upload-time = "2026-05-18T04:31:33.826Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/3e/a4302545cd589262a0dc7d140e86f7688eba3f9c72776c27f7e23b8864c4/watchfiles-1.2.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:3416ff151bb6b5a8d8d11664974fbef4d9305b9b2957839ab5a270468fd8df30", size = 629383, upload-time = "2026-05-18T04:31:15.596Z" },
+    { url = "https://files.pythonhosted.org/packages/db/99/d5649df0a9a410d45b7c882304d0b790903ac9b6e8f2cfd12114e0c6b9f2/watchfiles-1.2.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:0e831a271c035d89789cffc386b6aa1375f39f1cd25eb7ca0997e4970d152fc5", size = 656093, upload-time = "2026-05-18T04:31:58.707Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b9/362702539275019a54dd2e94511b31a9b89c5f9e6a21966de7eb692549fc/watchfiles-1.2.0-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:37a6721cdf3f65dbb13aa9503510ccb4451603ac837e44d265d7992a597e1374", size = 400109, upload-time = "2026-05-18T04:31:16.879Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/75/71d5ba62db781e5587bded1d944c675374bc4aa37ff33d5018d98e8b6538/watchfiles-1.2.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2b37d10b5a63bd4d87e18472d80fa525bd670586fae62e5dd580452764879b65", size = 392167, upload-time = "2026-05-18T04:31:28.058Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/01/c66dd95d0423fe30d31820e2d1d5bda773764131bbb6ac0cb1cf303ac328/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a105bc2283f67e8fbec74253ec2d94925de92ed72c0393f1206bf326b7b7b69", size = 452372, upload-time = "2026-05-18T04:31:00.836Z" },
+    { url = "https://files.pythonhosted.org/packages/91/15/2fe99557e72f85627c6a8eed50d889e8d101623e060a22ad75b875cb932d/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5327989a465505f05cfe06f04fa9d0c2fd5432bb243e10e6f012b1bdca3c8579", size = 459596, upload-time = "2026-05-18T04:31:34.96Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/d4acfa0023367428ed48351b3b9b267893037b6cadae55620c61c24bcfd4/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ecb47f183a8025b2aa18b546725c3657e542112ae9c0613a2af79b4fa8d04ad7", size = 490869, upload-time = "2026-05-18T04:31:59.923Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/5f/3164cbdce06c9fb95c4f7b9e2f9760b5e2797af43a9ecc317ef42a23a278/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8520a4ab0e37f770afc34459c4f8f7019e153f9124dc101c15538365875d1ab2", size = 571641, upload-time = "2026-05-18T04:32:00.948Z" },
+    { url = "https://files.pythonhosted.org/packages/41/e6/85d3731c55e65cd7690f3f803d24c139588aaf863e4bf2148fe7a7fa1a19/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:71cd71740ed2c15211ebb237ced4e39a1cdf6f80566e5fe95428da1626f4fde6", size = 464444, upload-time = "2026-05-18T04:30:34.298Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7d/562641012b8b09872742c3b8adf9629ec479fd78f8d68ae4a0c13da8add6/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f88af53d6ddaf72179ef613ddc905e6f4785f712b49b80b3bef9f3525e6194b4", size = 453593, upload-time = "2026-05-18T04:31:23.464Z" },
+    { url = "https://files.pythonhosted.org/packages/56/fe/cb8ef3d6f929d14158fdaaad9925985b7310abc9384dcd4d82dd0016fb59/watchfiles-1.2.0-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:cee9d5efd929efdac5f7e58f72b3376f676b64050a91c5b99a7094c5b2317488", size = 465096, upload-time = "2026-05-18T04:31:30.384Z" },
+    { url = "https://files.pythonhosted.org/packages/25/91/80908e835e100527a9267147b08c0eee1fa6ab0ffec15edc04d1d44885f7/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_aarch64.whl", hash = "sha256:b718bf356bbc15e559bd8ef41782b573b8ae0e3f177ab244b440568d7ea02cfb", size = 630638, upload-time = "2026-05-18T04:30:49.89Z" },
+    { url = "https://files.pythonhosted.org/packages/46/4b/95ab2f256bb4af3cb2eb23b9317bda984ee6e0f11733a5c004a6c95b06e3/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_x86_64.whl", hash = "sha256:922c0e019fe68b3ae392965a766b02a71ba1168c932cebc3733cd52c5fe5b377", size = 657684, upload-time = "2026-05-18T04:31:32.027Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/7b/bac442e6b96c9d25092695578dda82403c77936104b5682307bd4deb1ad4/websockets-16.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:71c989cbf3254fbd5e84d3bff31e4da39c43f884e64f2551d14bb3c186230f00", size = 177365, upload-time = "2026-01-10T09:22:46.787Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/fe/136ccece61bd690d9c1f715baaeefd953bb2360134de73519d5df19d29ca/websockets-16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8b6e209ffee39ff1b6d0fa7bfef6de950c60dfb91b8fcead17da4ee539121a79", size = 175038, upload-time = "2026-01-10T09:22:47.999Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86890e837d61574c92a97496d590968b23c2ef0aeb8a9bc9421d174cd378ae39", size = 175328, upload-time = "2026-01-10T09:22:49.809Z" },
+    { url = "https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c", size = 184915, upload-time = "2026-01-10T09:22:51.071Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0334872c0a37b606418ac52f6ab9cfd17317ac26365f7f65e203e2d0d0d359f", size = 186152, upload-time = "2026-01-10T09:22:52.224Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/34/9bf8df0c0cf88fa7bfe36678dc7b02970c9a7d5e065a3099292db87b1be2/websockets-16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0b31e0b424cc6b5a04b8838bbaec1688834b2383256688cf47eb97412531da1", size = 185583, upload-time = "2026-01-10T09:22:53.443Z" },
+    { url = "https://files.pythonhosted.org/packages/47/88/4dd516068e1a3d6ab3c7c183288404cd424a9a02d585efbac226cb61ff2d/websockets-16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:485c49116d0af10ac698623c513c1cc01c9446c058a4e61e3bf6c19dff7335a2", size = 184880, upload-time = "2026-01-10T09:22:55.033Z" },
+    { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261, upload-time = "2026-01-10T09:22:56.251Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693, upload-time = "2026-01-10T09:22:57.478Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364, upload-time = "2026-01-10T09:22:59.333Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039, upload-time = "2026-01-10T09:23:01.171Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323, upload-time = "2026-01-10T09:23:02.341Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975, upload-time = "2026-01-10T09:23:03.756Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203, upload-time = "2026-01-10T09:23:05.01Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653, upload-time = "2026-01-10T09:23:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920, upload-time = "2026-01-10T09:23:07.492Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload-time = "2026-01-10T09:23:09.245Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload-time = "2026-01-10T09:23:10.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406, upload-time = "2026-01-10T09:23:12.178Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085, upload-time = "2026-01-10T09:23:13.511Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328, upload-time = "2026-01-10T09:23:14.727Z" },
+    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044, upload-time = "2026-01-10T09:23:15.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279, upload-time = "2026-01-10T09:23:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711, upload-time = "2026-01-10T09:23:18.372Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982, upload-time = "2026-01-10T09:23:19.652Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915, upload-time = "2026-01-10T09:23:21.458Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381, upload-time = "2026-01-10T09:23:22.715Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737, upload-time = "2026-01-10T09:23:24.523Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268, upload-time = "2026-01-10T09:23:25.781Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486, upload-time = "2026-01-10T09:23:27.033Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331, upload-time = "2026-01-10T09:23:28.259Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501, upload-time = "2026-01-10T09:23:29.449Z" },
+    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062, upload-time = "2026-01-10T09:23:31.368Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356, upload-time = "2026-01-10T09:23:32.627Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
 ]


### PR DESCRIPTION
- Upgrade all 4 app dashboards to PrefabApp with Metric cards, Ring health indicators, polished BarCharts, and Carousel lock overview; fix all component params to camelCase (dataKey, xAxis, trendSentiment, etc.)
- Add @mcp.tool(app=True) decorators to the 4 previously unregistered dashboard functions (rrt_health_dashboard, rrt_doctor_dashboard, rrt_tree_dashboard, rrt_locks_overview)
- Couple all tool version= params to package __version__ instead of "1.0"
- Add rrt_init (form app) + rrt_init_run (submit tool)
- Add rrt_locks_overview with PieChart + Carousel + DataTable
- Register GenerativeUI provider for LLM-driven custom visualizations
- Fix rrt_tree_dashboard: remove [snapshot] from table, drop empty note/updated_at columns, show snapshot as dedicated Metric card
- Add docs/mcp-server.md with full tool, resource, and prompt reference
- Update SKILL.md with 7 new/updated app tools and GenerativeUI section