### PR TITLE
fix: security hardening quick wins + Action changelog-status fix (modernization phase 6a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Fixed
+- **action**: use env-var indirection for `verbose` and `changelog-file` Action inputs instead of interpolating them directly into shell script text (SEC-001)
+- **action**: correct the changelog-status grep so a populated `[Unreleased]` section is classified `dirty` instead of always falling through to `clean` (D8)
+
 ## [1.11.2] - 2026-07-10
 ### Added
 - Add exclude glob patterns to publish-snapshot targets and CLI flag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixed
 - **action**: use env-var indirection for `verbose` and `changelog-file` Action inputs instead of interpolating them directly into shell script text (SEC-001)
 - **action**: correct the changelog-status grep so a populated `[Unreleased]` section is classified `dirty` instead of always falling through to `clean` (D8)
+- **action**: build the `health-summary` output with `jq -nc` instead of string interpolation, preventing a `"` in the detected version from corrupting the JSON output (SEC-006)
 
 ## [1.11.2] - 2026-07-10
 ### Added

--- a/action.yml
+++ b/action.yml
@@ -144,7 +144,8 @@ runs:
           fi
         fi
 
-        health_summary="{\"version\":\"${detected_version}\",\"changelog_status\":\"${changelog_status}\"}"
+        health_summary=$(jq -nc --arg version "$detected_version" --arg changelog_status "$changelog_status" \
+          '{version: $version, changelog_status: $changelog_status}')
 
         echo "detected_version=${detected_version}" >> "$GITHUB_OUTPUT"
         echo "changelog_status=${changelog_status}" >> "$GITHUB_OUTPUT"

--- a/action.yml
+++ b/action.yml
@@ -104,8 +104,10 @@ runs:
 
     - name: Build verbosity flag
       shell: bash
+      env:
+        INPUT_VERBOSE: ${{ inputs.verbose }}
       run: |
-        case "${{ inputs.verbose }}" in
+        case "$INPUT_VERBOSE" in
           1) echo "_rrt_verbose_flag=-v" >> "$GITHUB_ENV" ;;
           2) echo "_rrt_verbose_flag=-vv" >> "$GITHUB_ENV" ;;
           3) echo "_rrt_verbose_flag=-vvv" >> "$GITHUB_ENV" ;;
@@ -116,6 +118,8 @@ runs:
       id: detect-version
       shell: bash
       working-directory: ${{ inputs.working-directory }}
+      env:
+        INPUT_CHANGELOG_FILE: ${{ inputs.changelog-file }}
       run: |
         set -euo pipefail
         detected_version=""
@@ -125,7 +129,7 @@ runs:
           detected_version="${detected_version//[$'\n\r']}"
         fi
 
-        changelog_file="${{ inputs.changelog-file }}"
+        changelog_file="$INPUT_CHANGELOG_FILE"
         if [[ -f "$changelog_file" ]]; then
           if grep -q '^\[Unreleased\]' "$changelog_file" 2>/dev/null; then
             # Count non-empty lines under [Unreleased]

--- a/action.yml
+++ b/action.yml
@@ -131,9 +131,9 @@ runs:
 
         changelog_file="$INPUT_CHANGELOG_FILE"
         if [[ -f "$changelog_file" ]]; then
-          if grep -q '^\[Unreleased\]' "$changelog_file" 2>/dev/null; then
+          if grep -q '^## \[Unreleased\]' "$changelog_file" 2>/dev/null; then
             # Count non-empty lines under [Unreleased]
-            entries=$(awk '/^\[Unreleased\]/{p=1;next} /^\[/{p=0} p && /^\s*-/{count++} END{print count+0}' "$changelog_file")
+            entries=$(awk '/^## \[Unreleased\]/{p=1;next} /^## \[/{p=0} p && /^\s*-/{count++} END{print count+0}' "$changelog_file")
             if [[ "$entries" -gt 0 ]]; then
               changelog_status="dirty"
             else

--- a/src/repo_release_tools/eol/core.py
+++ b/src/repo_release_tools/eol/core.py
@@ -72,6 +72,7 @@ from __future__ import annotations
 import json
 import re
 import urllib.error
+import urllib.parse
 import urllib.request
 from collections.abc import Iterable
 from dataclasses import dataclass
@@ -149,7 +150,7 @@ class EolRecord:
 def fetch_live_data(language: str) -> list[dict[str, object]]:
     """Fetch EOL data from endoflife.date API."""
     slug = _canonical_slug(language)
-    url = f"https://endoflife.date/api/v1/products/{slug}/"
+    url = f"https://endoflife.date/api/v1/products/{urllib.parse.quote(slug, safe='')}/"
     try:
         with urllib.request.urlopen(url, timeout=10) as response:  # noqa: S310
             raw = json.loads(response.read().decode("utf-8"))

--- a/src/repo_release_tools/mcp/apps.py
+++ b/src/repo_release_tools/mcp/apps.py
@@ -158,6 +158,12 @@ def _overall_badge(severities: list[str]) -> tuple[str, str]:
     return "All Healthy", "success"
 
 
+# Mirrors the --target choices in commands/init.py's argparse spec (SEC-007:
+# rrt_init_run validates LLM-supplied `target` against this set before it
+# reaches subprocess argv, the same pattern git_tools.py uses for commit_type).
+INIT_TARGETS: tuple[str, ...] = ("rrt-toml", "pyproject", "cargo", "node", "go")
+
+
 class RrtInitForm(BaseModel):
     """Form model for rrt init configuration."""
 
@@ -587,6 +593,10 @@ def register_apps(mcp: FastMCP) -> None:
         import subprocess
         import sys
         from pathlib import Path
+
+        if target not in INIT_TARGETS:
+            allowed = ", ".join(INIT_TARGETS)
+            return f"[error]: Invalid target {target!r}. Choose one of: {allowed}"
 
         root: Path = ctx.lifespan_context.get("root", Path.cwd())
         cmd = [sys.executable, "-m", "repo_release_tools.cli", "init", f"--target={target}"]

--- a/src/repo_release_tools/sync/providers.py
+++ b/src/repo_release_tools/sync/providers.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import urllib.error
+import urllib.parse
 import urllib.request
 
 from repo_release_tools.sync.pypi import fetch_pypi_versions
@@ -41,9 +42,23 @@ def _fetch_json(
 # ---------------------------------------------------------------------------
 
 
+def _quote_npm_package(package: str) -> str:
+    """Percent-encode an npm package identifier, handling ``@scope/name`` form.
+
+    The npm registry expects a scoped package's ``/`` separator to be
+    percent-encoded as ``%2F`` (``@scope%2Fname``) — an unencoded ``/`` would
+    otherwise be a second path segment. Quote with ``safe="@"`` so the scope
+    marker stays literal, then encode the separating slash. Any *other*
+    slash in the input (not the single scope separator) is left encoded by
+    ``quote`` too, so it cannot introduce extra path segments (CWE-20).
+    """
+    quoted = urllib.parse.quote(package, safe="@")
+    return quoted.replace("/", "%2F")
+
+
 def _fetch_npm_versions(package: str, *, timeout: int = 10) -> list[str]:
     """Return all versions of *package* from the npm registry."""
-    url = f"https://registry.npmjs.org/{package}"
+    url = f"https://registry.npmjs.org/{_quote_npm_package(package)}"
     data = _fetch_json(url, timeout=timeout)
     if not isinstance(data, dict):
         return []
@@ -55,7 +70,10 @@ def _fetch_npm_versions(package: str, *, timeout: int = 10) -> list[str]:
 
 def _fetch_nuget_versions(package: str, *, timeout: int = 10) -> list[str]:
     """Return all versions of *package* from NuGet (package id is lowercased)."""
-    url = f"https://api.nuget.org/v3-flatcontainer/{package.lower()}/index.json"
+    url = (
+        "https://api.nuget.org/v3-flatcontainer/"
+        f"{urllib.parse.quote(package.lower(), safe='')}/index.json"
+    )
     data = _fetch_json(url, timeout=timeout)
     if not isinstance(data, dict):
         return []
@@ -67,7 +85,7 @@ def _fetch_nuget_versions(package: str, *, timeout: int = 10) -> list[str]:
 
 def _fetch_crates_versions(package: str, *, timeout: int = 10) -> list[str]:
     """Return all versions of *package* from crates.io (requires User-Agent)."""
-    url = f"https://crates.io/api/v1/crates/{package}/versions"
+    url = f"https://crates.io/api/v1/crates/{urllib.parse.quote(package, safe='')}/versions"
     data = _fetch_json(url, timeout=timeout, headers={"User-Agent": USER_AGENT})
     if not isinstance(data, dict):
         return []
@@ -83,9 +101,21 @@ def _fetch_crates_versions(package: str, *, timeout: int = 10) -> list[str]:
     return result
 
 
+def _quote_vendor_name_package(package: str) -> str:
+    """Percent-encode a Packagist ``vendor/name`` identifier, segment by segment.
+
+    Packagist routes on a literal two-segment ``vendor/name`` path, so the
+    single separating ``/`` must stay literal — but each segment (and any
+    *extra* ``/`` beyond the first, e.g. a ``../`` traversal attempt) is
+    percent-encoded with ``safe=""`` so the value cannot smuggle additional
+    path segments (CWE-20).
+    """
+    return "/".join(urllib.parse.quote(part, safe="") for part in package.split("/"))
+
+
 def _fetch_packagist_versions(package: str, *, timeout: int = 10) -> list[str]:
     """Return all versions of *package* from Packagist (vendor/name format)."""
-    url = f"https://packagist.org/packages/{package}.json"
+    url = f"https://packagist.org/packages/{_quote_vendor_name_package(package)}.json"
     data = _fetch_json(url, timeout=timeout)
     if not isinstance(data, dict):
         return []

--- a/src/repo_release_tools/workflow/git.py
+++ b/src/repo_release_tools/workflow/git.py
@@ -150,7 +150,7 @@ def current_branch(cwd: Path) -> str:
 
 def branch_exists(cwd: Path, branch: str) -> bool:
     """Return whether a local branch exists."""
-    return bool(capture(["git", "branch", "--list", branch], cwd))
+    return bool(capture(["git", "branch", "--list", "--", branch], cwd))
 
 
 def working_tree_clean(cwd: Path) -> bool:
@@ -166,7 +166,16 @@ def working_tree_clean(cwd: Path) -> bool:
 
 
 def commits_ahead(cwd: Path, base_ref: str) -> list[str]:
-    """Return short log lines for commits on HEAD not in the base ref."""
+    """Return short log lines for commits on HEAD not in the base ref.
+
+    Raises ``ValueError`` if *base_ref* starts with ``-``: the range expression
+    ``<base_ref>..HEAD`` is a single positional argument to ``git log`` that
+    cannot be guarded with a ``--`` separator (git would then treat the range
+    as a pathspec instead of a revision range), so a leading dash is rejected
+    outright to prevent option-injection (CWE-88).
+    """
+    if base_ref.startswith("-"):
+        raise ValueError(f"base_ref must not start with '-': {base_ref!r}")
     out = capture(["git", "log", f"{base_ref}..HEAD", "--pretty=format:%h %s"], cwd)
     return [line for line in out.splitlines() if line]
 
@@ -221,7 +230,16 @@ def upstream_branch(cwd: Path) -> str | None:
 
 
 def ref_exists(cwd: Path, ref: str) -> bool:
-    """Return whether *ref* resolves to an object in this repository."""
+    """Return whether *ref* resolves to an object in this repository.
+
+    Returns ``False`` (rather than invoking git) if *ref* starts with ``-``:
+    ``git rev-parse --verify`` parses its positional argument as an option
+    when it looks like one even after a ``--`` separator, so a leading dash
+    is rejected outright to prevent option-injection (CWE-88) instead of
+    being passed through to the subprocess.
+    """
+    if ref.startswith("-"):
+        return False
     result = subprocess.run(
         ["git", "rev-parse", "--verify", "--quiet", ref],
         cwd=cwd,

--- a/src/repo_release_tools/workflow/hooks.py
+++ b/src/repo_release_tools/workflow/hooks.py
@@ -231,6 +231,21 @@ def _normalize_repo_path(path: str, *, cwd: Path) -> str:
     return candidate.as_posix()
 
 
+def _contained_changelog_path(changelog_file: str, *, cwd: Path) -> Path | None:
+    """Resolve *changelog_file* against *cwd* and reject paths that escape it.
+
+    SEC-003: ``changelog_file`` is config-controlled; without a containment
+    check a value such as ``"../../evil.md"`` would resolve outside the work
+    tree (CWE-22). Returns the resolved path when it is contained within
+    *cwd*, or ``None`` when it escapes.
+    """
+    resolved_cwd = cwd.resolve()
+    resolved_path = (cwd / changelog_file).resolve()
+    if resolved_path.is_relative_to(resolved_cwd):
+        return resolved_path
+    return None
+
+
 def staged_files(cwd: Path) -> list[str]:
     """Return staged files for the current index."""
     out = git.capture(["git", "diff", "--cached", "--name-only", "--diff-filter=ACMR"], cwd)
@@ -753,7 +768,12 @@ def run_update_unreleased(
         p.verbose_line("  skipped (changelog meta-commit)")
         return 0
 
-    changelog_path = cwd / changelog_file
+    changelog_path = _contained_changelog_path(changelog_file, cwd=cwd)
+    if changelog_path is None:
+        return emit_failure(
+            "Changelog update failed.",
+            [f"Changelog file {changelog_file!r} resolves outside the repository root {cwd}."],
+        )
     if not changelog_path.exists():
         return emit_failure(
             "Changelog update failed.",
@@ -885,7 +905,12 @@ def run_post_correct(
     followed by ``"remove X"``), rewrites the file in-place, and optionally
     creates a follow-up commit.
     """
-    changelog_path = cwd / changelog_file
+    changelog_path = _contained_changelog_path(changelog_file, cwd=cwd)
+    if changelog_path is None:
+        return emit_failure(
+            "Changelog post-correction failed.",
+            [f"Changelog file {changelog_file!r} resolves outside the repository root {cwd}."],
+        )
     if not changelog_path.exists():
         return emit_failure(
             "Changelog post-correction failed.",

--- a/src/repo_release_tools/workflow/hooks.py
+++ b/src/repo_release_tools/workflow/hooks.py
@@ -766,7 +766,7 @@ def run_update_unreleased(
     updated = append_to_unreleased(original, subject, fmt)
     if updated != original:
         changelog_path.write_text(updated, encoding="utf-8")
-        git.run(["git", "add", changelog_file], cwd, dry_run=False, label="stage changelog")
+        git.run(["git", "add", "--", changelog_file], cwd, dry_run=False, label="stage changelog")
         p = VerbosePrinter(verbose=verbose)
         p.line(f"[Unreleased] section updated in {changelog_file}.", ok=True, stream=sys.stderr)
     else:
@@ -934,7 +934,7 @@ def run_post_correct(
     if commit:
         try:
             git.run(
-                ["git", "add", changelog_file],
+                ["git", "add", "--", changelog_file],
                 cwd,
                 dry_run=False,
                 label="git add changelog",

--- a/tests/e2e/test_policy_hooks_action.py
+++ b/tests/e2e/test_policy_hooks_action.py
@@ -10,10 +10,11 @@ Pins contract items from ``analysis/the/MODERNIZATION_BRIEF.md`` §5:
 * **C9** — commit-type -> changelog-section mapping (``rrt-hooks update-unreleased`` /
   ``check-changelog``): feat->Added, fix->Fixed, chore->Maintenance (no changelog
   required), ``fix!:``->Breaking Changes, scope rendered bold.
-* **D8** — the GitHub Action's changelog-status grep (``action.yml:130``) is anchored
-  ``^\\[Unreleased\\]`` and therefore never matches a standard ``## [Unreleased]``
-  heading. This is a live (likely unintended) defect, scheduled for a fix in Phase 6a
-  per the brief. Tests here characterize today's behavior only.
+* **D8** — the GitHub Action's changelog-status grep (``action.yml:134``) was anchored
+  ``^\\[Unreleased\\]`` and therefore never matched a standard ``## [Unreleased]``
+  heading. Fixed in Phase 6a to match ``^## \\[Unreleased\\]`` (mirroring
+  ``changelog.py``'s ``_UNRELEASED_HEADER_RE``); tests here now pin the corrected
+  three-way classification.
 
 All tests read the legacy code as an oracle: assertions reflect what
 ``src/repo_release_tools`` actually does today, not what the contract text implies it
@@ -423,52 +424,49 @@ All notable changes to this project will be documented in this file.
 # ---------------------------------------------------------------------------
 
 
-def test_d8_action_grep_pattern_never_matches_keep_a_changelog_heading(e2e_repo: Path) -> None:
-    """D8: the Action's changelog-status grep is anchored ``^\\[Unreleased\\]``.
+def test_d8_action_grep_pattern_matches_keep_a_changelog_heading(e2e_repo: Path) -> None:
+    """D8 (fixed): the Action's changelog-status grep is anchored ``^## \\[Unreleased\\]``.
 
-    # D8: Action grep never matches '## [Unreleased]' — scheduled fix in Phase 6a;
-    # this test documents the current (broken) classification and must be
-    # UPDATED when fixed.
+    # D8: Action grep now matches '## [Unreleased]' — fixed in Phase 6a.
+    # This test documents the corrected classification.
 
-    action.yml:130 runs ``grep -q '^\\[Unreleased\\]' "$changelog_file"`` against a
-    standard Keep-a-Changelog file whose heading is ``## [Unreleased]`` (with a
-    literal ``## `` prefix). The ``^`` anchor plus the missing ``## `` prefix in the
-    pattern means this grep can never match a real Keep-a-Changelog file - it always
-    falls through to the ``else`` branch. This test replicates the exact grep
-    invocation (not a re-implementation) against the harness's standard fixture
-    changelog to pin that observed (mis)behavior.
+    action.yml runs ``grep -q '^## \\[Unreleased\\]' "$changelog_file"`` against a
+    standard Keep-a-Changelog file whose heading is ``## [Unreleased]``. The pattern
+    now includes the literal ``## `` prefix, mirroring ``changelog.py``'s
+    ``_UNRELEASED_HEADER_RE``, so it matches a real Keep-a-Changelog file. This test
+    replicates the exact grep invocation (not a re-implementation) against the
+    harness's standard fixture changelog to pin the corrected behavior.
     """
     changelog_path = e2e_repo / "CHANGELOG.md"
     content = changelog_path.read_text(encoding="utf-8")
     assert "## [Unreleased]" in content, content  # sanity: fixture uses the standard heading
 
     grep_result = subprocess.run(
-        ["grep", "-q", r"^\[Unreleased\]", str(changelog_path)],
+        ["grep", "-q", r"^## \[Unreleased\]", str(changelog_path)],
         cwd=e2e_repo,
         capture_output=True,
         text=True,
         check=False,
     )
-    # `grep -q` exits 1 when no line matches. Pinning the broken-as-designed anchor:
-    assert grep_result.returncode == 1, f"stdout={grep_result.stdout}\nstderr={grep_result.stderr}"
+    # `grep -q` exits 0 when a line matches. Pinning the fixed anchor:
+    assert grep_result.returncode == 0, f"stdout={grep_result.stdout}\nstderr={grep_result.stderr}"
 
 
-def test_d8_action_three_way_classification_reports_clean_for_standard_heading(
+def test_d8_action_three_way_classification_reports_dirty_for_standard_heading(
     e2e_repo: Path,
 ) -> None:
-    """D8: replicating action.yml's surrounding shell logic, a populated [Unreleased]
+    """D8 (fixed): replicating action.yml's surrounding shell logic, a populated
 
-    section is misclassified as ``clean`` (not ``dirty``) because the anchored grep
-    never enters the branch that would count bullets and report ``dirty``.
+    [Unreleased] section is correctly classified as ``dirty`` because the fixed
+    grep pattern now enters the branch that counts bullets.
 
-    # D8: Action grep never matches '## [Unreleased]' — scheduled fix in Phase 6a;
-    # this test documents the current (broken) classification and must be
-    # UPDATED when fixed.
+    # D8: Action grep now matches '## [Unreleased]' — fixed in Phase 6a.
+    # This test documents the corrected classification.
 
-    This replicates action.yml:128-141 verbatim (same grep pattern, same awk
-    counter, same branch structure) against the harness's fixture, which has a
-    non-empty [Unreleased] section (a seed "Added" bullet) — a real user would
-    expect ``dirty`` here, but the Action's own shell logic reports ``clean``.
+    This replicates action.yml's changelog-status logic verbatim (same grep
+    pattern, same awk counter, same branch structure) against the harness's
+    fixture, which has a non-empty [Unreleased] section (a seed "Added" bullet) —
+    the Action's shell logic now reports ``dirty`` here, matching user intuition.
     """
     changelog_file = e2e_repo / "CHANGELOG.md"
     content = changelog_file.read_text(encoding="utf-8")
@@ -479,8 +477,8 @@ set -euo pipefail
 changelog_file="$1"
 changelog_status="missing"
 if [[ -f "$changelog_file" ]]; then
-  if grep -q '^\[Unreleased\]' "$changelog_file" 2>/dev/null; then
-    entries=$(awk '/^\[Unreleased\]/{p=1;next} /^\[/{p=0} p && /^\s*-/{count++} END{print count+0}' "$changelog_file")
+  if grep -q '^## \[Unreleased\]' "$changelog_file" 2>/dev/null; then
+    entries=$(awk '/^## \[Unreleased\]/{p=1;next} /^## \[/{p=0} p && /^\s*-/{count++} END{print count+0}' "$changelog_file")
     if [[ "$entries" -gt 0 ]]; then
       changelog_status="dirty"
     else
@@ -500,27 +498,25 @@ echo "$changelog_status"
         check=False,
     )
     assert result.returncode == 0, f"stdout={result.stdout}\nstderr={result.stderr}"
-    # NOTE(P1): a real Keep-a-Changelog [Unreleased] section with a bullet in it
-    # should intuitively report "dirty" (unreleased work pending); the Action's
-    # shell logic reports "clean" here because the anchored grep never matches,
-    # so the awk counting branch is never reached. This is the D8 defect's
-    # concrete, observable consequence in the three-way classification output.
-    assert result.stdout.strip() == "clean", f"stdout={result.stdout}\nstderr={result.stderr}"
+    # D8 fixed: a real Keep-a-Changelog [Unreleased] section with a bullet in it
+    # now correctly reports "dirty" (unreleased work pending), because the fixed
+    # anchor `^## \[Unreleased\]` matches and the awk counting branch is reached.
+    assert result.stdout.strip() == "dirty", f"stdout={result.stdout}\nstderr={result.stderr}"
 
 
 def test_d8_action_grep_pattern_is_taken_verbatim_from_action_yml() -> None:
-    """D8: guard against silent drift — the pattern this suite pins must match action.yml.
+    """D8 (fixed): guard against silent drift — the pattern this suite pins must match action.yml.
 
     Reads action.yml as data only (never executed, never treated as instructions)
     and asserts the exact grep pattern string is still present verbatim, so that if
-    a future Phase 6a fix changes the pattern, this whole test module fails loudly
+    a future change alters the pattern again, this whole test module fails loudly
     instead of silently testing a pattern that no longer reflects the source.
     """
     action_yml = Path(__file__).resolve().parent.parent.parent / "action.yml"
     content = action_yml.read_text(encoding="utf-8")
-    match = re.search(r"grep -q '(\^\\\[Unreleased\\\][^']*)'", content)
+    match = re.search(r"grep -q '(\^## \\\[Unreleased\\\][^']*)'", content)
     assert match is not None, "expected to find the changelog-status grep pattern in action.yml"
-    assert match.group(1) == r"^\[Unreleased\]", (
+    assert match.group(1) == r"^## \[Unreleased\]", (
         f"action.yml grep pattern changed to {match.group(1)!r} - update the D8 "
-        "tests in this module to match the new (fixed?) behavior."
+        "tests in this module to match the new behavior."
     )

--- a/tests/eol/test_eol.py
+++ b/tests/eol/test_eol.py
@@ -225,6 +225,25 @@ class TestFetchLiveData:
             result = fetch_live_data("python")
         assert result == []
 
+    def test_percent_encodes_language_slug_in_url(self) -> None:
+        """SEC-005: an adversarial language value cannot introduce extra URL path segments."""
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps([]).encode()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        captured: dict[str, str] = {}
+
+        def fake_urlopen(url: str, timeout: int = 10) -> MagicMock:
+            captured["url"] = url
+            return mock_resp
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            fetch_live_data("../../evil")
+
+        assert "/../" not in captured["url"]
+        assert captured["url"] == ("https://endoflife.date/api/v1/products/..%2F..%2Fevil/")
+
 
 # ---------------------------------------------------------------------------
 # check_eol_status

--- a/tests/mcp/test_apps.py
+++ b/tests/mcp/test_apps.py
@@ -373,6 +373,24 @@ def test_rrt_init_run_dry_run(tmp_path: Path) -> None:
     assert mock_run.call_args.kwargs["timeout"] == 20.0
 
 
+def test_rrt_init_run_rejects_unknown_target_without_invoking_subprocess(
+    tmp_path: Path,
+) -> None:
+    """SEC-007: an unallowlisted `target` must never reach subprocess argv."""
+    tools = _registered(tmp_path)
+    ctx = _ctx(tmp_path)
+    mock_run = MagicMock()
+
+    async def _run() -> str:
+        with patch("subprocess.run", mock_run):
+            return await tools["rrt_init_run"](ctx, target="rrt-toml; rm -rf /")
+
+    result = asyncio.run(_run())
+    assert "[error]" in result
+    assert "Invalid target" in result
+    mock_run.assert_not_called()
+
+
 def test_rrt_init_run_apply(tmp_path: Path) -> None:
     tools = _registered(tmp_path)
     ctx = _ctx(tmp_path)

--- a/tests/sync/test_providers.py
+++ b/tests/sync/test_providers.py
@@ -108,6 +108,36 @@ def test_fetch_versions_npm_non_dict_response(monkeypatch: pytest.MonkeyPatch) -
     assert providers.fetch_versions("lodash", "npm") == []
 
 
+def test_fetch_versions_npm_scoped_package_encodes_slash(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SEC-005: a scoped package's '/' separator is percent-encoded as %2F."""
+    payload = {"versions": {"1.0.0": {}}}
+    monkeypatch.setattr(
+        providers.urllib.request,
+        "urlopen",
+        _make_urlopen(payload, assert_url="registry.npmjs.org/@types%2Fnode"),
+    )
+    out = providers.fetch_versions("@types/node", "npm")
+    assert set(out) == {"1.0.0"}
+
+
+def test_fetch_versions_npm_rejects_extra_path_segments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SEC-005: an adversarial package name cannot introduce extra URL path segments."""
+    captured: dict[str, str] = {}
+
+    def fake_urlopen(req: urllib.request.Request, timeout: int = 10) -> _Resp:
+        captured["url"] = req.full_url
+        return _Resp(json.dumps({"versions": {}}).encode())
+
+    monkeypatch.setattr(providers.urllib.request, "urlopen", fake_urlopen)
+    providers.fetch_versions("../../evil", "npm")
+    assert "/../" not in captured["url"]
+    assert captured["url"] == "https://registry.npmjs.org/..%2F..%2Fevil"
+
+
 # ---------------------------------------------------------------------------
 # nuget
 # ---------------------------------------------------------------------------
@@ -166,6 +196,22 @@ def test_fetch_versions_nuget_missing_versions_key(monkeypatch: pytest.MonkeyPat
     assert providers.fetch_versions("Newtonsoft.Json", "nuget") == []
 
 
+def test_fetch_versions_nuget_rejects_extra_path_segments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SEC-005: an adversarial package name cannot introduce extra URL path segments."""
+    captured: dict[str, str] = {}
+
+    def fake_urlopen(req: urllib.request.Request, timeout: int = 10) -> _Resp:
+        captured["url"] = req.full_url
+        return _Resp(json.dumps({"versions": []}).encode())
+
+    monkeypatch.setattr(providers.urllib.request, "urlopen", fake_urlopen)
+    providers.fetch_versions("../../evil", "nuget")
+    assert "/../" not in captured["url"]
+    assert captured["url"] == ("https://api.nuget.org/v3-flatcontainer/..%2F..%2Fevil/index.json")
+
+
 # ---------------------------------------------------------------------------
 # crates
 # ---------------------------------------------------------------------------
@@ -219,6 +265,22 @@ def test_fetch_versions_crates_missing_versions_key(monkeypatch: pytest.MonkeyPa
         _make_urlopen({"crate": {}}),
     )
     assert providers.fetch_versions("serde", "crates") == []
+
+
+def test_fetch_versions_crates_rejects_extra_path_segments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SEC-005: an adversarial package name cannot introduce extra URL path segments."""
+    captured: dict[str, str] = {}
+
+    def fake_urlopen(req: urllib.request.Request, timeout: int = 10) -> _Resp:
+        captured["url"] = req.full_url
+        return _Resp(json.dumps({"versions": []}).encode())
+
+    monkeypatch.setattr(providers.urllib.request, "urlopen", fake_urlopen)
+    providers.fetch_versions("../../evil", "crates")
+    assert "/../" not in captured["url"]
+    assert captured["url"] == ("https://crates.io/api/v1/crates/..%2F..%2Fevil/versions")
 
 
 # ---------------------------------------------------------------------------
@@ -279,6 +341,21 @@ def test_fetch_versions_packagist_missing_versions_key(monkeypatch: pytest.Monke
         _make_urlopen({"package": {"name": "symfony/console"}}),
     )
     assert providers.fetch_versions("symfony/console", "packagist") == []
+
+
+def test_fetch_versions_packagist_percent_encodes_each_segment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SEC-005: each vendor/name segment is percent-encoded; the separator stays literal."""
+    captured: dict[str, str] = {}
+
+    def fake_urlopen(req: urllib.request.Request, timeout: int = 10) -> _Resp:
+        captured["url"] = req.full_url
+        return _Resp(json.dumps({"package": {"versions": {}}}).encode())
+
+    monkeypatch.setattr(providers.urllib.request, "urlopen", fake_urlopen)
+    providers.fetch_versions("vendor name/pkg?name", "packagist")
+    assert captured["url"] == "https://packagist.org/packages/vendor%20name/pkg%3Fname.json"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/workflow/test_git_helpers.py
+++ b/tests/workflow/test_git_helpers.py
@@ -161,7 +161,7 @@ def test_current_branch_branch_exists_and_commits_ahead_delegate(
     def fake_capture(cmd: list[str], cwd: Path) -> str:
         if cmd == ["git", "branch", "--show-current"]:
             return "feature/current"
-        if cmd == ["git", "branch", "--list", "release/v1.2.3"]:
+        if cmd == ["git", "branch", "--list", "--", "release/v1.2.3"]:
             return "  release/v1.2.3"
         if cmd == ["git", "log", "origin/main..HEAD", "--pretty=format:%h %s"]:
             return "abc123 feat: add parser\n\nxyz789 fix: typo\n"
@@ -175,6 +175,33 @@ def test_current_branch_branch_exists_and_commits_ahead_delegate(
         "abc123 feat: add parser",
         "xyz789 fix: typo",
     ]
+
+
+def test_branch_exists_uses_dashdash_separator(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """SEC-004: a dash-prefixed branch name must not be parsed as a git option."""
+    captured: list[list[str]] = []
+
+    def fake_capture(cmd: list[str], cwd: Path) -> str:
+        captured.append(cmd)
+        return ""
+
+    monkeypatch.setattr(git, "capture", fake_capture)
+
+    assert git.branch_exists(tmp_path, "--force") is False
+    assert captured == [["git", "branch", "--list", "--", "--force"]]
+
+
+def test_commits_ahead_rejects_dash_prefixed_base_ref(tmp_path: Path) -> None:
+    """SEC-004: ``<base_ref>..HEAD`` is a single positional revision-range argument
+
+    that ``--`` cannot safely guard (it would be reinterpreted as a pathspec), so a
+    leading dash is rejected outright instead of reaching the subprocess.
+    """
+    with pytest.raises(ValueError, match=r"base_ref must not start with '-'"):
+        git.commits_ahead(tmp_path, "--output=/tmp/evil")
 
 
 def test_working_tree_clean_and_ahead_behind_handle_multiple_outcomes(
@@ -332,6 +359,23 @@ def test_ref_exists_checks_rev_parse(monkeypatch: pytest.MonkeyPatch, tmp_path: 
     monkeypatch.setattr(subprocess, "run", fake_run)
 
     assert git.ref_exists(tmp_path, "HEAD~1") is True
+
+
+def test_ref_exists_rejects_dash_prefixed_ref_without_invoking_git(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """SEC-004: a dash-prefixed ref must not reach ``git rev-parse --verify``.
+
+    Unlike a plain positional path, ``--`` does not reliably stop option parsing
+    for ``rev-parse``, so a leading dash is rejected before the subprocess call.
+    """
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("git must not run")),
+    )
+
+    assert git.ref_exists(tmp_path, "--output=/tmp/evil") is False
 
 
 def test_in_progress_operation_detects_rebase_and_merge(

--- a/tests/workflow/test_hooks.py
+++ b/tests/workflow/test_hooks.py
@@ -326,7 +326,46 @@ def test_run_update_unreleased_and_changelog_checks(
         == 0
     )
     assert "add parser" in changelog.read_text(encoding="utf-8")
-    assert git_runs == [["git", "add", "CHANGELOG.md"]]
+    assert git_runs == [["git", "add", "--", "CHANGELOG.md"]]
+
+
+def test_run_update_unreleased_uses_dashdash_separator_for_dash_prefixed_filename(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """SEC-004: a config-controlled changelog filename starting with '-' must not be
+
+    interpreted as a git option; the ``--`` separator forces positional treatment.
+    """
+    changelog_name = "-uploads.md"
+    changelog = tmp_path / changelog_name
+    changelog.write_text("# Changelog\n\n## [Unreleased]\n\n", encoding="utf-8")
+
+    monkeypatch.setattr(hooks, "_detect_changelog_workflow", lambda cwd: "incremental")
+    monkeypatch.setattr(hooks, "commit_subject_requires_changelog", lambda subject: True)
+    monkeypatch.setattr(hooks, "is_changelog_meta_commit", lambda subject: False)
+    monkeypatch.setattr(hooks, "detect_changelog_format", lambda changelog_file: "markdown")
+    monkeypatch.setattr(
+        hooks,
+        "append_to_unreleased",
+        lambda content, subject, fmt: content + "### Added\n- add parser\n",
+    )
+    git_runs: list[list[str]] = []
+    monkeypatch.setattr(
+        hooks.git,
+        "run",
+        lambda cmd, cwd, *, dry_run, label: git_runs.append(cmd),
+    )
+
+    assert (
+        hooks.run_update_unreleased(
+            tmp_path,
+            subject="feat: add parser",
+            changelog_file=changelog_name,
+        )
+        == 0
+    )
+    assert git_runs == [["git", "add", "--", changelog_name]]
 
 
 def test_run_changelog_check_covers_non_changelog_and_unreleased_failure(
@@ -1053,7 +1092,43 @@ def test_run_post_correct_commits_when_requested(
         == 0
     )
     assert git_runs == [
-        ["git", "add", "CHANGELOG.md"],
+        ["git", "add", "--", "CHANGELOG.md"],
+        ["git", "commit", "-m", "chore: post-correct changelog after squash merge [skip ci]"],
+    ]
+
+
+def test_run_post_correct_uses_dashdash_separator_for_dash_prefixed_filename(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """SEC-004: a config-controlled changelog filename starting with '-' must not be
+
+    interpreted as a git option when staged after squash post-correction.
+    """
+    changelog_name = "-uploads.md"
+    changelog = tmp_path / changelog_name
+    changelog.write_text("# Changelog\n\n- add x\n- add x\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        hooks,
+        "collect_squash_changelog_hunks",
+        lambda cwd, ref="HEAD", changelog_file=hooks.DEFAULT_CHANGELOG: (
+            ["- add x", "- add x"],
+            frozenset({3, 4}),
+        ),
+    )
+    git_runs: list[list[str]] = []
+    monkeypatch.setattr(
+        hooks.git,
+        "run",
+        lambda cmd, cwd, *, dry_run, label: git_runs.append(cmd),
+    )
+
+    assert (
+        hooks.run_post_correct(tmp_path, ref="HEAD", changelog_file=changelog_name, commit=True)
+        == 0
+    )
+    assert git_runs == [
+        ["git", "add", "--", changelog_name],
         ["git", "commit", "-m", "chore: post-correct changelog after squash merge [skip ci]"],
     ]
 

--- a/tests/workflow/test_hooks.py
+++ b/tests/workflow/test_hooks.py
@@ -106,6 +106,23 @@ def test_path_and_git_helpers_cover_remaining_branches(
     assert hooks.changed_files_for_ref(tmp_path, "HEAD") == ["one", "two"]
 
 
+def test_contained_changelog_path_rejects_escapes(tmp_path: Path) -> None:
+    """SEC-003: ``_contained_changelog_path`` rejects paths that escape cwd."""
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+
+    assert (
+        hooks._contained_changelog_path("CHANGELOG.md", cwd=repo_root)
+        == (repo_root / "CHANGELOG.md").resolve()
+    )
+    assert (
+        hooks._contained_changelog_path("nested/CHANGELOG.md", cwd=repo_root)
+        == (repo_root / "nested" / "CHANGELOG.md").resolve()
+    )
+    assert hooks._contained_changelog_path("../../evil.md", cwd=repo_root) is None
+    assert hooks._contained_changelog_path("../evil.md", cwd=repo_root) is None
+
+
 def test_changelog_requirement_helpers() -> None:
     assert hooks.commit_type_requires_changelog("feat") is True
     assert hooks.commit_type_requires_changelog("chore") is False
@@ -1044,6 +1061,29 @@ def test_run_update_unreleased_handles_missing_file(
     )
 
 
+def test_run_update_unreleased_rejects_path_outside_repo_root(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """SEC-003: a changelog_file that resolves outside cwd must be rejected."""
+    monkeypatch.setattr(hooks, "_detect_changelog_workflow", lambda cwd: "incremental")
+    monkeypatch.setattr(hooks, "commit_subject_requires_changelog", lambda subject: True)
+    monkeypatch.setattr(hooks, "is_changelog_meta_commit", lambda subject: False)
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    outside_target = tmp_path / "evil.md"
+    outside_target.write_text("# outside\n", encoding="utf-8")
+
+    result = hooks.run_update_unreleased(
+        repo_root,
+        subject="feat: add parser",
+        changelog_file="../evil.md",
+    )
+
+    assert result == 1
+    assert outside_target.read_text(encoding="utf-8") == "# outside\n"
+
+
 def test_run_update_unreleased_no_change_path(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -1210,6 +1250,21 @@ def test_run_post_correct_missing_file_and_commit_failure(
         hooks.run_post_correct(tmp_path, ref="HEAD", changelog_file="CHANGELOG.md", commit=True)
         == 1
     )
+
+
+def test_run_post_correct_rejects_path_outside_repo_root(tmp_path: Path) -> None:
+    """SEC-003: a changelog_file that resolves outside cwd must be rejected."""
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    outside_target = tmp_path / "evil.md"
+    outside_target.write_text("# outside\n", encoding="utf-8")
+
+    result = hooks.run_post_correct(
+        repo_root, ref="HEAD", changelog_file="../evil.md", commit=False
+    )
+
+    assert result == 1
+    assert outside_target.read_text(encoding="utf-8") == "# outside\n"
 
 
 def test_main_update_unreleased_uses_message_file_and_commit_editmsg(


### PR DESCRIPTION
## Summary

Phase 6a of the approved modernization plan (stacked on #147). Closes all seven security findings from `analysis/the/ASSESSMENT.md` plus the approved D8 behavior fix:

- **SEC-001** — `action.yml` no longer interpolates `${{ inputs.* }}` into `run:` script text; `verbose`/`changelog-file` pass via `env:` + `$INPUT_*` (GitHub Actions expression-injection hardening)
- **D8 (behavior change, changelog-noted)** — the changelog-status grep was anchored `^\[Unreleased\]` and could never match the real `## [Unreleased]` heading, so a populated section was always misreported as `clean`. Now anchored `^## \[Unreleased\]`; the three sentinel e2e tests from #147 were flipped exactly as designed
- **SEC-006** — `health_summary` JSON built with `jq -nc --arg` instead of string interpolation
- **SEC-004** — `--` separators / leading-dash guards for git argv positionals (CWE-88)
- **SEC-003** — changelog paths that resolve outside the repository root are rejected (CWE-22)
- **SEC-005** — package/slug values percent-encoded before API-URL interpolation (npm scoped packages handled as `@scope%2Fname`)
- **SEC-007** — MCP `rrt_init_run` validates `target` against an allowlist before building subprocess argv

## Test plan

- [x] `uv run pytest -q -m "not runtime and not e2e"` — 2,920 passed, coverage 100.00%
- [x] `uv run pytest -m e2e --no-cov` — 71 passed (only the 3 `test_d8_*` sentinels updated)
- [x] `uvx pre-commit run --all-files` — clean
- [x] `tox -p auto` — 3.12 / 3.13 / 3.14 all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjTsHn8U7Lmp9Uax8tNBHG