### PR TITLE
feat: add build-mcpb CI job with mcp2mcpb --from-dist, attach to release

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -240,7 +240,7 @@ jobs:
           name: python-package-distributions
           path: dist/
       - name: Build .mcpb bundle
-        uses: Anselmoo/mcp2mcpb@v0.5
+        uses: Anselmoo/mcp2mcpb@b040babc466902b721e2367d2e5611908c3603d8
         with:
           package: repo-release-tools
           registry: pypi

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -226,6 +226,34 @@ jobs:
           name: python-package-distributions
           path: dist/
 
+  build-mcpb:
+    name: 📦 Build .mcpb bundle
+    needs: [build]
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Download wheel
+        uses: actions/download-artifact@v8
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Build .mcpb bundle
+        uses: Anselmoo/mcp2mcpb@v0.5
+        with:
+          package: repo-release-tools
+          registry: pypi
+          mode: reference
+          from-dist: dist/
+          attach-to-release: 'false'
+      - name: Upload .mcpb artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: mcpb-package
+          path: dist/*.mcpb
+          if-no-files-found: error
+
   sbom:
     name: 📜 Generate SBOM
     needs: build
@@ -353,7 +381,7 @@ jobs:
 
   github-release:
     name: 🎁 Create GitHub release
-    needs: [publish-pypi, sbom, docker-publish]
+    needs: [publish-pypi, sbom, docker-publish, build-mcpb]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
@@ -370,6 +398,12 @@ jobs:
         with:
           name: sbom
           path: .
+
+      - name: Download .mcpb artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: mcpb-package
+          path: dist/
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Summary

- Adds a new `build-mcpb` CI job (between `build` and `sbom`) using `Anselmoo/mcp2mcpb@v0.5` with `from-dist: dist/`
- Downloads the locally-built wheel artifact, bundles it as `.mcpb`, and uploads the result
- Updates `github-release` job: adds `build-mcpb` to `needs` and downloads `mcpb-package` into `dist/` — picked up automatically by the existing `files: dist/*` in `softprops/action-gh-release@v2`
- Version is always correct: releasing v2.0.0 produces `repo-release-tools-2.0.0.mcpb`, read from the wheel METADATA

## Test plan

- [ ] CI passes the new `build-mcpb` job on this PR
- [ ] On a tag push: verify `github-release` includes `repo-release-tools-<version>.mcpb` in the release assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)