### PR TITLE
feat(release): add `rrt release repair` for polluted release branches

### DIFF
--- a/.rrt/tree.lock.toml
+++ b/.rrt/tree.lock.toml
@@ -1,10 +1,10 @@
 [meta]
-generated_at = "2026-06-10T17:20:50+00:00"
-rrt_version = "1.8.3"
+generated_at = "2026-06-10T20:30:27+00:00"
+rrt_version = "1.9.0"
 
 [snapshot]
-entry_count = 297
-tree_hash = "sha256:d29016fc85da59b917ec5a1df161b160ccb5af49b8d1cd88c351f5339e21ab26"
-updated_at = "2026-06-10T17:20:50+00:00"
+entry_count = 299
+tree_hash = "sha256:377a8e6dde4648e0871ba41e712afc1bec4531fba8bdd9af4a34cc8611ef7e7e"
+updated_at = "2026-06-10T20:30:27+00:00"
 ignored_count = 201
 phantom_empty_dirs = []

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Added
+
+- `rrt release repair` — fix or recreate a release branch after a polluted PR. Verify mode (`rrt release repair`) walks every version target, pin target, and `[VERSION]`/`[Unreleased]` section and prints drift; `--yes` rewrites the drifted files and commits `chore(release): repair v{ver}`. Recreate mode (`--from BASE --yes`) rewinds the current branch to `BASE`, restores the `[VERSION]` body from HEAD (or `--changelog-from PATH`), and replays the bump as a single `chore: bump version to v{ver}` commit. Safety: writes a `repair/backup/<branch>-<ts>` ref before any destructive operation, refuses when the working tree is dirty or the branch is ahead of `origin/<branch>` (use `--force-allow-pushed`), and supports a `--hotfix` mode that implies `--yes` and tags the commit as `chore(release): repair v{ver}` for express recovery.
+
 ## [1.9.0] - 2026-06-10
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 ### Added
 
 - `rrt release repair` — fix or recreate a release branch after a polluted PR. Verify mode (`rrt release repair`) walks every version target, pin target, and `[VERSION]`/`[Unreleased]` section and prints drift; `--yes` rewrites the drifted files and commits `chore(release): repair v{ver}`. Recreate mode (`--from BASE --yes`) rewinds the current branch to `BASE`, restores the `[VERSION]` body from HEAD (or `--changelog-from PATH`), and replays the bump as a single `chore: bump version to v{ver}` commit. Safety: writes a `repair/backup/<branch>-<ts>` ref before any destructive operation, refuses when the working tree is dirty or the branch is ahead of `origin/<branch>` (use `--force-allow-pushed`), and supports a `--hotfix` mode that implies `--yes` and tags the commit as `chore(release): repair v{ver}` for express recovery.
+- `clear_unreleased_section(content, fmt)` public helper in `changelog.py` — removes every entry under `[Unreleased]` while keeping the header. Used by `rrt release repair` for the `changelog_unreleased_dirty` drift case.
+
+### Fixed
+
+- `rrt release repair` no longer aborts when a pin file exists but its configured pattern does not match. Both `_recreate` and `_apply_drift_fixes` now guard pin rewrites with `search_pattern`, mirroring the drift-detection rule and matching the verify-mode "no-match is not drift" policy.
+- `rrt release repair` no longer duplicates the `[VERSION]` section when fixing `changelog_unreleased_dirty` drift. The two changelog drift kinds now take distinct fix paths: `changelog_missing_section` stamps a new section from the resolved body; `changelog_unreleased_dirty` clears `[Unreleased]` via the new `clear_unreleased_section` helper without touching the already-promoted versioned section below.
+- `rrt release repair --yes` (verify+fix mode) now refuses to apply when the changelog lacks a `[VERSION]` section and no `--changelog-from PATH` was provided, instead of silently writing an empty release section and dropping the intended notes. The refuse message mirrors recreate mode's safety guard.
 
 ## [1.9.0] - 2026-06-10
 ### Added

--- a/docs/commands/version-release.md
+++ b/docs/commands/version-release.md
@@ -46,6 +46,7 @@ permalink: "/commands/version-release/"
   - [Related docs](#related-docs-1)
   - [`rrt release check`](#rrt-release-check)
   - [`rrt release notes`](#rrt-release-notes)
+  - [`rrt release repair`](#rrt-release-repair)
 - [`rrt workspace`](#rrt-workspace)
   - [Overview](#overview-3)
   - [When to use this](#when-to-use-this)
@@ -525,6 +526,7 @@ Arguments
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   check       Validate version targets, pin targets, and changelog files.
   notes       Emit a changelog release section as a formatted release body.
+  repair      Fix drift or recreate a release branch cleanly.
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Options
@@ -583,6 +585,38 @@ Examples
   $ rrt release notes --format md > RELEASE_BODY.md
   $ rrt release notes --latest-released --output RELEASE_CHANGELOG.md
   $ rrt release notes --version 1.2.3
+```
+
+### `rrt release repair`
+
+```text
+Usage:  rrt release repair [OPTIONS]
+
+Verify (and optionally fix) version target / pin target / changelog drift on the current branch, or recreate the branch cleanly from a base ref while preserving the declared version and its [VERSION] changelog body.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Arguments
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  -h, --help             Show this message and exit.
+  --from BASE            Recreate mode: rewind the current branch to BASE (commit, branch, or tag) and replay the version bump. Without this flag the command runs in verify-and-fix mode.
+  --yes, -y              Required to apply changes; otherwise the command only previews.
+  --hotfix               Implies --yes and tags the commit as `chore(release): repair v{ver}` so hotfix recoveries are distinguishable from regular bumps.
+  --changelog-from PATH  Read the [VERSION] body from PATH instead of the current branch's CHANGELOG.md. Useful when the polluted HEAD has lost the section.
+  --force-allow-pushed   Allow recreate when the branch is ahead of origin/<branch>. The new history must then be force-pushed with `git push --force-with-lease`.
+  --no-backup            Skip the `repair/backup/<branch>-<ts>` ref that is otherwise written before any destructive operation.
+  --group GROUP          Pick the version group when multiple are configured.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Examples
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  $ rrt release repair
+  $ rrt release repair --yes
+  $ rrt release repair --from main --yes
+  $ rrt release repair --from main --hotfix
 ```
 
 ## `rrt workspace`

--- a/src/repo_release_tools/changelog.py
+++ b/src/repo_release_tools/changelog.py
@@ -288,6 +288,39 @@ def get_unreleased_entries(
     return [line for line in section_body.splitlines() if line.strip().startswith("- ")]
 
 
+def clear_unreleased_section(
+    content: str,
+    fmt: ChangelogFormat = ChangelogFormat.MARKDOWN,
+) -> str:
+    """Remove every entry under ``[Unreleased]``, keeping the header line.
+
+    Used by post-release cleanup tooling (``rrt release repair`` for the
+    ``changelog_unreleased_dirty`` drift case): a forgotten bullet under
+    ``[Unreleased]`` after a bump is wiped without touching the already-
+    promoted versioned section below.
+
+    Returns the content unchanged when no ``[Unreleased]`` header is
+    present. When a versioned section follows the header, a single blank
+    line is left between the header and that next section.
+    """
+    if fmt == ChangelogFormat.RST:
+        m = _RST_UNRELEASED_HEADER_RE.search(content)
+        if not m:
+            return content
+        section_start = m.end()
+        next_section = _RST_SECTION_BOUNDARY_RE.search(content, section_start)
+    else:
+        m = _UNRELEASED_HEADER_RE.search(content)
+        if not m:
+            return content
+        section_start = m.end()
+        next_section = _SECTION_HEADER_RE.search(content, section_start)
+
+    if next_section is None:
+        return content[:section_start].rstrip() + "\n"
+    return content[:section_start].rstrip() + "\n\n" + content[next_section.start() :]
+
+
 # ---------------------------------------------------------------------------
 # Versioned section helpers
 # ---------------------------------------------------------------------------

--- a/src/repo_release_tools/commands/release_cmd.py
+++ b/src/repo_release_tools/commands/release_cmd.py
@@ -68,6 +68,7 @@ import sys
 from pathlib import Path
 
 from repo_release_tools.commands.release_notes import register_subcommand as _register_notes
+from repo_release_tools.commands.release_repair import register_subcommand as _register_repair
 from repo_release_tools.config import (
     PinTarget,
     VersionTarget,
@@ -256,3 +257,4 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
     check_parser.set_defaults(handler=cmd_release_check)
 
     _register_notes(release_subparsers)
+    _register_repair(release_subparsers)

--- a/src/repo_release_tools/commands/release_repair.py
+++ b/src/repo_release_tools/commands/release_repair.py
@@ -48,6 +48,7 @@ from pathlib import Path
 
 from repo_release_tools.changelog import (
     ChangelogFormat,
+    clear_unreleased_section,
     detect_changelog_format,
     get_release_section_body,
     get_unreleased_entries,
@@ -228,13 +229,7 @@ def _recreate(
         replace_all_versions_atomic(targets_to_rewrite, declared_version, dry_run=False)
 
     all_pins = _unique_pins(group, config)
-    for pin in all_pins:
-        replace_pin_in_file(
-            pin,
-            declared_version,
-            dry_run=False,
-            pin_target_missing=config.pin_target_missing,
-        )
+    _rewrite_matching_pins(all_pins, declared_version, config)
 
     base_changelog = (
         group.changelog_file.read_text(encoding="utf-8") if group.changelog_file.exists() else ""
@@ -316,6 +311,19 @@ def _verify_and_fix(
     apply = bool(getattr(args, "yes", False) or getattr(args, "hotfix", False))
     if not apply:
         p.warn("Preview only. Re-run with --yes to apply fixes.")
+        return 1
+
+    # When the changelog is missing the [VERSION] section, applying without
+    # a body would silently rewrite the section as empty and drop the
+    # intended release notes. Match the recreate-mode safety: refuse unless
+    # the caller provided --changelog-from PATH.
+    if any(d.kind == "changelog_missing_section" for d in drifts) and version_body is None:
+        p.line(
+            f"Repair refused: CHANGELOG.md has no [{declared_version}] section "
+            "on this branch. Re-run with --changelog-from PATH.",
+            ok=False,
+            stream=sys.stderr,
+        )
         return 1
 
     _apply_drift_fixes(
@@ -428,15 +436,23 @@ def _apply_drift_fixes(
 ) -> None:
     """Apply every fix implied by *drifts*.
 
-    Version-target and pin-target drift rewrite the offending files via the
-    same helpers used by ``rrt bump``. Changelog drift uses the saved
-    ``version_body`` (or the existing one) to rebuild the section.
+    Version-target drift writes via :func:`replace_all_versions_atomic`,
+    pin-target drift via :func:`_rewrite_matching_pins` (which silently
+    skips files whose pattern does not match, matching the drift-detection
+    rule). Changelog drift is split:
+
+    - ``changelog_missing_section`` requires *version_body*; the caller is
+      expected to refuse earlier when no body is available so this function
+      only runs when a body exists. The body is stamped via
+      :func:`_stamp_version_section`.
+    - ``changelog_unreleased_dirty`` calls :func:`clear_unreleased_section`
+      to wipe ``[Unreleased]`` without touching the already-promoted
+      versioned section below.
     """
     needs_version_rewrite = any(d.kind == "version_target" for d in drifts)
     needs_pin_rewrite = any(d.kind == "pin_target" for d in drifts)
-    needs_changelog_rewrite = any(
-        d.kind in {"changelog_missing_section", "changelog_unreleased_dirty"} for d in drifts
-    )
+    missing_section = any(d.kind == "changelog_missing_section" for d in drifts)
+    unreleased_dirty = any(d.kind == "changelog_unreleased_dirty" for d in drifts)
 
     if needs_version_rewrite:
         targets_to_rewrite = _targets_needing_rewrite(group.version_targets, declared_version)
@@ -444,18 +460,19 @@ def _apply_drift_fixes(
             replace_all_versions_atomic(targets_to_rewrite, declared_version, dry_run=False)
 
     if needs_pin_rewrite:
-        for pin in _unique_pins(group, config):
-            replace_pin_in_file(
-                pin,
-                declared_version,
-                dry_run=False,
-                pin_target_missing=config.pin_target_missing,
-            )
+        _rewrite_matching_pins(_unique_pins(group, config), declared_version, config)
 
-    if needs_changelog_rewrite and group.changelog_file.exists():
-        body = version_body or ""
-        rebuilt = _stamp_version_section(existing_changelog, declared_version, body, fmt)
-        group.changelog_file.write_text(rebuilt, encoding="utf-8")
+    if (missing_section or unreleased_dirty) and group.changelog_file.exists():
+        content = existing_changelog
+        if missing_section:
+            assert version_body is not None, (
+                "missing_section drift reached _apply_drift_fixes without a body; "
+                "the caller must refuse with --changelog-from guidance before this point."
+            )
+            content = _stamp_version_section(content, declared_version, version_body, fmt)
+        if unreleased_dirty:
+            content = clear_unreleased_section(content, fmt)
+        group.changelog_file.write_text(content, encoding="utf-8")
 
 
 # ---------------------------------------------------------------------------
@@ -536,6 +553,30 @@ def _unique_pins(group: VersionGroup, config: RrtConfig) -> list[PinTarget]:
         seen.add(key)
         result.append(pin)
     return result
+
+
+def _rewrite_matching_pins(pins: list[PinTarget], declared_version: str, config: RrtConfig) -> None:
+    """Rewrite each pin target whose pattern actually matches.
+
+    Mirrors the no-match policy used by :func:`_collect_drifts`: a pin file
+    that exists but does not match its configured pattern is treated as
+    non-drift and silently skipped. Without this guard,
+    :func:`replace_pin_in_file` would raise ``RuntimeError`` under the
+    default ``pin_target_missing="error"`` policy, aborting the entire
+    repair even though there is nothing to fix for that pin.
+    """
+    for pin in pins:
+        if not pin.path.exists():
+            continue
+        text = pin.path.read_text(encoding="utf-8")
+        if search_pattern(text, pin.pattern) is None:
+            continue
+        replace_pin_in_file(
+            pin,
+            declared_version,
+            dry_run=False,
+            pin_target_missing=config.pin_target_missing,
+        )
 
 
 def _files_to_stage(group: VersionGroup, root: Path, pins: list[PinTarget]) -> list[str]:

--- a/src/repo_release_tools/commands/release_repair.py
+++ b/src/repo_release_tools/commands/release_repair.py
@@ -1,0 +1,736 @@
+"""`rrt release repair` — fix or recreate a release branch.
+
+## Overview
+
+A release branch can drift in two ways:
+
+1. **Polluted history** — feature commits land alongside the version bump on
+   the same `release/v{ver}` branch. The PR ends up mixing feature work and
+   the release commit.
+2. **Drifted targets** — one or more `version_targets`, `pin_targets`, or the
+   changelog `[VERSION]` section don't match the declared project version
+   (typically because a manual edit was missed).
+
+`rrt release repair` addresses both. Two modes share the same skeleton:
+
+- **Recreate mode** (``--from BASE``): rewinds the current branch to ``BASE``
+  via ``git reset --hard``, then replays the version bump cleanly against
+  that base. The ``[VERSION]`` body is carried over from the polluted HEAD
+  (or from ``--changelog-from PATH``), so no manually written entries are
+  lost. A safety backup ref ``repair/backup/<branch>-<ts>`` is created first
+  unless ``--no-backup`` is passed.
+- **Verify mode** (no ``--from``): walks every version target, pin target,
+  and the changelog `[VERSION]`/`[Unreleased]` sections. Reports drift to
+  stdout. With ``--yes`` it also rewrites the drifted files and creates a
+  ``chore(release): repair v{ver}`` commit on the current branch.
+
+Both modes refuse to run when the working tree is dirty. Recreate mode also
+refuses by default when the branch is ahead of ``origin/<branch>`` (the
+caller must opt in with ``--force-allow-pushed`` because the recreate forces
+a destructive rewrite that needs a force-push).
+
+## Examples
+
+- ``rrt release repair`` — verify drift, exit 1 if any.
+- ``rrt release repair --yes`` — apply fixes in place, commit them.
+- ``rrt release repair --from main --yes`` — rewind to main and replay the bump.
+- ``rrt release repair --from main --hotfix`` — same as above, no prompt, uses
+  ``chore(release): repair v{ver}`` as the commit subject.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from repo_release_tools.changelog import (
+    ChangelogFormat,
+    detect_changelog_format,
+    get_release_section_body,
+    get_unreleased_entries,
+    insert_generated_section,
+)
+from repo_release_tools.config import (
+    PinTarget,
+    RrtConfig,
+    VersionGroup,
+    VersionTarget,
+    find_repo_root,
+    format_missing_tool_rrt_guidance,
+    is_missing_tool_rrt_error,
+    iter_config_files,
+    load_or_autodetect_config,
+)
+from repo_release_tools.ui import VerbosePrinter
+from repo_release_tools.version.targets import (
+    read_group_current_version,
+    read_version_string,
+    replace_all_versions_atomic,
+    replace_pin_in_file,
+    search_pattern,
+)
+from repo_release_tools.workflow import git
+
+REPAIR_EPILOG = (
+    "  $ rrt release repair\n"
+    "  $ rrt release repair --yes\n"
+    "  $ rrt release repair --from main --yes\n"
+    "  $ rrt release repair --from main --hotfix"
+)
+
+
+@dataclass(frozen=True)
+class Drift:
+    """One mismatch between the declared project version and a tracked target.
+
+    ``kind`` is a short identifier: ``"version_target"``, ``"pin_target"``,
+    ``"changelog_missing_section"``, or ``"changelog_unreleased_dirty"``.
+    ``path`` is the file's path relative to the repo root.
+    """
+
+    kind: str
+    path: str
+    expected: str
+    actual: str
+
+
+def cmd_release_repair(args: argparse.Namespace) -> int:
+    """Verify or recreate the release state for the current branch."""
+    verbose: int = getattr(args, "verbose", 0) or 0
+    root = find_repo_root(Path.cwd())
+
+    config, group, exit_code = _load_config_and_group(args, root, verbose)
+    if config is None or group is None:
+        return exit_code
+
+    if not git.working_tree_clean(root):
+        VerbosePrinter(verbose=verbose).line(
+            "Repair refused: working tree has uncommitted changes. Commit or stash first.",
+            ok=False,
+            stream=sys.stderr,
+        )
+        return 1
+
+    declared_version = str(read_group_current_version(group))
+    changelog_path = group.changelog_file
+    fmt = detect_changelog_format(changelog_path.name)
+    existing_changelog = (
+        changelog_path.read_text(encoding="utf-8") if changelog_path.exists() else ""
+    )
+    version_body = _resolve_version_body(args, declared_version, existing_changelog, fmt)
+
+    base_ref: str | None = getattr(args, "from_ref", None)
+    if base_ref:
+        return _recreate(
+            args=args,
+            config=config,
+            group=group,
+            root=root,
+            declared_version=declared_version,
+            fmt=fmt,
+            version_body=version_body,
+            base_ref=base_ref,
+            verbose=verbose,
+        )
+
+    return _verify_and_fix(
+        args=args,
+        config=config,
+        group=group,
+        root=root,
+        declared_version=declared_version,
+        fmt=fmt,
+        existing_changelog=existing_changelog,
+        version_body=version_body,
+        verbose=verbose,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Recreate mode
+# ---------------------------------------------------------------------------
+
+
+def _recreate(
+    *,
+    args: argparse.Namespace,
+    config: RrtConfig,
+    group: VersionGroup,
+    root: Path,
+    declared_version: str,
+    fmt: ChangelogFormat,
+    version_body: str | None,
+    base_ref: str,
+    verbose: int,
+) -> int:
+    """Rewind the current branch to *base_ref* and replay the bump."""
+    p = VerbosePrinter(verbose=verbose)
+
+    if version_body is None:
+        p.line(
+            f"Repair refused: CHANGELOG.md has no [{declared_version}] section "
+            "on this branch. Re-run with --changelog-from PATH.",
+            ok=False,
+            stream=sys.stderr,
+        )
+        return 1
+
+    if not git.ref_exists(root, base_ref):
+        p.line(
+            f"Repair refused: base ref {base_ref!r} not found.",
+            ok=False,
+            stream=sys.stderr,
+        )
+        return 1
+
+    branch = git.current_branch(root)
+    if not getattr(args, "force_allow_pushed", False):
+        upstream = f"origin/{branch}"
+        if git.ref_exists(root, upstream) and git.commits_ahead(root, upstream):
+            p.line(
+                f"Repair refused: {branch} is ahead of {upstream}. "
+                "Re-run with --force-allow-pushed; the new history must be "
+                "force-pushed with `git push --force-with-lease`.",
+                ok=False,
+                stream=sys.stderr,
+            )
+            return 1
+
+    apply = bool(getattr(args, "yes", False) or getattr(args, "hotfix", False))
+
+    p.ok("rrt release repair (recreate)")
+    p.action(f"Branch: {branch}")
+    p.action(f"Base ref: {base_ref}")
+    p.action(f"Version to restore: {declared_version}")
+    p.action(f"Changelog body lines: {len(version_body.splitlines())}")
+    p.blank_line()
+
+    if not apply:
+        p.warn("Preview only. Re-run with --yes (or --hotfix) to apply.")
+        return 1
+
+    if not getattr(args, "no_backup", False):
+        backup_ref = _make_backup_ref(root, branch)
+        p.ok(f"Backup ref: {backup_ref}")
+
+    git.run(
+        ["git", "reset", "--hard", base_ref],
+        root,
+        dry_run=False,
+        label=f"git reset --hard {base_ref}",
+    )
+
+    targets_to_rewrite = _targets_needing_rewrite(group.version_targets, declared_version)
+    if targets_to_rewrite:
+        replace_all_versions_atomic(targets_to_rewrite, declared_version, dry_run=False)
+
+    all_pins = _unique_pins(group, config)
+    for pin in all_pins:
+        replace_pin_in_file(
+            pin,
+            declared_version,
+            dry_run=False,
+            pin_target_missing=config.pin_target_missing,
+        )
+
+    base_changelog = (
+        group.changelog_file.read_text(encoding="utf-8") if group.changelog_file.exists() else ""
+    )
+    rebuilt = _stamp_version_section(base_changelog, declared_version, version_body, fmt)
+    group.changelog_file.write_text(rebuilt, encoding="utf-8")
+
+    files_to_stage = _files_to_stage(group, root, all_pins)
+    git.run(
+        ["git", "add", *dict.fromkeys(files_to_stage)],
+        root,
+        dry_run=False,
+        label="git add",
+    )
+
+    commit_msg = _commit_message(args, declared_version, mode="recreate")
+    git.run(
+        ["git", "commit", "-m", commit_msg],
+        root,
+        dry_run=False,
+        label="git commit",
+    )
+
+    p.ok(f"Done. Branch '{branch}' rewritten on top of {base_ref} ({commit_msg!r}).")
+    upstream = f"origin/{branch}"
+    if git.ref_exists(root, upstream):
+        p.warn(
+            f"Remote {upstream} exists; push with: `git push --force-with-lease origin {branch}`",
+        )
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Verify-and-fix mode
+# ---------------------------------------------------------------------------
+
+
+def _verify_and_fix(
+    *,
+    args: argparse.Namespace,
+    config: RrtConfig,
+    group: VersionGroup,
+    root: Path,
+    declared_version: str,
+    fmt: ChangelogFormat,
+    existing_changelog: str,
+    version_body: str | None,
+    verbose: int,
+) -> int:
+    """Detect drift on the current branch and optionally fix it in place."""
+    p = VerbosePrinter(verbose=verbose)
+
+    drifts = _collect_drifts(
+        config=config,
+        group=group,
+        root=root,
+        declared_version=declared_version,
+        fmt=fmt,
+        existing_changelog=existing_changelog,
+    )
+
+    p.ok("rrt release repair (verify)")
+    p.action(f"Declared version: {declared_version}")
+    p.action(f"Drift records: {len(drifts)}")
+    p.blank_line()
+
+    if not drifts:
+        p.ok("No drift detected.")
+        return 0
+
+    p.section("Drift")
+    for d in drifts:
+        p.line(
+            f"  [{d.kind}] {d.path}: expected={d.expected!r} actual={d.actual!r}",
+            ok=False,
+        )
+    p.blank_line()
+
+    apply = bool(getattr(args, "yes", False) or getattr(args, "hotfix", False))
+    if not apply:
+        p.warn("Preview only. Re-run with --yes to apply fixes.")
+        return 1
+
+    _apply_drift_fixes(
+        drifts=drifts,
+        config=config,
+        group=group,
+        declared_version=declared_version,
+        existing_changelog=existing_changelog,
+        version_body=version_body,
+        fmt=fmt,
+    )
+
+    branch = git.current_branch(root)
+    files_to_stage = _files_to_stage(group, root, _unique_pins(group, config))
+    git.run(
+        ["git", "add", *dict.fromkeys(files_to_stage)],
+        root,
+        dry_run=False,
+        label="git add",
+    )
+
+    commit_msg = _commit_message(args, declared_version, mode="verify")
+    git.run(
+        ["git", "commit", "-m", commit_msg],
+        root,
+        dry_run=False,
+        label="git commit",
+    )
+
+    p.ok(f"Done. Drift repaired on '{branch}' ({commit_msg!r}).")
+    return 0
+
+
+def _collect_drifts(
+    *,
+    config: RrtConfig,
+    group: VersionGroup,
+    root: Path,
+    declared_version: str,
+    fmt: ChangelogFormat,
+    existing_changelog: str,
+) -> list[Drift]:
+    """Walk targets + changelog, return one Drift per mismatch."""
+    drifts: list[Drift] = []
+
+    for target in group.version_targets:
+        relative = str(target.path.relative_to(root))
+        if not target.path.exists():
+            drifts.append(Drift("version_target", relative, declared_version, "<missing>"))
+            continue
+        try:
+            actual = read_version_string(target)
+        except (RuntimeError, ValueError):
+            drifts.append(Drift("version_target", relative, declared_version, "<unreadable>"))
+            continue
+        if actual != declared_version:
+            drifts.append(Drift("version_target", relative, declared_version, actual))
+
+    for pin in _unique_pins(group, config):
+        relative = str(pin.path.relative_to(root))
+        if not pin.path.exists():
+            drifts.append(Drift("pin_target", relative, declared_version, "<missing>"))
+            continue
+        text = pin.path.read_text(encoding="utf-8")
+        match = search_pattern(text, pin.pattern)
+        if match is None:
+            continue
+        actual = match.group(2)
+        if actual != declared_version:
+            drifts.append(Drift("pin_target", relative, declared_version, actual))
+
+    changelog_rel = str(group.changelog_file.relative_to(root))
+    # Drift is based on what's actually on disk, not the override source.
+    on_disk_body = (
+        get_release_section_body(existing_changelog, declared_version, fmt)
+        if existing_changelog
+        else None
+    )
+    if on_disk_body is None and existing_changelog:
+        drifts.append(
+            Drift(
+                "changelog_missing_section",
+                changelog_rel,
+                f"[{declared_version}] present",
+                "missing",
+            )
+        )
+    if existing_changelog and get_unreleased_entries(existing_changelog, fmt):
+        drifts.append(
+            Drift(
+                "changelog_unreleased_dirty",
+                changelog_rel,
+                "[Unreleased] empty",
+                "<has entries>",
+            )
+        )
+
+    return drifts
+
+
+def _apply_drift_fixes(
+    *,
+    drifts: list[Drift],
+    config: RrtConfig,
+    group: VersionGroup,
+    declared_version: str,
+    existing_changelog: str,
+    version_body: str | None,
+    fmt: ChangelogFormat,
+) -> None:
+    """Apply every fix implied by *drifts*.
+
+    Version-target and pin-target drift rewrite the offending files via the
+    same helpers used by ``rrt bump``. Changelog drift uses the saved
+    ``version_body`` (or the existing one) to rebuild the section.
+    """
+    needs_version_rewrite = any(d.kind == "version_target" for d in drifts)
+    needs_pin_rewrite = any(d.kind == "pin_target" for d in drifts)
+    needs_changelog_rewrite = any(
+        d.kind in {"changelog_missing_section", "changelog_unreleased_dirty"} for d in drifts
+    )
+
+    if needs_version_rewrite:
+        targets_to_rewrite = _targets_needing_rewrite(group.version_targets, declared_version)
+        if targets_to_rewrite:
+            replace_all_versions_atomic(targets_to_rewrite, declared_version, dry_run=False)
+
+    if needs_pin_rewrite:
+        for pin in _unique_pins(group, config):
+            replace_pin_in_file(
+                pin,
+                declared_version,
+                dry_run=False,
+                pin_target_missing=config.pin_target_missing,
+            )
+
+    if needs_changelog_rewrite and group.changelog_file.exists():
+        body = version_body or ""
+        rebuilt = _stamp_version_section(existing_changelog, declared_version, body, fmt)
+        group.changelog_file.write_text(rebuilt, encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_version_body(
+    args: argparse.Namespace,
+    declared_version: str,
+    existing_changelog: str,
+    fmt: ChangelogFormat,
+) -> str | None:
+    """Resolve the [VERSION] body to restore, honoring --changelog-from."""
+    override = getattr(args, "changelog_from", None)
+    if override:
+        override_path = Path(override)
+        if not override_path.exists():
+            return None
+        override_text = override_path.read_text(encoding="utf-8")
+        return get_release_section_body(override_text, declared_version, fmt)
+    if not existing_changelog:
+        return None
+    return get_release_section_body(existing_changelog, declared_version, fmt)
+
+
+def _stamp_version_section(
+    base_changelog: str, version: str, body: str, fmt: ChangelogFormat
+) -> str:
+    """Insert a fresh ``[VERSION] - today`` section into *base_changelog*.
+
+    Reuses :func:`insert_generated_section` so the new block lands either
+    just after an existing ``[Unreleased]`` placeholder or, if the document
+    has no placeholder, after the title line.
+    """
+    today = dt.datetime.now(dt.UTC).date().isoformat()
+    body = body.strip()
+    if fmt == ChangelogFormat.RST:
+        header = f"{version} - {today}"
+        section = f"{header}\n{'-' * max(len(header), 3)}\n\n{body}\n"
+    else:
+        section = f"## [{version}] - {today}\n\n{body}\n"
+    return insert_generated_section(base_changelog, section, fmt)
+
+
+def _targets_needing_rewrite(
+    targets: list[VersionTarget], declared_version: str
+) -> list[VersionTarget]:
+    """Return targets whose on-disk version differs from *declared_version*.
+
+    Filtering before calling :func:`replace_all_versions_atomic` matters
+    because that helper deliberately raises when a write would be a no-op
+    (the bump use case treats "no change" as a bug). In repair we want
+    idempotent behavior — only touch what actually drifted.
+    """
+    drifted: list[VersionTarget] = []
+    for target in targets:
+        if not target.path.exists():
+            continue
+        try:
+            current = read_version_string(target)
+        except (RuntimeError, ValueError):
+            drifted.append(target)
+            continue
+        if current != declared_version:
+            drifted.append(target)
+    return drifted
+
+
+def _unique_pins(group: VersionGroup, config: RrtConfig) -> list[PinTarget]:
+    """Return pin targets de-duplicated by (path, pattern), preserving order."""
+    seen: set[tuple[object, str]] = set()
+    result: list[PinTarget] = []
+    for pin in (*group.pin_targets, *config.global_pin_targets):
+        key = (pin.path, pin.pattern)
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(pin)
+    return result
+
+
+def _files_to_stage(group: VersionGroup, root: Path, pins: list[PinTarget]) -> list[str]:
+    """Return the file list passed to ``git add`` after the rewrite."""
+    files: list[str] = []
+    seen: set[str] = set()
+
+    def _add(target: Path) -> None:
+        rel = str(target.relative_to(root))
+        if rel in seen:
+            return
+        seen.add(rel)
+        files.append(rel)
+
+    for target in group.version_targets:
+        if target.path.exists():
+            _add(target.path)
+    if group.changelog_file.exists():
+        _add(group.changelog_file)
+    for pin in pins:
+        if pin.path.exists():
+            _add(pin.path)
+    return files
+
+
+def _make_backup_ref(root: Path, branch: str) -> str:
+    """Write a backup ref pointing at HEAD and return its name."""
+    timestamp = dt.datetime.now(dt.UTC).strftime("%Y%m%dT%H%M%S")
+    safe_branch = branch.replace("/", "-")
+    ref_name = f"refs/heads/repair/backup/{safe_branch}-{timestamp}"
+    git.run(
+        ["git", "update-ref", ref_name, "HEAD"],
+        root,
+        dry_run=False,
+        label="backup ref",
+    )
+    return ref_name
+
+
+def _commit_message(args: argparse.Namespace, version: str, *, mode: str) -> str:
+    """Choose the commit subject for the repair commit."""
+    if getattr(args, "hotfix", False):
+        return f"chore(release): repair v{version}"
+    if mode == "recreate":
+        return f"chore: bump version to v{version}"
+    return f"chore(release): repair v{version}"
+
+
+# ---------------------------------------------------------------------------
+# Config / group resolution boilerplate (mirrors release_notes.py / bump.py)
+# ---------------------------------------------------------------------------
+
+
+def _load_config_and_group(
+    args: argparse.Namespace, root: Path, verbose: int
+) -> tuple[RrtConfig | None, VersionGroup | None, int]:
+    """Resolve the rrt config and the requested version group, or print why not."""
+    p = VerbosePrinter(verbose=verbose)
+    try:
+        config = load_or_autodetect_config(root)
+    except FileNotFoundError:
+        p.line(
+            format_missing_tool_rrt_guidance(root, iter_config_files(root)),
+            ok=False,
+            stream=sys.stderr,
+        )
+        return None, None, 1
+    except ValueError as exc:
+        if is_missing_tool_rrt_error(exc):
+            p.line("No [tool.rrt] configuration found.", ok=False, stream=sys.stderr)
+            p.line(
+                format_missing_tool_rrt_guidance(root, iter_config_files(root)),
+                ok=False,
+                stream=sys.stderr,
+            )
+            return None, None, 1
+        p.line(str(exc), ok=False, stream=sys.stderr)
+        return None, None, 1
+    except RuntimeError as exc:
+        p.line(str(exc), ok=False, stream=sys.stderr)
+        return None, None, 1
+
+    requested_group = getattr(args, "group", None)
+    if requested_group is None and len(config.version_groups) > 1:
+        p.line(
+            "Repair refused: multiple version groups configured. Pass --group NAME.",
+            ok=False,
+            stream=sys.stderr,
+        )
+        return None, None, 1
+
+    try:
+        group = config.resolve_group(requested_group)
+    except ValueError as exc:
+        p.line(str(exc), ok=False, stream=sys.stderr)
+        return None, None, 1
+
+    if not _verify_target_compatibility(group):
+        p.line(
+            "Repair refused: no version targets configured for the resolved group.",
+            ok=False,
+            stream=sys.stderr,
+        )
+        return None, None, 1
+
+    return config, group, 0
+
+
+def _verify_target_compatibility(group: VersionGroup) -> bool:
+    """Return True when the group can be repaired (has at least one target)."""
+    return bool(group.version_targets)
+
+
+# ---------------------------------------------------------------------------
+# Subparser registration
+# ---------------------------------------------------------------------------
+
+
+def register_subcommand(
+    release_subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> None:
+    """Register `repair` under the existing release subparser group."""
+    parser = release_subparsers.add_parser(
+        "repair",
+        help="Fix drift or recreate a release branch cleanly.",
+        description=(
+            "Verify (and optionally fix) version target / pin target / "
+            "changelog drift on the current branch, or recreate the branch "
+            "cleanly from a base ref while preserving the declared version "
+            "and its [VERSION] changelog body."
+        ),
+        epilog=REPAIR_EPILOG,
+    )
+    parser.add_argument(
+        "--from",
+        dest="from_ref",
+        default=None,
+        metavar="BASE",
+        help=(
+            "Recreate mode: rewind the current branch to BASE (commit, "
+            "branch, or tag) and replay the version bump. Without this flag "
+            "the command runs in verify-and-fix mode."
+        ),
+    )
+    parser.add_argument(
+        "--yes",
+        "-y",
+        action="store_true",
+        default=False,
+        help="Required to apply changes; otherwise the command only previews.",
+    )
+    parser.add_argument(
+        "--hotfix",
+        action="store_true",
+        default=False,
+        help=(
+            "Implies --yes and tags the commit as `chore(release): repair "
+            "v{ver}` so hotfix recoveries are distinguishable from regular "
+            "bumps."
+        ),
+    )
+    parser.add_argument(
+        "--changelog-from",
+        dest="changelog_from",
+        default=None,
+        metavar="PATH",
+        help=(
+            "Read the [VERSION] body from PATH instead of the current "
+            "branch's CHANGELOG.md. Useful when the polluted HEAD has "
+            "lost the section."
+        ),
+    )
+    parser.add_argument(
+        "--force-allow-pushed",
+        action="store_true",
+        default=False,
+        help=(
+            "Allow recreate when the branch is ahead of origin/<branch>. "
+            "The new history must then be force-pushed with "
+            "`git push --force-with-lease`."
+        ),
+    )
+    parser.add_argument(
+        "--no-backup",
+        action="store_true",
+        default=False,
+        help=(
+            "Skip the `repair/backup/<branch>-<ts>` ref that is otherwise "
+            "written before any destructive operation."
+        ),
+    )
+    parser.add_argument(
+        "--group",
+        default=None,
+        metavar="GROUP",
+        help="Pick the version group when multiple are configured.",
+    )
+    parser.set_defaults(handler=cmd_release_repair)

--- a/tests/commands/test_release_repair.py
+++ b/tests/commands/test_release_repair.py
@@ -1,0 +1,973 @@
+"""Tests for `rrt release repair` (verify-and-fix + recreate modes)."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+from repo_release_tools.changelog import ChangelogFormat
+from repo_release_tools.commands import release_repair
+from repo_release_tools.config import PinTarget, RrtConfig, VersionGroup, VersionTarget
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+_RRT_TOML = """\
+[tool.rrt]
+release_branch = "release/v{version}"
+lock_command = []
+
+[[tool.rrt.version_targets]]
+path = "pyproject.toml"
+kind = "pep621"
+
+[[tool.rrt.pin_targets]]
+path = "docs/install.md"
+pattern = '(rrt@v)(\\d+\\.\\d+\\.\\d+)()'
+"""
+
+_CHANGELOG = """\
+# Changelog
+
+## [Unreleased]
+
+## [1.9.0] - 2026-06-10
+### Added
+- release-notes selector
+- tree json/flat formats
+- project info
+
+## [1.8.3] - 2026-06-06
+"""
+
+
+def _args(**overrides: object) -> argparse.Namespace:
+    """Build a Namespace with every CLI flag defaulted, then override."""
+    base: dict[str, object] = {
+        "from_ref": None,
+        "yes": False,
+        "hotfix": False,
+        "changelog_from": None,
+        "force_allow_pushed": False,
+        "no_backup": False,
+        "group": None,
+        "verbose": 0,
+    }
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+def _seed_repo(
+    tmp_path: Path,
+    *,
+    pyproject_version: str = "1.9.0",
+    install_pin_version: str = "1.9.0",
+    changelog: str = _CHANGELOG,
+) -> None:
+    """Write a self-contained mini-repo to *tmp_path*."""
+    (tmp_path / ".rrt.toml").write_text(_RRT_TOML, encoding="utf-8")
+    (tmp_path / "pyproject.toml").write_text(
+        f'[project]\nname = "demo"\nversion = "{pyproject_version}"\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "CHANGELOG.md").write_text(changelog, encoding="utf-8")
+    (tmp_path / "docs").mkdir(exist_ok=True)
+    (tmp_path / "docs" / "install.md").write_text(f"rrt@v{install_pin_version}\n", encoding="utf-8")
+
+
+def _patch_git(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    clean: bool = True,
+    current_branch: str = "release/v1.9.0",
+    base_ref_exists: bool = True,
+    upstream_ahead: bool = False,
+    upstream_exists: bool = False,
+) -> list[list[str]]:
+    """Stub the git helpers used by release_repair. Returns the recorded calls."""
+    calls: list[list[str]] = []
+
+    monkeypatch.setattr(
+        "repo_release_tools.commands.release_repair.git.working_tree_clean",
+        lambda root: clean,
+    )
+    monkeypatch.setattr(
+        "repo_release_tools.commands.release_repair.git.current_branch",
+        lambda root: current_branch,
+    )
+
+    def fake_ref_exists(root: Path, ref: str) -> bool:
+        if ref.startswith("origin/"):
+            return upstream_exists
+        return base_ref_exists
+
+    monkeypatch.setattr(
+        "repo_release_tools.commands.release_repair.git.ref_exists",
+        fake_ref_exists,
+    )
+    monkeypatch.setattr(
+        "repo_release_tools.commands.release_repair.git.commits_ahead",
+        lambda root, ref: ["a1b2c3 feat: stray"] if upstream_ahead else [],
+    )
+
+    def fake_run(
+        cmd: list[str],
+        root: Path,
+        *,
+        dry_run: bool,
+        label: str,
+        suppress_announce: bool = False,
+    ) -> str:
+        calls.append(cmd)
+        return ""
+
+    monkeypatch.setattr(
+        "repo_release_tools.commands.release_repair.git.run",
+        fake_run,
+    )
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# Pre-flight blockers
+# ---------------------------------------------------------------------------
+
+
+def test_repair_refuses_dirty_tree(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _seed_repo(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    _patch_git(monkeypatch, clean=False)
+    rc = release_repair.cmd_release_repair(_args())
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "Commit or stash" in err
+
+
+def test_repair_refuses_when_base_ref_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _seed_repo(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    _patch_git(monkeypatch, base_ref_exists=False)
+    rc = release_repair.cmd_release_repair(_args(from_ref="bogus"))
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "base ref 'bogus' not found" in err
+
+
+def test_repair_refuses_when_branch_is_ahead_of_remote(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _seed_repo(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    _patch_git(monkeypatch, upstream_exists=True, upstream_ahead=True)
+    rc = release_repair.cmd_release_repair(_args(from_ref="main"))
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "--force-allow-pushed" in err
+
+
+def test_force_allow_pushed_overrides_remote_check(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """`--force-allow-pushed` lets the recreate proceed and prints the push reminder."""
+    _seed_repo(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    calls = _patch_git(monkeypatch, upstream_exists=True, upstream_ahead=True)
+    rc = release_repair.cmd_release_repair(
+        _args(from_ref="main", yes=True, force_allow_pushed=True, no_backup=True)
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert any(cmd[:3] == ["git", "reset", "--hard"] for cmd in calls)
+    assert "force-with-lease" in out
+
+
+# ---------------------------------------------------------------------------
+# Verify mode
+# ---------------------------------------------------------------------------
+
+
+def test_verify_no_drift_reports_clean_and_exits_zero(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """No drift across version/pin/changelog → exit 0, no git mutations."""
+    _seed_repo(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    calls = _patch_git(monkeypatch)
+    rc = release_repair.cmd_release_repair(_args())
+    assert rc == 0
+    assert "No drift detected" in capsys.readouterr().out
+    assert calls == []
+
+
+def test_verify_detects_version_target_drift_in_preview(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A version-target mismatch shows up in the report and exits 1."""
+    _seed_repo(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    calls = _patch_git(monkeypatch)
+    # Manually demote the pyproject so the declared version (read from the
+    # first target) diverges from the pin target.
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "demo"\nversion = "1.9.0"\n', encoding="utf-8"
+    )
+    (tmp_path / "docs" / "install.md").write_text("rrt@v1.8.3\n", encoding="utf-8")
+    rc = release_repair.cmd_release_repair(_args())
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "pin_target" in out
+    assert "install.md" in out
+    assert calls == []
+
+
+def test_verify_with_yes_writes_fixes_and_commits(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Pin drift + `--yes` → file rewritten, repair commit recorded."""
+    _seed_repo(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "docs" / "install.md").write_text("rrt@v1.8.3\n", encoding="utf-8")
+    calls = _patch_git(monkeypatch)
+    rc = release_repair.cmd_release_repair(_args(yes=True))
+    assert rc == 0
+    assert "rrt@v1.9.0" in (tmp_path / "docs" / "install.md").read_text(encoding="utf-8")
+    commit_calls = [c for c in calls if c[:2] == ["git", "commit"]]
+    assert commit_calls
+    assert commit_calls[0][-1] == "chore(release): repair v1.9.0"
+    _ = capsys.readouterr()
+
+
+def test_verify_detects_dirty_unreleased(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A non-empty `[Unreleased]` after a release is drift."""
+    polluted = (
+        "# Changelog\n\n"
+        "## [Unreleased]\n"
+        "- forgotten entry\n\n"
+        "## [1.9.0] - 2026-06-10\n"
+        "### Added\n- shipped\n"
+    )
+    _seed_repo(tmp_path, changelog=polluted)
+    monkeypatch.chdir(tmp_path)
+    _patch_git(monkeypatch)
+    rc = release_repair.cmd_release_repair(_args())
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "changelog_unreleased_dirty" in out
+
+
+# ---------------------------------------------------------------------------
+# Recreate mode
+# ---------------------------------------------------------------------------
+
+
+def test_recreate_dry_run_shows_plan_and_no_writes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _seed_repo(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    calls = _patch_git(monkeypatch)
+    rc = release_repair.cmd_release_repair(_args(from_ref="main"))
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "Preview only" in out
+    assert calls == []
+
+
+def test_recreate_creates_backup_and_resets_to_base(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _seed_repo(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    calls = _patch_git(monkeypatch)
+    rc = release_repair.cmd_release_repair(_args(from_ref="main", yes=True))
+    assert rc == 0
+    cmd_strs = [" ".join(c) for c in calls]
+    assert any(
+        c.startswith("git update-ref refs/heads/repair/backup/release-v1.9.0-") for c in cmd_strs
+    )
+    assert ["git", "reset", "--hard", "main"] in calls
+    commit_calls = [c for c in calls if c[:2] == ["git", "commit"]]
+    assert commit_calls[0][-1] == "chore: bump version to v1.9.0"
+    _ = capsys.readouterr()
+
+
+def test_recreate_preserves_version_section_in_changelog(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _seed_repo(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    _patch_git(monkeypatch)
+    rc = release_repair.cmd_release_repair(_args(from_ref="main", yes=True, no_backup=True))
+    assert rc == 0
+    rebuilt = (tmp_path / "CHANGELOG.md").read_text(encoding="utf-8")
+    assert "## [1.9.0]" in rebuilt
+    assert "release-notes selector" in rebuilt
+    assert "tree json/flat formats" in rebuilt
+    _ = capsys.readouterr()
+
+
+def test_recreate_uses_changelog_from_flag(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """When `--changelog-from PATH` is set, body comes from PATH not HEAD."""
+    saved = tmp_path / "saved-CHANGELOG.md"
+    saved.write_text(
+        "# Changelog\n\n## [1.9.0] - 2026-06-10\n### Added\n- saved entry\n",
+        encoding="utf-8",
+    )
+    # Polluted HEAD has no [1.9.0] entry — would normally fail.
+    polluted = "# Changelog\n\n## [Unreleased]\n\n## [1.8.3] - 2026-06-06\n"
+    _seed_repo(tmp_path, changelog=polluted)
+    monkeypatch.chdir(tmp_path)
+    _patch_git(monkeypatch)
+    rc = release_repair.cmd_release_repair(
+        _args(from_ref="main", yes=True, no_backup=True, changelog_from=str(saved))
+    )
+    assert rc == 0
+    rebuilt = (tmp_path / "CHANGELOG.md").read_text(encoding="utf-8")
+    assert "saved entry" in rebuilt
+    _ = capsys.readouterr()
+
+
+def test_recreate_refuses_when_section_missing_no_override(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    polluted = "# Changelog\n\n## [Unreleased]\n\n## [1.8.3] - 2026-06-06\n"
+    _seed_repo(tmp_path, changelog=polluted)
+    monkeypatch.chdir(tmp_path)
+    _patch_git(monkeypatch)
+    rc = release_repair.cmd_release_repair(_args(from_ref="main", yes=True))
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "no [1.9.0] section" in err.lower()
+
+
+def test_recreate_refuses_when_changelog_from_file_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _seed_repo(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    _patch_git(monkeypatch)
+    rc = release_repair.cmd_release_repair(
+        _args(from_ref="main", yes=True, changelog_from=str(tmp_path / "nope.md"))
+    )
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "no [1.9.0] section" in err.lower()
+
+
+# ---------------------------------------------------------------------------
+# Modes & flags
+# ---------------------------------------------------------------------------
+
+
+def test_hotfix_implies_yes_and_uses_repair_commit_message(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _seed_repo(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    calls = _patch_git(monkeypatch)
+    rc = release_repair.cmd_release_repair(_args(from_ref="main", hotfix=True, no_backup=True))
+    assert rc == 0
+    commit_calls = [c for c in calls if c[:2] == ["git", "commit"]]
+    assert commit_calls[0][-1] == "chore(release): repair v1.9.0"
+    _ = capsys.readouterr()
+
+
+def test_no_backup_skips_ref_creation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _seed_repo(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    calls = _patch_git(monkeypatch)
+    rc = release_repair.cmd_release_repair(_args(from_ref="main", yes=True, no_backup=True))
+    assert rc == 0
+    assert not any(c[:2] == ["git", "update-ref"] for c in calls)
+    _ = capsys.readouterr()
+
+
+def test_group_required_when_multiple_groups(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Multi-group config without `--group` fails before any git work."""
+    multi_rrt = """\
+[tool.rrt]
+default_group = "api"
+
+[[tool.rrt.version_groups]]
+name = "api"
+release_branch = "release/api-v{version}"
+version_source = "pyproject.toml"
+
+[[tool.rrt.version_groups.version_targets]]
+path = "pyproject.toml"
+kind = "pep621"
+
+[[tool.rrt.version_groups]]
+name = "web"
+release_branch = "release/web-v{version}"
+version_source = "package.json"
+
+[[tool.rrt.version_groups.version_targets]]
+path = "package.json"
+kind = "package_json"
+"""
+    (tmp_path / ".rrt.toml").write_text(multi_rrt, encoding="utf-8")
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "demo"\nversion = "1.9.0"\n', encoding="utf-8"
+    )
+    (tmp_path / "package.json").write_text(
+        '{ "name": "demo", "version": "1.9.0" }\n', encoding="utf-8"
+    )
+    (tmp_path / "CHANGELOG.md").write_text("# Changelog\n\n## [Unreleased]\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    _patch_git(monkeypatch)
+    rc = release_repair.cmd_release_repair(_args())
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "multiple version groups" in err
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def test_drift_dataclass_is_frozen() -> None:
+    """Drift is a frozen dataclass — assignments are rejected at runtime."""
+    import dataclasses
+
+    d = release_repair.Drift("version_target", "pyproject.toml", "1.9.0", "1.8.0")
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        object.__setattr__  # used implicitly to confirm normal assignment fails
+        setattr(d, "kind", "pin_target")
+
+
+def test_stamp_version_section_markdown_uses_today_and_body() -> None:
+    base = "# Changelog\n\n## [Unreleased]\n\n## [1.8.3] - 2026-06-06\n"
+    result = release_repair._stamp_version_section(
+        base, "1.9.0", "### Added\n- thing", ChangelogFormat.MARKDOWN
+    )
+    assert "## [1.9.0]" in result
+    assert "- thing" in result
+    # The version section lands after [Unreleased] and before [1.8.3].
+    unreleased_pos = result.index("[Unreleased]")
+    v190_pos = result.index("[1.9.0]")
+    v183_pos = result.index("[1.8.3]")
+    assert unreleased_pos < v190_pos < v183_pos
+
+
+def test_stamp_version_section_rst_uses_dash_underline() -> None:
+    base = "Changelog\n=========\n\nUnreleased\n----------\n"
+    result = release_repair._stamp_version_section(base, "1.9.0", "- thing", ChangelogFormat.RST)
+    assert "1.9.0 -" in result
+    assert "------------------" in result  # dashes under the new header
+
+
+def test_unique_pins_dedupes_by_path_and_pattern(tmp_path: Path) -> None:
+    target = VersionTarget(path=tmp_path / "pyproject.toml", kind="pep621")
+    pin = PinTarget(path=tmp_path / "README.md", pattern=r"(rrt@v)(\d+\.\d+\.\d+)")
+    pin_dup = PinTarget(path=tmp_path / "README.md", pattern=r"(rrt@v)(\d+\.\d+\.\d+)")
+    pin_other = PinTarget(path=tmp_path / "docs.md", pattern=r"(rrt@v)(\d+\.\d+\.\d+)")
+    group = VersionGroup(
+        name="default",
+        release_branch="release/v{version}",
+        changelog_file=tmp_path / "CHANGELOG.md",
+        lock_command=[],
+        generated_files=[],
+        version_targets=[target],
+        pin_targets=[pin, pin_dup],
+    )
+    config = RrtConfig(
+        root=tmp_path,
+        config_file=tmp_path / ".rrt.toml",
+        version_groups=[group],
+        default_group_name="default",
+        global_pin_targets=[pin_other],
+    )
+    result = release_repair._unique_pins(group, config)
+    assert [p.path.name for p in result] == ["README.md", "docs.md"]
+
+
+def test_files_to_stage_skips_missing_files(tmp_path: Path) -> None:
+    """Only files that actually exist on disk get staged."""
+    target = VersionTarget(path=tmp_path / "pyproject.toml", kind="pep621")
+    pin_present = PinTarget(path=tmp_path / "README.md", pattern=r"(rrt@v)(\d+\.\d+\.\d+)")
+    pin_missing = PinTarget(path=tmp_path / "gone.md", pattern=r"(rrt@v)(\d+\.\d+\.\d+)")
+    (tmp_path / "pyproject.toml").write_text("", encoding="utf-8")
+    (tmp_path / "README.md").write_text("", encoding="utf-8")
+    (tmp_path / "CHANGELOG.md").write_text("", encoding="utf-8")
+    group = VersionGroup(
+        name="default",
+        release_branch="release/v{version}",
+        changelog_file=tmp_path / "CHANGELOG.md",
+        lock_command=[],
+        generated_files=[],
+        version_targets=[target],
+        pin_targets=[pin_present, pin_missing],
+    )
+    files = release_repair._files_to_stage(group, tmp_path, [pin_present, pin_missing])
+    assert "pyproject.toml" in files
+    assert "README.md" in files
+    assert "CHANGELOG.md" in files
+    assert "gone.md" not in files
+
+
+def test_make_backup_ref_runs_git_update_ref(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], root: Path, **kwargs: object) -> str:
+        calls.append(cmd)
+        return ""
+
+    monkeypatch.setattr("repo_release_tools.commands.release_repair.git.run", fake_run)
+    name = release_repair._make_backup_ref(tmp_path, "release/v1.9.0")
+    assert name.startswith("refs/heads/repair/backup/release-v1.9.0-")
+    assert calls[0][:2] == ["git", "update-ref"]
+    assert calls[0][2] == name
+
+
+@pytest.mark.parametrize(
+    ("hotfix", "mode", "expected"),
+    [
+        (False, "recreate", "chore: bump version to v1.9.0"),
+        (True, "recreate", "chore(release): repair v1.9.0"),
+        (False, "verify", "chore(release): repair v1.9.0"),
+        (True, "verify", "chore(release): repair v1.9.0"),
+    ],
+)
+def test_commit_message_variants(hotfix: bool, mode: str, expected: str) -> None:
+    ns = argparse.Namespace(hotfix=hotfix)
+    assert release_repair._commit_message(ns, "1.9.0", mode=mode) == expected
+
+
+def test_register_subcommand_wires_handler() -> None:
+    parser = argparse.ArgumentParser(prog="rrt-test")
+    subparsers = parser.add_subparsers()
+    release_repair.register_subcommand(subparsers)
+    ns = parser.parse_args(["repair", "--from", "main", "--yes"])
+    assert ns.from_ref == "main"
+    assert ns.yes is True
+    assert ns.handler is release_repair.cmd_release_repair
+
+
+# ---------------------------------------------------------------------------
+# Config / group failure paths
+# ---------------------------------------------------------------------------
+
+
+def test_repair_handles_missing_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Empty repo (no .rrt.toml, no pyproject) yields a guidance error."""
+    monkeypatch.chdir(tmp_path)
+    rc = release_repair.cmd_release_repair(_args())
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert err  # guidance lines printed
+
+
+def test_repair_handles_missing_tool_rrt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """pyproject.toml without `[tool.rrt]` reports the missing-config guidance."""
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "demo"\nversion = "1.9.0"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    rc = release_repair.cmd_release_repair(_args())
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert err
+
+
+def test_repair_propagates_value_error_with_str(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A generic ValueError from config loading surfaces its message."""
+    _seed_repo(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_release_tools.commands.release_repair.load_or_autodetect_config",
+        lambda _: (_ for _ in ()).throw(ValueError("totally bogus config")),
+    )
+    rc = release_repair.cmd_release_repair(_args())
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "totally bogus config" in err
+
+
+def test_repair_renders_missing_tool_rrt_guidance(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """When config loading raises MissingRrtConfigError, the guidance text appears."""
+    from repo_release_tools.config import MissingRrtConfigError
+
+    _seed_repo(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_release_tools.commands.release_repair.load_or_autodetect_config",
+        lambda _: (_ for _ in ()).throw(MissingRrtConfigError("missing tool rrt")),
+    )
+    rc = release_repair.cmd_release_repair(_args())
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "No [tool.rrt]" in err
+
+
+def test_repair_propagates_runtime_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A RuntimeError from config loading surfaces its message."""
+    _seed_repo(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_release_tools.commands.release_repair.load_or_autodetect_config",
+        lambda _: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    rc = release_repair.cmd_release_repair(_args())
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "boom" in err
+
+
+def test_repair_propagates_resolve_group_value_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """`resolve_group` ValueError (unknown group) surfaces to the user."""
+    _seed_repo(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    rc = release_repair.cmd_release_repair(_args(group="missing"))
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "missing" in err
+
+
+def test_repair_refuses_group_without_version_targets(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A resolved group with no version targets fails fast."""
+    _seed_repo(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_release_tools.commands.release_repair._verify_target_compatibility",
+        lambda group: False,
+    )
+    rc = release_repair.cmd_release_repair(_args())
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "no version targets configured" in err
+
+
+# ---------------------------------------------------------------------------
+# Drift coverage — extra cases
+# ---------------------------------------------------------------------------
+
+
+def test_verify_detects_version_target_drift_when_pyproject_lags(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """When the primary target version differs from declared, that drift is reported.
+
+    The declared version is the one ``read_group_current_version`` returns
+    (the primary target). To produce a version-target drift we mock the
+    declared version to be different from what's on disk.
+    """
+    _seed_repo(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    _patch_git(monkeypatch)
+    monkeypatch.setattr(
+        "repo_release_tools.commands.release_repair.read_group_current_version",
+        lambda group: "9.9.9",
+    )
+    rc = release_repair.cmd_release_repair(_args())
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "version_target" in out
+    assert "9.9.9" in out
+
+
+def test_verify_detects_unreadable_version_target(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An unreadable version target is reported as drift with `<unreadable>`."""
+    _seed_repo(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    _patch_git(monkeypatch)
+    # Force read_version_string to raise — twice for _collect_drifts and
+    # again for _targets_needing_rewrite (if invoked) so they both treat it
+    # as drifted.
+    monkeypatch.setattr(
+        "repo_release_tools.commands.release_repair.read_version_string",
+        lambda target: (_ for _ in ()).throw(RuntimeError("can't read")),
+    )
+    monkeypatch.setattr(
+        "repo_release_tools.commands.release_repair.read_group_current_version",
+        lambda group: "1.9.0",
+    )
+    rc = release_repair.cmd_release_repair(_args())
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "<unreadable>" in out
+
+
+def test_verify_reports_missing_version_target_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A non-existent version-target file is reported as `<missing>`."""
+    _seed_repo(tmp_path)
+    (tmp_path / "pyproject.toml").unlink()
+    # Bring back a stub so config can still load via .rrt.toml
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "demo"\nversion = "1.9.0"\n', encoding="utf-8"
+    )
+    monkeypatch.chdir(tmp_path)
+    _patch_git(monkeypatch)
+    # After config load, mock the target's path resolver away — simulate a
+    # missing file by patching `Path.exists` via a stub for the version target.
+    real_exists = Path.exists
+
+    def fake_exists(self: Path) -> bool:
+        if self.name == "pyproject.toml":
+            return False
+        return real_exists(self)
+
+    monkeypatch.setattr(Path, "exists", fake_exists)
+    monkeypatch.setattr(
+        "repo_release_tools.commands.release_repair.read_group_current_version",
+        lambda group: "1.9.0",
+    )
+    rc = release_repair.cmd_release_repair(_args())
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "<missing>" in out
+
+
+def test_verify_reports_missing_pin_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A pin target whose file disappeared shows up as drift."""
+    _seed_repo(tmp_path)
+    (tmp_path / "docs" / "install.md").unlink()
+    monkeypatch.chdir(tmp_path)
+    _patch_git(monkeypatch)
+    rc = release_repair.cmd_release_repair(_args())
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "pin_target" in out
+    assert "<missing>" in out
+
+
+def test_verify_pin_pattern_no_match_is_silent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A pin file that exists but doesn't match the pattern is not drift."""
+    _seed_repo(tmp_path)
+    (tmp_path / "docs" / "install.md").write_text("no version pin here\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    _patch_git(monkeypatch)
+    rc = release_repair.cmd_release_repair(_args())
+    assert rc == 0
+    assert "No drift" in capsys.readouterr().out
+
+
+def test_verify_reports_missing_changelog_section(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A changelog with no `[VERSION]` block becomes a drift record."""
+    polluted = "# Changelog\n\n## [Unreleased]\n\n## [1.8.3] - 2026-06-06\n"
+    _seed_repo(tmp_path, changelog=polluted)
+    monkeypatch.chdir(tmp_path)
+    _patch_git(monkeypatch)
+    rc = release_repair.cmd_release_repair(_args())
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "changelog_missing_section" in out
+
+
+def test_verify_with_yes_rewrites_changelog_when_section_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """In-place fix uses `--changelog-from` body to reconstruct the section."""
+    polluted = "# Changelog\n\n## [Unreleased]\n\n## [1.8.3] - 2026-06-06\n"
+    _seed_repo(tmp_path, changelog=polluted)
+    saved = tmp_path / "saved.md"
+    saved.write_text(
+        "# Changelog\n\n## [1.9.0] - 2026-06-10\n### Added\n- saved\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    _patch_git(monkeypatch)
+    rc = release_repair.cmd_release_repair(_args(yes=True, changelog_from=str(saved)))
+    assert rc == 0
+    body = (tmp_path / "CHANGELOG.md").read_text(encoding="utf-8")
+    assert "saved" in body
+    _ = capsys.readouterr()
+
+
+def test_verify_with_yes_rewrites_version_target_when_lagging(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A primary version-target lagging declared version is rewritten in place."""
+    _seed_repo(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    _patch_git(monkeypatch)
+    # Declared version (from primary target) is overridden to differ on purpose.
+    monkeypatch.setattr(
+        "repo_release_tools.commands.release_repair.read_group_current_version",
+        lambda group: "9.9.9",
+    )
+    rc = release_repair.cmd_release_repair(_args(yes=True))
+    assert rc == 0
+    text = (tmp_path / "pyproject.toml").read_text(encoding="utf-8")
+    assert 'version = "9.9.9"' in text
+    _ = capsys.readouterr()
+
+
+def test_recreate_rewrites_version_targets_when_base_is_older(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """When the rewind landed on a base where the version still lags, replay rewrites."""
+    _seed_repo(tmp_path, pyproject_version="1.8.0")
+    # Declared version comes from `read_group_current_version`; force it to 1.9.0
+    # so the recreate replays 1.9.0 onto a base file that still says 1.8.0.
+    monkeypatch.chdir(tmp_path)
+    _patch_git(monkeypatch)
+    monkeypatch.setattr(
+        "repo_release_tools.commands.release_repair.read_group_current_version",
+        lambda group: "1.9.0",
+    )
+    rc = release_repair.cmd_release_repair(_args(from_ref="main", yes=True, no_backup=True))
+    assert rc == 0
+    assert 'version = "1.9.0"' in (tmp_path / "pyproject.toml").read_text(encoding="utf-8")
+    _ = capsys.readouterr()
+
+
+def test_resolve_version_body_empty_changelog_returns_none() -> None:
+    """An empty changelog and no `--changelog-from` resolve to None."""
+    ns = argparse.Namespace(changelog_from=None)
+    assert release_repair._resolve_version_body(ns, "1.9.0", "", ChangelogFormat.MARKDOWN) is None
+
+
+def test_targets_needing_rewrite_skips_missing_and_keeps_unreadable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing-file targets are skipped; unreadable targets are still rewritten."""
+    present = VersionTarget(path=tmp_path / "py.toml", kind="pep621")
+    missing = VersionTarget(path=tmp_path / "gone.toml", kind="pep621")
+    unreadable = VersionTarget(path=tmp_path / "bad.toml", kind="pep621")
+
+    (tmp_path / "py.toml").write_text('[project]\nversion = "1.9.0"\n', encoding="utf-8")
+    (tmp_path / "bad.toml").write_text("garbage", encoding="utf-8")
+
+    def fake_read(target: VersionTarget) -> str:
+        if target.path.name == "py.toml":
+            return "1.9.0"
+        raise RuntimeError("unreadable")
+
+    monkeypatch.setattr("repo_release_tools.commands.release_repair.read_version_string", fake_read)
+
+    drifted = release_repair._targets_needing_rewrite([present, missing, unreadable], "1.9.0")
+    names = [t.path.name for t in drifted]
+    assert "py.toml" not in names  # already at declared version
+    assert "gone.toml" not in names  # missing files are skipped
+    assert "bad.toml" in names  # unreadable becomes drift
+
+
+def test_files_to_stage_deduplicates_overlapping_paths(tmp_path: Path) -> None:
+    """A path mentioned both as a version target and as a pin appears once."""
+    target = VersionTarget(path=tmp_path / "pyproject.toml", kind="pep621")
+    overlap_pin = PinTarget(path=tmp_path / "pyproject.toml", pattern=r"(rrt@v)(\d+\.\d+\.\d+)()")
+    (tmp_path / "pyproject.toml").write_text("", encoding="utf-8")
+    (tmp_path / "CHANGELOG.md").write_text("", encoding="utf-8")
+    group = VersionGroup(
+        name="default",
+        release_branch="release/v{version}",
+        changelog_file=tmp_path / "CHANGELOG.md",
+        lock_command=[],
+        generated_files=[],
+        version_targets=[target],
+        pin_targets=[overlap_pin],
+    )
+    files = release_repair._files_to_stage(group, tmp_path, [overlap_pin])
+    assert files.count("pyproject.toml") == 1

--- a/tests/commands/test_release_repair.py
+++ b/tests/commands/test_release_repair.py
@@ -886,10 +886,15 @@ def test_verify_with_yes_rewrites_version_target_when_lagging(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     """A primary version-target lagging declared version is rewritten in place."""
-    _seed_repo(tmp_path)
+    # Changelog already has a [9.9.9] section so the only drift is the version
+    # target — the new safety check refuses verify+yes when [VERSION] is
+    # missing without a --changelog-from override.
+    changelog_with_9990 = (
+        "# Changelog\n\n## [Unreleased]\n\n## [9.9.9] - 2026-06-10\n### Added\n- already shipped\n"
+    )
+    _seed_repo(tmp_path, changelog=changelog_with_9990)
     monkeypatch.chdir(tmp_path)
     _patch_git(monkeypatch)
-    # Declared version (from primary target) is overridden to differ on purpose.
     monkeypatch.setattr(
         "repo_release_tools.commands.release_repair.read_group_current_version",
         lambda group: "9.9.9",
@@ -952,6 +957,144 @@ def test_targets_needing_rewrite_skips_missing_and_keeps_unreadable(
     assert "py.toml" not in names  # already at declared version
     assert "gone.toml" not in names  # missing files are skipped
     assert "bad.toml" in names  # unreadable becomes drift
+
+
+# ---------------------------------------------------------------------------
+# Review-driven safety cases (PR #100)
+# ---------------------------------------------------------------------------
+
+
+def test_recreate_skips_pin_when_pattern_does_not_match(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A pin file whose pattern doesn't match must not abort the recreate.
+
+    The default ``pin_target_missing="error"`` policy on `replace_pin_in_file`
+    would raise; the rewrite helper guards with `search_pattern` first.
+    """
+    _seed_repo(tmp_path)
+    (tmp_path / "docs" / "install.md").write_text("no version pin here at all\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    calls = _patch_git(monkeypatch)
+    rc = release_repair.cmd_release_repair(_args(from_ref="main", yes=True, no_backup=True))
+    assert rc == 0
+    commit_calls = [c for c in calls if c[:2] == ["git", "commit"]]
+    assert commit_calls  # commit went through; no abort
+    _ = capsys.readouterr()
+
+
+def test_verify_with_yes_skips_pin_when_pattern_does_not_match(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Same no-match guard for `_apply_drift_fixes`.
+
+    The drift in this scenario is a version-target mismatch; the pin file
+    has no matching pattern so applying fixes must not raise even though
+    `needs_pin_rewrite` is False (the helper is still called from the
+    recreate path tested above, so this test ensures the symmetry).
+    """
+    changelog_with_9990 = (
+        "# Changelog\n\n## [Unreleased]\n\n## [9.9.9] - 2026-06-10\n### Added\n- shipped\n"
+    )
+    _seed_repo(tmp_path, changelog=changelog_with_9990)
+    (tmp_path / "docs" / "install.md").write_text("totally unrelated content\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    _patch_git(monkeypatch)
+    monkeypatch.setattr(
+        "repo_release_tools.commands.release_repair.read_group_current_version",
+        lambda group: "9.9.9",
+    )
+    rc = release_repair.cmd_release_repair(_args(yes=True))
+    assert rc == 0
+    _ = capsys.readouterr()
+
+
+def test_verify_with_yes_refuses_changelog_missing_section_without_body(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Verify+yes mode mirrors recreate's safety: refuses to silently empty notes.
+
+    When `[VERSION]` is absent and the caller passed no `--changelog-from`,
+    proceeding would write the section with an empty body and silently
+    discard the intended release notes. Refuse instead.
+    """
+    polluted = "# Changelog\n\n## [Unreleased]\n\n## [1.8.3] - 2026-06-06\n"
+    _seed_repo(tmp_path, changelog=polluted)
+    monkeypatch.chdir(tmp_path)
+    _patch_git(monkeypatch)
+    rc = release_repair.cmd_release_repair(_args(yes=True))
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "no [1.9.0] section" in err.lower()
+    # Changelog must be untouched after refuse.
+    assert "## [1.9.0]" not in (tmp_path / "CHANGELOG.md").read_text(encoding="utf-8")
+
+
+def test_verify_with_yes_clears_unreleased_when_only_unreleased_dirty(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A non-empty `[Unreleased]` is wiped without duplicating the `[VERSION]` section."""
+    polluted = (
+        "# Changelog\n\n"
+        "## [Unreleased]\n"
+        "- forgotten cleanup\n\n"
+        "## [1.9.0] - 2026-06-10\n### Added\n- shipped\n"
+    )
+    _seed_repo(tmp_path, changelog=polluted)
+    monkeypatch.chdir(tmp_path)
+    _patch_git(monkeypatch)
+    rc = release_repair.cmd_release_repair(_args(yes=True))
+    assert rc == 0
+    rebuilt = (tmp_path / "CHANGELOG.md").read_text(encoding="utf-8")
+    # Forgotten bullet is wiped.
+    assert "forgotten cleanup" not in rebuilt
+    # The shipped section was not duplicated.
+    assert rebuilt.count("## [1.9.0]") == 1
+    # Shipped content is still there.
+    assert "- shipped" in rebuilt
+    _ = capsys.readouterr()
+
+
+def test_rewrite_matching_pins_skips_missing_files(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`_rewrite_matching_pins` silently skips pin files that don't exist."""
+    pin = PinTarget(path=tmp_path / "absent.md", pattern=r"(rrt@v)(\d+\.\d+\.\d+)()")
+    config = RrtConfig(
+        root=tmp_path,
+        config_file=tmp_path / ".rrt.toml",
+        version_groups=[
+            VersionGroup(
+                name="default",
+                release_branch="release/v{version}",
+                changelog_file=tmp_path / "CHANGELOG.md",
+                lock_command=[],
+                generated_files=[],
+                version_targets=[VersionTarget(path=tmp_path / "py.toml", kind="pep621")],
+            )
+        ],
+        default_group_name="default",
+    )
+    called: list[str] = []
+
+    def fake_replace_pin_in_file(*args: object, **kwargs: object) -> None:
+        called.append("called")
+
+    monkeypatch.setattr(
+        "repo_release_tools.commands.release_repair.replace_pin_in_file",
+        fake_replace_pin_in_file,
+    )
+    release_repair._rewrite_matching_pins([pin], "1.9.0", config)
+    assert called == []
 
 
 def test_files_to_stage_deduplicates_overlapping_paths(tmp_path: Path) -> None:

--- a/tests/core/test_changelog.py
+++ b/tests/core/test_changelog.py
@@ -886,3 +886,84 @@ def test_get_latest_released_version_returns_none_when_empty() -> None:
     from repo_release_tools.changelog import get_latest_released_version
 
     assert get_latest_released_version("# Changelog\n\n## [Unreleased]\n") is None
+
+
+# ---------------------------------------------------------------------------
+# clear_unreleased_section
+# ---------------------------------------------------------------------------
+
+
+def test_clear_unreleased_section_md_wipes_bullets() -> None:
+    """Bullets under `[Unreleased]` are removed; the `[VERSION]` section stays."""
+    from repo_release_tools.changelog import clear_unreleased_section
+
+    content = (
+        "# Changelog\n\n"
+        "## [Unreleased]\n"
+        "- forgotten cleanup\n"
+        "- another one\n\n"
+        "## [1.9.0] - 2026-06-10\n### Added\n- shipped\n"
+    )
+    cleared = clear_unreleased_section(content)
+    assert "forgotten cleanup" not in cleared
+    assert "another one" not in cleared
+    # [VERSION] survives untouched, including its body.
+    assert "## [1.9.0]" in cleared
+    assert "- shipped" in cleared
+    # The placeholder header is preserved.
+    assert "## [Unreleased]" in cleared
+
+
+def test_clear_unreleased_section_md_no_unreleased_is_noop() -> None:
+    """Missing `[Unreleased]` header → content returned unchanged."""
+    from repo_release_tools.changelog import clear_unreleased_section
+
+    content = "# Changelog\n\n## [1.9.0] - 2026-06-10\n- shipped\n"
+    assert clear_unreleased_section(content) == content
+
+
+def test_clear_unreleased_section_md_without_next_section() -> None:
+    """`[Unreleased]` with bullets and no following section gets trimmed cleanly."""
+    from repo_release_tools.changelog import clear_unreleased_section
+
+    content = "# Changelog\n\n## [Unreleased]\n- stuff\n- more stuff\n"
+    cleared = clear_unreleased_section(content)
+    assert "## [Unreleased]" in cleared
+    assert "stuff" not in cleared
+    # No spurious trailing artefacts.
+    assert cleared.endswith("\n")
+
+
+def test_clear_unreleased_section_rst() -> None:
+    """RST notation: dash-underlined header is preserved, body wiped."""
+    from repo_release_tools.changelog import ChangelogFormat, clear_unreleased_section
+
+    content = (
+        "Changelog\n=========\n\n"
+        "Unreleased\n----------\n"
+        "- forgotten\n\n"
+        "1.9.0 - 2026-06-10\n------------------\nAdded\n~~~~~\n- shipped\n"
+    )
+    cleared = clear_unreleased_section(content, ChangelogFormat.RST)
+    assert "forgotten" not in cleared
+    assert "1.9.0 - 2026-06-10" in cleared
+    assert "- shipped" in cleared
+    assert "Unreleased\n----------" in cleared
+
+
+def test_clear_unreleased_section_rst_missing_unreleased_is_noop() -> None:
+    """RST: missing Unreleased header → unchanged content."""
+    from repo_release_tools.changelog import ChangelogFormat, clear_unreleased_section
+
+    content = "Changelog\n=========\n\n1.0.0 - 2026-01-01\n------------------\n- shipped\n"
+    assert clear_unreleased_section(content, ChangelogFormat.RST) == content
+
+
+def test_clear_unreleased_section_rst_no_following_section() -> None:
+    """RST: `[Unreleased]` with no follow-up section drops the body cleanly."""
+    from repo_release_tools.changelog import ChangelogFormat, clear_unreleased_section
+
+    content = "Changelog\n=========\n\nUnreleased\n----------\n- stale\n"
+    cleared = clear_unreleased_section(content, ChangelogFormat.RST)
+    assert "stale" not in cleared
+    assert "Unreleased\n----------" in cleared


### PR DESCRIPTION
## Summary

- New `rrt release repair` subcommand under the existing `release` group, with two modes that share the same skeleton: **verify** (drift report + optional in-place fix) and **recreate** (rewind to a base ref and replay the bump cleanly).
- Built so that a release branch contaminated by feature commits (the situation that produced the recent `release/v1.9.0` PR) can be cleaned up in one shot — `rrt release repair --from main --hotfix` rewinds, restores the `[VERSION]` body, replays version + pin targets, and commits a single `chore(release): repair v{ver}`.
- Reuses existing helpers (`replace_all_versions_atomic`, `replace_pin_in_file`, `promote_unreleased`, `insert_generated_section`, `workflow/git.py`) so the new module stays focused.

## Safety guarantees

- Refuses on dirty working tree (matches `rrt bump`).
- Refuses recreate when the branch is ahead of `origin/<branch>` unless `--force-allow-pushed` is passed; prints the `git push --force-with-lease` reminder.
- Writes a `refs/heads/repair/backup/<branch>-<ts>` ref before `git reset --hard`; recoverable with `git reset --hard <ref>`. Opt out with `--no-backup`.
- Default is preview only; needs `--yes` (or `--hotfix`, which implies it) to mutate.
- `--changelog-from PATH` lets the caller supply the `[VERSION]` body from a saved file when the polluted HEAD has lost the section.

## Commit messages

- Recreate: `chore: bump version to v{ver}` (matches `rrt bump`).
- Hotfix or in-place verify+fix: `chore(release): repair v{ver}`.

## Test plan

- [x] 47 tests in `tests/commands/test_release_repair.py` covering: dirty-tree refuse, base-ref-missing refuse, ahead-of-remote refuse, `--force-allow-pushed` override, no-drift exit 0, version/pin/changelog drift detection, `--yes` apply-and-commit, recreate dry-run vs apply, backup ref, `--changelog-from`, hotfix message, multi-group `--group` requirement, error paths in config/group resolution, every helper (`_unique_pins`, `_files_to_stage`, `_targets_needing_rewrite`, `_stamp_version_section`, `_make_backup_ref`, `_commit_message`).
- [x] Full suite: **2568 passed**, 13 deselected, **100.00% coverage**.
- [x] `ruff check`, `ruff format --check`, `ty check src tests`, `poe docs-verify` — all green.
- [x] CLI smoke: `rrt release --help` lists `repair`; `rrt release repair --help` renders all flags and examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)