### PR TITLE
feat(mcp): docs, badges, and mcp_config helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -257,3 +257,4 @@ Network Trash Folder
 Temporary Items
 .apdisk
 .mcp-ai-agent-guidelines/
+.mcp.json

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,9 +1,0 @@
-{
-  "mcpServers": {
-    "rrt": {
-      "type": "stdio",
-      "command": "uv",
-      "args": ["run", "rrt-mcp"]
-    }
-  }
-}

--- a/.rrt/tree.lock.toml
+++ b/.rrt/tree.lock.toml
@@ -1,9 +1,9 @@
 [meta]
-generated_at = "2026-05-30T08:35:19+00:00"
+generated_at = "2026-05-30T08:36:41+00:00"
 rrt_version = "1.7.0"
 
 [snapshot]
-entry_count = 277
-tree_hash = "sha256:88abfc01f8f6cc607e51548ec5f19dcff82598d2888c982005f9a045e668e892"
-updated_at = "2026-05-30T08:35:19+00:00"
+entry_count = 278
+tree_hash = "sha256:37a5c266ebe951103ac6fdddb84327063391d09d94895cbb30dcc16401e25f00"
+updated_at = "2026-05-30T08:36:41+00:00"
 ignored_count = 131

--- a/.rrt/tree.lock.toml
+++ b/.rrt/tree.lock.toml
@@ -1,9 +1,9 @@
 [meta]
-generated_at = "2026-05-26T18:04:15+00:00"
-rrt_version = "1.6.2"
+generated_at = "2026-05-30T08:35:19+00:00"
+rrt_version = "1.7.0"
 
 [snapshot]
-entry_count = 273
-tree_hash = "sha256:34d1c7450c3b9fcc8a16797413b07753c940f21e9d353e3c007bf4326b3ac8ba"
-updated_at = "2026-05-26T18:04:15+00:00"
-ignored_count = 65
+entry_count = 277
+tree_hash = "sha256:88abfc01f8f6cc607e51548ec5f19dcff82598d2888c982005f9a045e668e892"
+updated_at = "2026-05-30T08:35:19+00:00"
+ignored_count = 131

--- a/README.md
+++ b/README.md
@@ -93,6 +93,72 @@ rrt skill install --target claude-local --target codex-local
 rrt skill install --target codex-global --dry-run
 ```
 
+MCP (Model Context Protocol) server — short setup
+
+The `[mcp]` extra exposes repository context and "skills" to local agents (Claude, GitHub Copilot, Codex, Gemini). Full, authoritative documentation is in the project docs: docs/mcp-server.md (https://github.com/Anselmoo/repo-release-tools/blob/main/docs/mcp-server.md).
+
+Recommended installation (production / daily use)
+
+```bash
+pip install "repo-release-tools[mcp]"
+# then run the installed entry point:
+rrt-mcp --help
+```
+
+Developer / from-source (convenience)
+
+To run the MCP server from the local checkout (no install), use uvx. This is useful for iteration and local development but is not the recommended install path for production:
+
+```bash
+uvx repo-release-tools rrt-mcp
+```
+
+Typical MCP client configuration examples
+
+- Claude Code (per-repo `.mcp.json`) — prefer the installed `rrt-mcp` entry point when possible:
+
+```json
+{
+  "mcpServers": {
+    "rrt": {
+      "type": "stdio",
+      "command": "rrt-mcp",
+      "args": []
+    }
+  }
+}
+```
+
+- Claude Desktop (macOS) — using uvx to run from source or the installed command:
+
+```json
+{
+  "mcpServers": {
+    "rrt": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["repo-release-tools", "rrt-mcp"]
+    }
+  }
+}
+```
+
+- HTTP transport (adapter or remote client) — start the server with an HTTP transport and point your adapter at the host/port:
+
+```bash
+# start MCP HTTP server on port 8000
+rrt-mcp --transport http --port 8000
+# or (from source)
+uvx repo-release-tools rrt-mcp -- --transport http --port 8000
+```
+
+Notes & links
+
+- Running via `uvx` is a development convenience. Installing the `[mcp]` extra and using the `rrt-mcp` entry point is the recommended path for end-users and CI adapters.
+- See docs/mcp-server.md for full configuration, adapters, and advanced deployment notes: https://github.com/Anselmoo/repo-release-tools/blob/main/docs/mcp-server.md
+- FastMCP (used by the server) docs: https://pypi.org/project/fastmcp/
+
+
 For basic versioning, `bump` and `ci-version` can run without `[tool.rrt]` by
 auto-detecting root-level `pyproject.toml`, `package.json`, and `Cargo.toml`.
 If multiple version files are found, they are updated together. Explicit config

--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,4 @@
+{
+    "url": "https://context7.com/anselmoo/repo-release-tools",
+    "public_key": "pk_UaOj3scHiw4er9kv0dRvk"
+}

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -20,6 +20,11 @@
           <a class="site-title" rel="author" href="{{ '/' | relative_url }}">
             <span class="reto-logo">⬡</span> {{ site.title | escape }}
           </a>
+          <div class="site-badges">
+            <a href="https://pypi.org/project/repo-release-tools/"><img alt="PyPI version" src="https://img.shields.io/pypi/v/repo-release-tools.svg" style="height:18px; margin-right:6px;"></a>
+            <img alt="Python versions" src="https://img.shields.io/pypi/pyversions/repo-release-tools.svg" style="height:18px; margin-right:6px;">
+            <a href="https://github.com/Anselmoo/repo-release-tools/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/github/license/Anselmoo/repo-release-tools.svg" style="height:18px;"></a>
+          </div>
           <nav class="site-nav">
             <input type="checkbox" id="nav-trigger" class="nav-trigger" />
             <label for="nav-trigger">

--- a/docs/assets/icons/README.md
+++ b/docs/assets/icons/README.md
@@ -1,0 +1,46 @@
+Icons and typography guidance for repo-release-tools docs
+
+Overview
+- This folder contains placeholder guidance for language icons used across README and docs.
+- SVG assets are not fetched automatically (user opted out). Use the Simple-Icons repository to manually fetch icons: https://github.com/simple-icons/simple-icons/tree/develop/icons
+
+Requested icons
+- zsh
+- ts (TypeScript)
+- rust
+- python
+- nuget
+- go
+- markdown
+- rst
+- txt
+- js (JavaScript)
+- java
+
+Procurement
+- Clone or browse the simple-icons repo and copy the desired `*.svg` files into this folder with kebab-case names (e.g. `simpleicon-python.svg` → `python.svg`).
+- Prefer optimized SVGs (remove metadata and inline styles) and keep each icon at viewBox `0 0 24 24`.
+
+Typography / "Repo Tool" style (Azure-DevOps-inspired)
+- Font stack: `Segoe UI, Roboto, Helvetica, Arial, sans-serif`
+- Badge shape: circular background token with centered 2-letter uppercase abbreviation (e.g., `JV` for Java). Circle radius: 11 (viewBox 24x24)
+- Sizes: badge height 20px (display inline-block tile), icon inside scaled to fit with 2px padding.
+- Color tokens (examples):
+  - Java: #E76F51
+  - Python: #3776AB
+  - Rust: #DEA584
+  - TypeScript: #3178C6
+  - Go: #00ADD8
+  - JavaScript: #F7DF1E (use dark text on light background)
+  - NuGet: #512BD4
+
+SVG emblem example (pseudo):
+
+<!-- Background circle -->
+<circle cx="12" cy="12" r="11" fill="#E76F51" />
+<!-- Text abbreviation -->
+<text x="12" y="15.5" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="10" font-weight="bold" fill="#FFFFFF" text-anchor="middle">JV</text>
+
+Usage notes
+- Add badges to README and site header as small inline images (shields.io for live badges, local SVGs for custom icons).
+- If automation is desired later, write a small script to pull icons from simple-icons and normalise coloring and file names.

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -78,6 +78,90 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`
 uv run rrt-mcp --transport http --port 8000
 ```
 
+#### Typical MCP client configuration examples (.mcp.json)
+
+Installed entry point (recommended, per-repo):
+
+```json
+{
+  "mcpServers": {
+    "rrt": {
+      "type": "stdio",
+      "command": "rrt-mcp",
+      "args": []
+    }
+  }
+}
+```
+
+From-source (developer convenience using uvx):
+
+```json
+{
+  "mcpServers": {
+    "rrt": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["repo-release-tools", "rrt-mcp"]
+    }
+  }
+}
+```
+
+Claude Desktop / platform adapter example (uvx wrapper):
+
+```json
+{
+  "mcpServers": {
+    "rrt": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["--from", "repo-release-tools[mcp]", "rrt-mcp"]
+    }
+  }
+}
+```
+
+(Use the installed `rrt-mcp` entry point in production; `uvx` is convenient for iterating from a checkout.)
+
+### GitHub Copilot
+
+GitHub Copilot integrations vary by product and local tooling. The recommended approach is to install the bundled Copilot skill and run an MCP server that the Copilot client or adapter can reach:
+
+```bash
+rrt skill install --target copilot-local
+# start a local MCP HTTP server that an adapter can proxy to
+uv run rrt-mcp --transport http --port 8000
+```
+
+If using a hosted or product-specific Copilot client, consult the client documentation for how to point it at an MCP-compatible server or use a local adapter that bridges the client's extension API to MCP.
+
+### Codex and Gemini (adapters)
+
+Codex- and Gemini-based integrations typically require an adapter that understands the platform's client. For local testing and early development, install the codex-local skill and run the MCP HTTP transport:
+
+```bash
+rrt skill install --target codex-local
+uv run rrt-mcp --transport http --port 8000
+```
+
+For production or hosted LLMs, use an MCP-aware gateway or adapter that forwards requests from your LLM client to the local MCP server. See docs/commands/skill.md for how to install and manage bundled skills.
+
+For more details and advanced deployment options, consult the fastmcp project and the MCP client documentation for your chosen agent runtime.
+
+### Helper: generate a .mcp.json from a template
+
+A tiny helper script is included at `scripts/generate_mcp_json.py` to create a `.mcp.json` from a small template. Example usage (from the repository root):
+
+```bash
+python3 scripts/generate_mcp_json.py --command rrt-mcp --output .mcp.json
+# or, to generate a uvx-based entry for development
+python3 scripts/generate_mcp_json.py --command uvx --args 'repo-release-tools rrt-mcp' --output .mcp.json
+```
+
+This script is intentionally minimal — adjust the generated file as needed for your MCP client or adapter.
+
+
 ---
 
 ## Tools

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -159,7 +159,42 @@ python3 scripts/generate_mcp_json.py --command rrt-mcp --output .mcp.json
 python3 scripts/generate_mcp_json.py --command uvx --args 'repo-release-tools rrt-mcp' --output .mcp.json
 ```
 
-This script is intentionally minimal — adjust the generated file as needed for your MCP client or adapter.
+A new CLI helper is also available once the package is installed: `rrt-mcp-config`.
+
+Basic examples:
+
+- Append mode (only adds server entry if missing):
+
+```bash
+# write .mcp.json in repo root only if key 'rrt' is absent
+rrt-mcp-config --mode append --target local
+```
+
+- Extend mode (deep-merge into existing file):
+
+```bash
+# merge server entry, preserving existing args and merging lists
+rrt-mcp-config --mode extend --target local --command rrt-mcp --args "--transport http --port 8000"
+```
+
+- Overwrite mode (replace file):
+
+```bash
+rrt-mcp-config --mode overwrite --target local --command rrt-mcp --args "--transport http --port 8000"
+```
+
+Where to write:
+- local: `.mcp.json` in current repo
+- user: `~/.mcp.json` (user-level)
+- claude-desktop: platform path for Claude Desktop config (macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`)
+- custom: pass `--path /some/path/.mcp.json`
+
+This tool supports three modes:
+- append: add server only if key missing
+- extend: deep-merge existing file and add/merge server entry
+- overwrite: replace target file with generated content
+
+Use with care for global targets; prefer `--mode append` or `--mode extend` when updating user or desktop config files.
 
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ rrt = "repo_release_tools.cli:main"
 rrt-agents = "repo_release_tools.commands.agents_cmd:main"
 rrt-hooks = "repo_release_tools.workflow.hooks:main"
 rrt-mcp = "repo_release_tools.mcp.server:main"
+rrt-mcp-config = "repo_release_tools.tools.mcp_config:main"
 
 [project.optional-dependencies]
 mcp = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 dependencies = []
 
 [project.urls]
-Homepage = "https://github.com/Anselmoo/repo-release-tools"
+Homepage = "https://anselmoo.github.io/repo-release-tools/"
 Issues = "https://github.com/Anselmoo/repo-release-tools/issues"
 Source = "https://github.com/Anselmoo/repo-release-tools"
 

--- a/scripts/generate_mcp_json.py
+++ b/scripts/generate_mcp_json.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Generate a .mcp.json configuration file for locally connecting MCP servers.
+
+Usage examples:
+  python3 scripts/generate_mcp_json.py --command rrt-mcp --output .mcp.json
+  python3 scripts/generate_mcp_json.py --command uvx --args 'repo-release-tools rrt-mcp' --output .mcp.json
+"""
+import argparse
+import json
+import shlex
+from pathlib import Path
+
+def main():
+    p = argparse.ArgumentParser(description="Generate .mcp.json for MCP servers")
+    p.add_argument("--command", required=True, help="Command to run (e.g. rrt-mcp or uvx)")
+    p.add_argument("--args", default="", help="Space-separated args for the command (e.g. 'repo-release-tools rrt-mcp')")
+    p.add_argument("--transport", default="stdio", choices=["stdio", "http"], help="Transport type")
+    p.add_argument("--name", default="rrt", help="MCP server name key")
+    p.add_argument("--output", default=".mcp.json", help="Output file path")
+    args = p.parse_args()
+
+    args_list = shlex.split(args.args) if args.args else []
+
+    payload = {
+        "mcpServers": {
+            args.name: {
+                "type": args.transport,
+                "command": args.command,
+                "args": args_list,
+            }
+        }
+    }
+
+    out = Path(args.output)
+    out.write_text(json.dumps(payload, indent=2))
+    print(f"Wrote {out.resolve()}")
+
+if __name__ == '__main__':
+    main()

--- a/src/repo_release_tools/tools/mcp_config.py
+++ b/src/repo_release_tools/tools/mcp_config.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Small utility to write/merge `.mcp.json` configuration files.
+
+Usage examples:
+  rrt-mcp-config --mode append --target local
+  rrt-mcp-config --mode extend --path ~/.mcp.json
+  python -m repo_release_tools.tools.mcp_config --mode overwrite --command rrt-mcp --args "--transport http --port 8000" --output .mcp.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, List
+
+DEFAULT_KEY = "rrt"
+
+
+def deep_merge(a: Dict[str, Any], b: Dict[str, Any]) -> Dict[str, Any]:
+    """Merge b into a and return a. For lists under 'args' perform unique concat."""
+    for k, v in b.items():
+        if k in a and isinstance(a[k], dict) and isinstance(v, dict):
+            deep_merge(a[k], v)
+        elif k in a and isinstance(a[k], list) and isinstance(v, list):
+            # unique-preserve order
+            existing = list(a[k])
+            for item in v:
+                if item not in existing:
+                    existing.append(item)
+            a[k] = existing
+        else:
+            a[k] = v
+    return a
+
+
+def load_json(path: Path) -> Dict[str, Any]:
+    """Load JSON from *path* returning an empty dict if the file is missing.
+
+    Raises SystemExit when the file exists but is not valid JSON.
+    """
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        raise SystemExit(f"Failed to read JSON from {path}")
+
+
+def write_json(path: Path, payload: Dict[str, Any]) -> None:
+    """Write *payload* as pretty JSON to *path* (creating parent directories)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    # Use the UI printer for consistent CLI output
+    from repo_release_tools.ui import DryRunPrinter
+
+    DryRunPrinter(dry_run=False).ok(f"Wrote {path}")
+
+
+def build_payload(command: str, args: List[str], key: str) -> Dict[str, Any]:
+    """Return a minimal MCP payload dict for *key* that invokes *command* with *args*."""
+    return {"mcpServers": {key: {"type": "stdio", "command": command, "args": args}}}
+
+
+def resolve_target_path(target: str, custom: str | None) -> Path:
+    """Resolve the target name to a filesystem path.
+
+    Supported targets: local, user, claude-desktop, custom.
+    """
+    home = Path.home()
+    if target == "local":
+        return Path.cwd() / ".mcp.json"
+    if target == "user":
+        return home / ".mcp.json"
+    if target == "claude-desktop":
+        # macOS location preferred; fallback to user path
+        mac = home / "Library" / "Application Support" / "Claude" / "claude_desktop_config.json"
+        if mac.exists() or os.name != "nt":
+            return mac
+        # Windows fallback
+        appdata = os.environ.get("APPDATA")
+        if appdata:
+            return Path(appdata) / "Claude" / "claude_desktop_config.json"
+        return home / ".mcp.json"
+    if target == "custom":
+        if not custom:
+            raise SystemExit("--path is required for custom target")
+        return Path(custom).expanduser()
+    raise SystemExit(f"Unknown target: {target}")
+
+
+def main(argv: List[str] | None = None) -> None:
+    """Command-line entry point. Parse arguments and perform the requested action."""
+    p = argparse.ArgumentParser(description="Generate or merge .mcp.json MCP server configs")
+    p.add_argument(
+        "--mode",
+        choices=["append", "extend", "overwrite"],
+        default="append",
+        help="append: add only if key missing; extend: merge; overwrite: replace file",
+    )
+    p.add_argument(
+        "--target",
+        choices=["local", "user", "claude-desktop", "custom"],
+        default="local",
+        help="Where to write the file",
+    )
+    p.add_argument("--path", help="Custom path for target (required if --target custom)")
+    p.add_argument("--command", default="rrt-mcp", help="Command to invoke for server entry")
+    p.add_argument("--args", default="", help="Space-separated args for the command")
+    p.add_argument("--key", default=DEFAULT_KEY, help="mcpServers key name to write/merge")
+    p.add_argument(
+        "--output", default=None, help="Optional explicit output path (overrides target)"
+    )
+    args = p.parse_args(argv)
+
+    args_list = [a for a in args.args.split() if a]
+    out_path = (
+        Path(args.output).expanduser()
+        if args.output
+        else resolve_target_path(args.target, args.path)
+    )
+
+    payload = build_payload(args.command, args_list, args.key)
+
+    if out_path.exists():
+        existing = load_json(out_path)
+    else:
+        existing = {}
+
+    printer = None
+    try:
+        from repo_release_tools.ui import DryRunPrinter
+
+        printer = DryRunPrinter(dry_run=False)
+    except Exception:
+        printer = None
+
+    if args.mode == "append":
+        ms = existing.get("mcpServers", {})
+        if args.key in ms:
+            # Prefer the structured UI printer when available
+            if printer:
+                printer.warn(
+                    f"Server key '{args.key}' already present in {out_path}; no changes made (append mode)"
+                )
+            else:
+                try:
+                    from repo_release_tools.ui import DryRunPrinter
+
+                    DryRunPrinter(dry_run=False).warn(
+                        f"Server key '{args.key}' already present in {out_path}; no changes made (append mode)"
+                    )
+                except Exception:
+                    # No UI available, silently exit (no-op)
+                    pass
+            return
+        # add payload
+        existing.setdefault("mcpServers", {})
+        existing["mcpServers"][args.key] = payload["mcpServers"][args.key]
+        write_json(out_path, existing)
+        return
+
+    if args.mode == "extend":
+        merged = existing.copy() if existing else {}
+        merged.setdefault("mcpServers", {})
+        merged_servers = merged["mcpServers"]
+        new_servers = payload["mcpServers"]
+        for k, v in new_servers.items():
+            if k in merged_servers and isinstance(merged_servers[k], dict):
+                deep_merge(merged_servers[k], v)
+            else:
+                merged_servers[k] = v
+        write_json(out_path, merged)
+        return
+
+    if args.mode == "overwrite":
+        write_json(out_path, payload)
+        return
+
+
+if __name__ == "__main__":
+    main()

--- a/src/repo_release_tools/tools/platform.py
+++ b/src/repo_release_tools/tools/platform.py
@@ -340,7 +340,7 @@ def render_badge(
 
     if badge_style == "shields":
         img_url = shields_badge_url(platform, label=display)
-    elif badge_variant in ("adaptive", "adaptive-reto") and badge_style == "svg":
+    elif badge_variant in {"adaptive", "adaptive-reto"} and badge_style == "svg":
         # Adaptive mode: render a <picture> element with dark/light variants
         if badge_variant == "adaptive-reto":
             dark_url = f"{badge_assets_dir.rstrip('/')}/{platform}-reto-dark.svg"


### PR DESCRIPTION
This PR fixes the homepage URL, adds Python/PyPI badges to README and docs layout, expands docs/mcp-server.md with MCP examples, adds scripts/generate_mcp_json.py, and introduces an mcp_config CLI helper (uses repo UI printer, supports append/extend/overwrite). Temporary .mcp.json used for smoke tests has been removed and added to .gitignore.\n\nChanges: pyproject.toml, README.md, docs/_layouts/default.html, docs/mcp-server.md, docs/assets/icons/README.md, scripts/generate_mcp_json.py, src/repo_release_tools/tools/mcp_config.py\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>