### PR TITLE
fix: land Phase 6a security hardening + Phase 2 cross-cutting seams onto main

### DIFF
--- a/.rrt/tree.lock.toml
+++ b/.rrt/tree.lock.toml
@@ -1,10 +1,10 @@
 [meta]
-generated_at = "2026-07-10T15:08:21+00:00"
+generated_at = "2026-07-10T15:51:53+00:00"
 rrt_version = "1.11.2"
 
 [snapshot]
-entry_count = 403
-tree_hash = "sha256:e6cdff7c0592d237e9a9fe850f53a0ac0e463912db44ce31d4425f4313115797"
-updated_at = "2026-07-10T15:08:21+00:00"
-ignored_count = 205
+entry_count = 404
+tree_hash = "sha256:b2e36809441ccedd898f31684d3e4b1777d0b71616eaa3f69be8b9c820b18f1f"
+updated_at = "2026-07-10T15:51:53+00:00"
+ignored_count = 32
 phantom_empty_dirs = []

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Fixed
+- **action**: use env-var indirection for `verbose` and `changelog-file` Action inputs instead of interpolating them directly into shell script text (SEC-001)
+- **action**: correct the changelog-status grep so a populated `[Unreleased]` section is classified `dirty` instead of always falling through to `clean` (D8)
+
 ## [1.11.2] - 2026-07-10
 ### Added
 - Add exclude glob patterns to publish-snapshot targets and CLI flag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixed
 - **action**: use env-var indirection for `verbose` and `changelog-file` Action inputs instead of interpolating them directly into shell script text (SEC-001)
 - **action**: correct the changelog-status grep so a populated `[Unreleased]` section is classified `dirty` instead of always falling through to `clean` (D8)
+- **action**: build the `health-summary` output with `jq -nc` instead of string interpolation, preventing a `"` in the detected version from corrupting the JSON output (SEC-006)
 
 ## [1.11.2] - 2026-07-10
 ### Added

--- a/action.yml
+++ b/action.yml
@@ -144,7 +144,8 @@ runs:
           fi
         fi
 
-        health_summary="{\"version\":\"${detected_version}\",\"changelog_status\":\"${changelog_status}\"}"
+        health_summary=$(jq -nc --arg version "$detected_version" --arg changelog_status "$changelog_status" \
+          '{version: $version, changelog_status: $changelog_status}')
 
         echo "detected_version=${detected_version}" >> "$GITHUB_OUTPUT"
         echo "changelog_status=${changelog_status}" >> "$GITHUB_OUTPUT"

--- a/action.yml
+++ b/action.yml
@@ -104,8 +104,10 @@ runs:
 
     - name: Build verbosity flag
       shell: bash
+      env:
+        INPUT_VERBOSE: ${{ inputs.verbose }}
       run: |
-        case "${{ inputs.verbose }}" in
+        case "$INPUT_VERBOSE" in
           1) echo "_rrt_verbose_flag=-v" >> "$GITHUB_ENV" ;;
           2) echo "_rrt_verbose_flag=-vv" >> "$GITHUB_ENV" ;;
           3) echo "_rrt_verbose_flag=-vvv" >> "$GITHUB_ENV" ;;
@@ -116,6 +118,8 @@ runs:
       id: detect-version
       shell: bash
       working-directory: ${{ inputs.working-directory }}
+      env:
+        INPUT_CHANGELOG_FILE: ${{ inputs.changelog-file }}
       run: |
         set -euo pipefail
         detected_version=""
@@ -125,7 +129,7 @@ runs:
           detected_version="${detected_version//[$'\n\r']}"
         fi
 
-        changelog_file="${{ inputs.changelog-file }}"
+        changelog_file="$INPUT_CHANGELOG_FILE"
         if [[ -f "$changelog_file" ]]; then
           if grep -q '^\[Unreleased\]' "$changelog_file" 2>/dev/null; then
             # Count non-empty lines under [Unreleased]

--- a/action.yml
+++ b/action.yml
@@ -131,9 +131,9 @@ runs:
 
         changelog_file="$INPUT_CHANGELOG_FILE"
         if [[ -f "$changelog_file" ]]; then
-          if grep -q '^\[Unreleased\]' "$changelog_file" 2>/dev/null; then
+          if grep -q '^## \[Unreleased\]' "$changelog_file" 2>/dev/null; then
             # Count non-empty lines under [Unreleased]
-            entries=$(awk '/^\[Unreleased\]/{p=1;next} /^\[/{p=0} p && /^\s*-/{count++} END{print count+0}' "$changelog_file")
+            entries=$(awk '/^## \[Unreleased\]/{p=1;next} /^## \[/{p=0} p && /^\s*-/{count++} END{print count+0}' "$changelog_file")
             if [[ "$entries" -gt 0 ]]; then
               changelog_status="dirty"
             else

--- a/src/repo_release_tools/commands/_git_shared.py
+++ b/src/repo_release_tools/commands/_git_shared.py
@@ -26,7 +26,13 @@ def conflict_status_lines(status_lines: list[str]) -> list[str]:
     return [line for line in status_lines if git.classify_status_line(line)[0] == "conflict"]
 
 
-def summarize_status(branch_name: str, status_lines: list[str], *, upstream: str | None) -> str:
+def summarize_status(
+    branch_name: str,
+    status_lines: list[str],
+    *,
+    upstream: str | None,
+    root: Path,
+) -> str:
     """Render a compact one-line branch status summary."""
     modified = 0
     untracked = 0
@@ -40,7 +46,7 @@ def summarize_status(branch_name: str, status_lines: list[str], *, upstream: str
     ahead = 0
     behind = 0
     if upstream is not None:
-        ahead, behind = git.ahead_behind(Path.cwd(), upstream)
+        ahead, behind = git.ahead_behind(root, upstream)
 
     return GLYPHS.git.status_line(
         branch_name,

--- a/src/repo_release_tools/commands/_version_render.py
+++ b/src/repo_release_tools/commands/_version_render.py
@@ -1,0 +1,33 @@
+"""Rendering for :class:`~repo_release_tools.version.targets.VersionWriteEvent`.
+
+`version/targets.py`'s write primitives are headless: they return
+``VersionWriteEvent`` records instead of printing. This module holds the one
+rendering routine shared by every surface that consumes those events
+(`bump.py`, `workspace.py`, `ci_version.py`, `release_repair.py`, and the MCP
+bump tool), so the exact `--dry-run` / applied output produced before the
+seam was introduced stays byte-identical no matter which command triggered
+the write.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from repo_release_tools.ui import GLYPHS, DryRunPrinter, VerbosePrinter
+from repo_release_tools.version.targets import VersionWriteEvent
+
+
+def render_version_write_events(events: Iterable[VersionWriteEvent]) -> None:
+    """Print one line per event, matching the pre-seam ``targets.py`` output.
+
+    Dry-run events render as ``Would update <path>: version = "<new>"``;
+    applied events render as ``<path>  →  version = "<new>"``.
+    """
+    for event in events:
+        if event.dry_run:
+            p = DryRunPrinter(dry_run=True)
+            p.would_write(str(event.path), detail=f'version = "{event.new_version}"')
+        else:
+            msg = f'{event.path}  {GLYPHS.arrow.right}  version = "{event.new_version}"'
+            p = VerbosePrinter()
+            p.ok(msg)

--- a/src/repo_release_tools/commands/bump.py
+++ b/src/repo_release_tools/commands/bump.py
@@ -77,6 +77,7 @@ from repo_release_tools.changelog import (
     insert_generated_section,
     promote_unreleased,
 )
+from repo_release_tools.commands._version_render import render_version_write_events
 from repo_release_tools.config import (
     RrtConfig,
     VersionGroup,
@@ -131,7 +132,8 @@ def apply_version(
     file that was (or, in dry-run, would be) modified.  Callers use this list
     to stage the changes with ``git add``.
     """
-    replace_all_versions_atomic(group.version_targets, version, dry_run=dry_run)
+    events = replace_all_versions_atomic(group.version_targets, version, dry_run=dry_run)
+    render_version_write_events(events)
     changed: list[Path] = [target.path for target in group.version_targets]
 
     all_pins = group.pin_targets + config.global_pin_targets

--- a/src/repo_release_tools/commands/bump.py
+++ b/src/repo_release_tools/commands/bump.py
@@ -92,7 +92,6 @@ from repo_release_tools.preflight import PreflightError, run_preflight
 from repo_release_tools.ui import (
     GLYPHS,
     DryRunPrinter,
-    ProgressLine,
     VerbosePrinter,
     spinner_lines,
 )
@@ -378,37 +377,12 @@ def cmd_bump(args: argparse.Namespace) -> int:
             p = VerbosePrinter(verbose=verbose)
             p.line(msg)
 
-    version_progress = ProgressLine(file=sys.stdout)
     p.section("Updating version strings")
-    total_targets = len(group.version_targets)
-    for i, _target in enumerate(group.version_targets, 1):
-        if total_targets > 1 and i > 1:
-            version_progress.clear()
-        if total_targets > 1:
-            version_progress.update_bar(i / total_targets)
-    if total_targets > 1:
-        version_progress.clear()
 
     all_pins = group.pin_targets + config.global_pin_targets
     no_pin_sync = getattr(args, "no_pin_sync", False)
     if all_pins and not no_pin_sync:
-        pin_progress = ProgressLine(file=sys.stdout)
         p.section("Updating doc pins")
-        seen_pin_count: set[tuple[object, str]] = set()
-        unique_pin_count = 0
-        for pin in all_pins:
-            key = (pin.path, pin.pattern)
-            if key not in seen_pin_count:
-                seen_pin_count.add(key)
-                unique_pin_count += 1
-        total_pins = unique_pin_count
-        for i in range(1, total_pins + 1):
-            if total_pins > 1 and i > 1:
-                pin_progress.clear()
-            if total_pins > 1:
-                pin_progress.update_bar(i / total_pins)
-        if total_pins > 1:
-            pin_progress.clear()
 
     # Build a pin-free view when no_pin_sync is set so apply_version skips pins.
     apply_group = dataclasses.replace(group, pin_targets=[]) if no_pin_sync else group

--- a/src/repo_release_tools/commands/ci_version.py
+++ b/src/repo_release_tools/commands/ci_version.py
@@ -55,6 +55,7 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+from repo_release_tools.commands._version_render import render_version_write_events
 from repo_release_tools.config import (
     VALID_CI_FORMATS,
     find_repo_root,
@@ -313,7 +314,8 @@ def cmd_ci_version_apply(args: argparse.Namespace) -> int:
         if total > 1 and i > 1:
             progress.clear()
         try:
-            replace_version_in_file(target, version_str, dry_run=args.dry_run)
+            event = replace_version_in_file(target, version_str, dry_run=args.dry_run)
+            render_version_write_events([event])
         except (FileNotFoundError, RuntimeError) as exc:
             progress.clear()
             p = VerbosePrinter(verbose=verbose)

--- a/src/repo_release_tools/commands/docs_map_lock.py
+++ b/src/repo_release_tools/commands/docs_map_lock.py
@@ -25,6 +25,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from repo_release_tools.commands.docs_map import build_full_block, iter_target_directories
+from repo_release_tools.state import docs_map_lock_path
 
 if TYPE_CHECKING:
     from repo_release_tools.config import MapConfig
@@ -90,7 +91,7 @@ def compute_desired_hashes(config: MapConfig, repo_root: Path) -> dict[str, str]
 
 def detect_drift(config: MapConfig, repo_root: Path) -> list[DriftItem]:
     """Compare desired hashes against the lockfile; return drift items."""
-    lockfile_path = repo_root / config.lock_file
+    lockfile_path = docs_map_lock_path(repo_root, config.lock_file)
     recorded = read_lockfile(lockfile_path)
     desired = compute_desired_hashes(config, repo_root)
 

--- a/src/repo_release_tools/commands/drift_cmd.py
+++ b/src/repo_release_tools/commands/drift_cmd.py
@@ -64,6 +64,7 @@ from pathlib import Path
 from typing import Any
 
 from repo_release_tools.state import (
+    DRIFT_LOCK_NAME,
     build_lock,
     docs_lock_path,
     hash_content,
@@ -73,7 +74,7 @@ from repo_release_tools.state import (
 from repo_release_tools.ui import DryRunPrinter, VerbosePrinter
 
 DRIFT_LOCK_EXAMPLES = "  $ rrt drift generate --dry-run\n  $ rrt drift check"
-DRIFT_LOCK_FILE = "drift.lock.toml"
+DRIFT_LOCK_FILE = DRIFT_LOCK_NAME
 DRIFT_SURFACE_PATTERNS = (
     ".claude/settings.json",
     ".claude/hooks/*.py",

--- a/src/repo_release_tools/commands/folder.py
+++ b/src/repo_release_tools/commands/folder.py
@@ -52,10 +52,10 @@ FOLDER_EPILOG = (
 )
 
 
-def _load_folder_policy_config() -> RrtConfig | None:
+def _load_folder_policy_config(root: Path) -> RrtConfig | None:
     """Return loaded config when available, otherwise ``None`` for template-only flows."""
     try:
-        return load_or_autodetect_config(Path.cwd())
+        return load_or_autodetect_config(root)
     except FileNotFoundError:
         return None
     except ValueError as exc:
@@ -68,7 +68,7 @@ def cmd_folder_check(args: argparse.Namespace) -> int:
     """Run folder supervision checks."""
     verbose: int = getattr(args, "verbose", 0) or 0
     root = Path(args.root).resolve()
-    config = _load_folder_policy_config()
+    config = _load_folder_policy_config(root)
     report = check_folders(
         root=root,
         policy=None if config is None else config.folders,
@@ -122,7 +122,7 @@ def cmd_folder_scaffold(args: argparse.Namespace) -> int:
     """Scaffold folder structure from templates or config."""
     verbose: int = getattr(args, "verbose", 0) or 0
     root = Path(args.root).resolve()
-    config = _load_folder_policy_config()
+    config = _load_folder_policy_config(root)
     report = scaffold_folders(
         root=root,
         policy=None if config is None else config.folders,

--- a/src/repo_release_tools/commands/git_inspect.py
+++ b/src/repo_release_tools/commands/git_inspect.py
@@ -90,7 +90,7 @@ def cmd_status(args: argparse.Namespace) -> int:
         p = VerbosePrinter(verbose=verbose)
         p.line(str(exc), ok=False, stream=sys.stderr)
         return 1
-    summary = summarize_status(branch_name, status_lines, upstream=upstream)
+    summary = summarize_status(branch_name, status_lines, upstream=upstream, root=root)
 
     p = VerbosePrinter(verbose=verbose)
     p.blank_line()
@@ -196,7 +196,7 @@ def cmd_doctor(args: argparse.Namespace) -> int:
                 "is not part of HEAD."
             )
 
-    summary = summarize_status(branch_name, status_lines, upstream=upstream)
+    summary = summarize_status(branch_name, status_lines, upstream=upstream, root=root)
     p = VerbosePrinter(verbose=verbose)
     p.blank_line()
     p.header(
@@ -285,7 +285,7 @@ def cmd_check_dirty_tree(args: argparse.Namespace) -> int:
         branch_name = git.current_branch(root) or "<detached>"
         upstream = git.upstream_branch(root)
         p.ok("Working tree is clean.")
-        p.meta("Status", summarize_status(branch_name, [], upstream=upstream))
+        p.meta("Status", summarize_status(branch_name, [], upstream=upstream, root=root))
         return 0
 
     branch_name = git.current_branch(root) or "<detached>"
@@ -297,7 +297,11 @@ def cmd_check_dirty_tree(args: argparse.Namespace) -> int:
         p.line(str(exc), ok=False, stream=sys.stderr)
         return 1
     p.warn("Working tree has uncommitted changes.", stream=sys.stderr)
-    p.meta("Status", summarize_status(branch_name, changed, upstream=upstream), stream=sys.stderr)
+    p.meta(
+        "Status",
+        summarize_status(branch_name, changed, upstream=upstream, root=root),
+        stream=sys.stderr,
+    )
     shown = changed[:STATUS_MAX]
     for line in shown:
         p.file_entry(*git.classify_status_line(line), stream=sys.stderr)
@@ -341,7 +345,7 @@ def cmd_sync_status(args: argparse.Namespace) -> int:
         Base=base_ref or "<none>",
         Relation=relation,
         Operation=operation or "idle",
-        Status=summarize_status(branch_name, status_lines, upstream=base_ref),
+        Status=summarize_status(branch_name, status_lines, upstream=base_ref, root=root),
     )
 
     p.section("Analysis")

--- a/src/repo_release_tools/commands/git_sync.py
+++ b/src/repo_release_tools/commands/git_sync.py
@@ -122,7 +122,7 @@ def cmd_sync(args: argparse.Namespace) -> int:
         Strategy=strategy,
         **{
             "Working tree": "dirty" if dirty else "clean",
-            "Status": summarize_status(branch_name, status_lines, upstream=upstream),
+            "Status": summarize_status(branch_name, status_lines, upstream=upstream, root=root),
         },
     )
     p.section("Syncing")

--- a/src/repo_release_tools/commands/init.py
+++ b/src/repo_release_tools/commands/init.py
@@ -92,24 +92,24 @@ INIT_EPILOG = (
 def cmd_init(args: argparse.Namespace) -> int:
     """Write a recommended rrt configuration block."""
     _: int = getattr(args, "verbose", 0) or 0
+    root = Path.cwd()
     target_fmt = getattr(args, "target", "rrt-toml")
     match target_fmt:
         case "pyproject":
-            return _init_manifest(args, manifest="pyproject.toml", section_label="[tool.rrt]")
+            return _init_manifest(args, root, manifest="pyproject.toml", section_label="[tool.rrt]")
         case "cargo":
             return _init_manifest(
-                args, manifest="Cargo.toml", section_label="[package.metadata.rrt]"
+                args, root, manifest="Cargo.toml", section_label="[package.metadata.rrt]"
             )
         case "node":
-            return _init_package_json(args)
+            return _init_package_json(args, root)
         case "go":
-            return _init_rrt_toml(args, go=True)
-    return _init_rrt_toml(args)
+            return _init_rrt_toml(args, root, go=True)
+    return _init_rrt_toml(args, root)
 
 
-def _init_rrt_toml(args: argparse.Namespace, *, go: bool = False) -> int:
+def _init_rrt_toml(args: argparse.Namespace, root: Path, *, go: bool = False) -> int:
     """Write a recommended local .rrt.toml file."""
-    root = Path.cwd()
     target = root / DEFAULT_INIT_CONFIG
 
     try:
@@ -181,12 +181,12 @@ def _init_rrt_toml(args: argparse.Namespace, *, go: bool = False) -> int:
 
 def _init_manifest(
     args: argparse.Namespace,
+    root: Path,
     *,
     manifest: str,
     section_label: str,
 ) -> int:
     """Append an rrt configuration section to an existing manifest file."""
-    root = Path.cwd()
     manifest_path = root / manifest
 
     if not manifest_path.exists():
@@ -244,9 +244,8 @@ def _init_manifest(
     return 0
 
 
-def _init_package_json(args: argparse.Namespace) -> int:
+def _init_package_json(args: argparse.Namespace, root: Path) -> int:
     """Merge the rrt config block into an existing package.json."""
-    root = Path.cwd()
     manifest_path = root / "package.json"
 
     if not manifest_path.exists():

--- a/src/repo_release_tools/commands/release_repair.py
+++ b/src/repo_release_tools/commands/release_repair.py
@@ -54,6 +54,7 @@ from repo_release_tools.changelog import (
     get_unreleased_entries,
     insert_generated_section,
 )
+from repo_release_tools.commands._version_render import render_version_write_events
 from repo_release_tools.config import (
     PinTarget,
     RrtConfig,
@@ -226,7 +227,8 @@ def _recreate(
 
     targets_to_rewrite = _targets_needing_rewrite(group.version_targets, declared_version)
     if targets_to_rewrite:
-        replace_all_versions_atomic(targets_to_rewrite, declared_version, dry_run=False)
+        events = replace_all_versions_atomic(targets_to_rewrite, declared_version, dry_run=False)
+        render_version_write_events(events)
 
     all_pins = _unique_pins(group, config)
     _rewrite_matching_pins(all_pins, declared_version, config)
@@ -457,7 +459,10 @@ def _apply_drift_fixes(
     if needs_version_rewrite:
         targets_to_rewrite = _targets_needing_rewrite(group.version_targets, declared_version)
         if targets_to_rewrite:
-            replace_all_versions_atomic(targets_to_rewrite, declared_version, dry_run=False)
+            events = replace_all_versions_atomic(
+                targets_to_rewrite, declared_version, dry_run=False
+            )
+            render_version_write_events(events)
 
     if needs_pin_rewrite:
         _rewrite_matching_pins(_unique_pins(group, config), declared_version, config)

--- a/src/repo_release_tools/commands/tree.py
+++ b/src/repo_release_tools/commands/tree.py
@@ -126,6 +126,8 @@ from repo_release_tools.state import (
     rrt_dir,
     tree_lock_is_current,
     tree_lock_path,
+    tree_manifest_gz_path,
+    tree_manifest_path,
     write_lock,
 )
 from repo_release_tools.tools.inject import (
@@ -705,8 +707,8 @@ def _write_tree_manifest(
 
     target_dir = rrt_dir(root)
     target_dir.mkdir(parents=True, exist_ok=True)
-    target = target_dir / "tree.manifest.json"
-    gz_target = target_dir / "tree.manifest.json.gz"
+    target = tree_manifest_path(root)
+    gz_target = tree_manifest_gz_path(root)
 
     if p.dry_run:
         dest = gz_target if compressed else target
@@ -945,9 +947,8 @@ def cmd_tree(args: argparse.Namespace) -> int:
         # avoids dumping a large JSON blob into logs while giving humans a
         # concise list of added/removed paths and file/dir counts.
         try:
-            manifest_dir = rrt_dir(root)
-            manifest_json = manifest_dir / "tree.manifest.json"
-            manifest_gz = manifest_dir / "tree.manifest.json.gz"
+            manifest_json = tree_manifest_path(root)
+            manifest_gz = tree_manifest_gz_path(root)
 
             manifest_text: str | None = None
             if manifest_json.exists():

--- a/src/repo_release_tools/commands/workspace.py
+++ b/src/repo_release_tools/commands/workspace.py
@@ -48,6 +48,7 @@ from repo_release_tools.changelog import (
     has_unreleased_section,
     promote_unreleased,
 )
+from repo_release_tools.commands._version_render import render_version_write_events
 from repo_release_tools.config import (
     RrtConfig,
     format_missing_tool_rrt_guidance,
@@ -195,7 +196,8 @@ def cmd_workspace_bump(args: argparse.Namespace) -> int:
         current = read_group_current_version(group)
         pr.section(f"{pkg_path.name}: {current} {GLYPHS.arrow.right} {new}")
 
-        replace_all_versions_atomic(group.version_targets, str(new), dry_run=dry_run)
+        events = replace_all_versions_atomic(group.version_targets, str(new), dry_run=dry_run)
+        render_version_write_events(events)
 
         if not no_changelog:
             group_config = RrtConfig(

--- a/src/repo_release_tools/config/docs_config.py
+++ b/src/repo_release_tools/config/docs_config.py
@@ -21,6 +21,8 @@ import warnings
 from pathlib import Path
 from typing import cast
 
+from repo_release_tools.state import DOCS_LOCK_DEFAULT, DOCS_MAP_LOCK_DEFAULT
+
 from .model import (
     VALID_BADGE_STYLES,
     VALID_BADGE_VARIANTS,
@@ -198,7 +200,7 @@ def _load_docs_languages(d: dict[str, object]) -> tuple[str, ...]:
 def _load_docs_lock_file(d: dict[str, object]) -> str:
     raw = d.get("lock_file")
     if raw is None:
-        return ".rrt/docs.lock.toml"
+        return DOCS_LOCK_DEFAULT
     if not isinstance(raw, str) or not raw:
         raise ValueError("tool.rrt.docs.lock_file must be a non-empty string")
     return raw
@@ -488,7 +490,7 @@ def _load_map_config(raw: object) -> MapConfig | None:
         purpose=_load_map_purpose(d),
         include=_load_map_string_tuple(d, "include"),
         exclude=_load_map_string_tuple(d, "exclude"),
-        lock_file=_load_map_string(d, "lock_file", default=".rrt/docs_map.lock.toml"),
+        lock_file=_load_map_string(d, "lock_file", default=DOCS_MAP_LOCK_DEFAULT),
     )
     cfg.validate()
     return cfg

--- a/src/repo_release_tools/config/model.py
+++ b/src/repo_release_tools/config/model.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from textwrap import dedent
 
+from repo_release_tools.state import DOCS_LOCK_DEFAULT, DOCS_MAP_LOCK_DEFAULT
 from repo_release_tools.sync.providers import PROVIDERS as VALID_UPSTREAM_PROVIDERS  # noqa: F401
 
 DEFAULT_RELEASE_BRANCH = "release/v{version}"
@@ -490,7 +491,7 @@ class MapConfig:
     purpose: dict[str, str] = field(default_factory=dict)
     include: tuple[str, ...] = ()
     exclude: tuple[str, ...] = ()
-    lock_file: str = ".rrt/docs_map.lock.toml"
+    lock_file: str = DOCS_MAP_LOCK_DEFAULT
 
     def validate(self) -> None:
         """Validate enumerated fields."""
@@ -524,7 +525,7 @@ class DocsConfig:
     # Multi-language doc extraction settings
     extraction_mode: str = "explicit"  # "explicit" | "implicit" | "both"
     languages: tuple[str, ...] = ("python",)
-    lock_file: str = ".rrt/docs.lock.toml"
+    lock_file: str = DOCS_LOCK_DEFAULT
     formats: tuple[str, ...] = ("md",)
     source_repo_url: str | None = None
     source_ref: str | None = None

--- a/src/repo_release_tools/eol/core.py
+++ b/src/repo_release_tools/eol/core.py
@@ -72,6 +72,7 @@ from __future__ import annotations
 import json
 import re
 import urllib.error
+import urllib.parse
 import urllib.request
 from collections.abc import Iterable
 from dataclasses import dataclass
@@ -149,7 +150,7 @@ class EolRecord:
 def fetch_live_data(language: str) -> list[dict[str, object]]:
     """Fetch EOL data from endoflife.date API."""
     slug = _canonical_slug(language)
-    url = f"https://endoflife.date/api/v1/products/{slug}/"
+    url = f"https://endoflife.date/api/v1/products/{urllib.parse.quote(slug, safe='')}/"
     try:
         with urllib.request.urlopen(url, timeout=10) as response:  # noqa: S310
             raw = json.loads(response.read().decode("utf-8"))

--- a/src/repo_release_tools/mcp/apps.py
+++ b/src/repo_release_tools/mcp/apps.py
@@ -191,9 +191,9 @@ def register_apps(mcp: FastMCP) -> None:
 
         from repo_release_tools.state import (
             artifacts_lock_path,
+            drift_lock_path,
             health_lock_path,
             read_lock,
-            rrt_dir,
             tree_lock_path,
         )
 
@@ -255,7 +255,7 @@ def register_apps(mcp: FastMCP) -> None:
             ac["ok"] += 1
         lock_counts["artifacts"] = ac
 
-        drift = read_lock(rrt_dir(root) / "drift.lock.toml")
+        drift = read_lock(drift_lock_path(root))
         dc: dict[str, int] = {"ok": 0, "warning": 0, "error": 0}
         for source, entry in drift.get("sources", {}).items():
             rows.append(
@@ -634,9 +634,9 @@ def register_apps(mcp: FastMCP) -> None:
 
         from repo_release_tools.state import (
             artifacts_lock_path,
+            drift_lock_path,
             health_lock_path,
             read_lock,
-            rrt_dir,
             tree_lock_path,
         )
 
@@ -734,7 +734,7 @@ def register_apps(mcp: FastMCP) -> None:
             }
         )
 
-        drift = read_lock(rrt_dir(root) / "drift.lock.toml")
+        drift = read_lock(drift_lock_path(root))
         drift_sources = drift.get("sources", {})
         for source, entry in drift_sources.items():
             rows.append(

--- a/src/repo_release_tools/mcp/apps.py
+++ b/src/repo_release_tools/mcp/apps.py
@@ -158,6 +158,12 @@ def _overall_badge(severities: list[str]) -> tuple[str, str]:
     return "All Healthy", "success"
 
 
+# Mirrors the --target choices in commands/init.py's argparse spec (SEC-007:
+# rrt_init_run validates LLM-supplied `target` against this set before it
+# reaches subprocess argv, the same pattern git_tools.py uses for commit_type).
+INIT_TARGETS: tuple[str, ...] = ("rrt-toml", "pyproject", "cargo", "node", "go")
+
+
 class RrtInitForm(BaseModel):
     """Form model for rrt init configuration."""
 
@@ -587,6 +593,10 @@ def register_apps(mcp: FastMCP) -> None:
         import subprocess
         import sys
         from pathlib import Path
+
+        if target not in INIT_TARGETS:
+            allowed = ", ".join(INIT_TARGETS)
+            return f"[error]: Invalid target {target!r}. Choose one of: {allowed}"
 
         root: Path = ctx.lifespan_context.get("root", Path.cwd())
         cmd = [sys.executable, "-m", "repo_release_tools.cli", "init", f"--target={target}"]

--- a/src/repo_release_tools/mcp/resources.py
+++ b/src/repo_release_tools/mcp/resources.py
@@ -26,14 +26,14 @@ def register_resources(mcp: FastMCP) -> None:
     from repo_release_tools.mcp.server import _find_repo_root
     from repo_release_tools.state import (
         artifacts_lock_path,
+        drift_lock_path,
         health_lock_path,
         read_lock,
-        rrt_dir,
         tree_lock_path,
     )
 
     _LOCK_RESOLVER = {
-        "drift": lambda root: rrt_dir(root) / "drift.lock.toml",
+        "drift": drift_lock_path,
         "health": health_lock_path,
         "tree": tree_lock_path,
         "artifacts": artifacts_lock_path,

--- a/src/repo_release_tools/mcp/tools/lock_tools.py
+++ b/src/repo_release_tools/mcp/tools/lock_tools.py
@@ -40,10 +40,10 @@ def register(mcp: FastMCP) -> None:
     )
     def rrt_drift(ctx: Context) -> dict[str, Any]:
         """Return source drift state from .rrt/drift.lock.toml (file hashes and symbols)."""
-        from repo_release_tools.state import read_lock, rrt_dir
+        from repo_release_tools.state import drift_lock_path, read_lock
 
         root: Path = ctx.lifespan_context.get("root", Path.cwd())
-        data = read_lock(rrt_dir(root) / "drift.lock.toml")
+        data = read_lock(drift_lock_path(root))
         if not data:
             return {"error": "No drift lock found. Run: rrt drift --snapshot"}
         return data

--- a/src/repo_release_tools/mcp/tools/version_tools.py
+++ b/src/repo_release_tools/mcp/tools/version_tools.py
@@ -80,14 +80,10 @@ def register(mcp: FastMCP) -> None:
                 )
                 applied = False
                 if not dry_run:
-                    import contextlib
-                    import io
-
                     from repo_release_tools.version.targets import replace_version_in_file
 
                     for target in group.version_targets:
-                        with contextlib.redirect_stdout(io.StringIO()):
-                            replace_version_in_file(target, new_ver, dry_run=False)
+                        replace_version_in_file(target, new_ver, dry_run=False)
                         await ctx.info(f"Updated {target.path}")
                     applied = True
                 results.append(

--- a/src/repo_release_tools/state.py
+++ b/src/repo_release_tools/state.py
@@ -17,6 +17,33 @@ _DOCS_LOCK_NAME = "docs.lock.toml"
 _HEALTH_LOCK_NAME = "health.lock.toml"
 _TREE_LOCK_NAME = "tree.lock.toml"
 _ARTIFACTS_LOCK_NAME = "artifacts.lock.toml"
+_DRIFT_LOCK_NAME = "drift.lock.toml"
+_DOCS_MAP_LOCK_NAME = "docs_map.lock.toml"
+_TREE_MANIFEST_NAME = "tree.manifest.json"
+_TREE_MANIFEST_GZ_NAME = "tree.manifest.json.gz"
+
+#: Public re-export of the bare lock filenames, for call sites that need the
+#: name itself (e.g. an argparse ``help=`` string or a CLI default) rather
+#: than a resolved :class:`~pathlib.Path`.
+DOCS_LOCK_NAME = _DOCS_LOCK_NAME
+HEALTH_LOCK_NAME = _HEALTH_LOCK_NAME
+TREE_LOCK_NAME = _TREE_LOCK_NAME
+ARTIFACTS_LOCK_NAME = _ARTIFACTS_LOCK_NAME
+DRIFT_LOCK_NAME = _DRIFT_LOCK_NAME
+DOCS_MAP_LOCK_NAME = _DOCS_MAP_LOCK_NAME
+TREE_MANIFEST_NAME = _TREE_MANIFEST_NAME
+TREE_MANIFEST_GZ_NAME = _TREE_MANIFEST_GZ_NAME
+
+#: Public re-export of each lock's default ``.rrt/``-relative path string, for
+#: call sites that store the *default value* of a configurable lock-file
+#: field (e.g. a dataclass field default) rather than resolving an absolute
+#: path against a repo root.
+DOCS_LOCK_DEFAULT = f"{_RRT_DIR}/{_DOCS_LOCK_NAME}"
+HEALTH_LOCK_DEFAULT = f"{_RRT_DIR}/{_HEALTH_LOCK_NAME}"
+TREE_LOCK_DEFAULT = f"{_RRT_DIR}/{_TREE_LOCK_NAME}"
+ARTIFACTS_LOCK_DEFAULT = f"{_RRT_DIR}/{_ARTIFACTS_LOCK_NAME}"
+DRIFT_LOCK_DEFAULT = f"{_RRT_DIR}/{_DRIFT_LOCK_NAME}"
+DOCS_MAP_LOCK_DEFAULT = f"{_RRT_DIR}/{_DOCS_MAP_LOCK_NAME}"
 
 
 def rrt_dir(root: Path) -> Path:
@@ -45,6 +72,33 @@ def tree_lock_path(root: Path) -> Path:
 def artifacts_lock_path(root: Path) -> Path:
     """Return the path to the artifact integrity lockfile."""
     return root / _RRT_DIR / _ARTIFACTS_LOCK_NAME
+
+
+def drift_lock_path(root: Path) -> Path:
+    """Return the path to the source-drift lockfile."""
+    return root / _RRT_DIR / _DRIFT_LOCK_NAME
+
+
+def docs_map_lock_path(root: Path, lock_file: str = _DOCS_MAP_LOCK_NAME) -> Path:
+    """Return the path to the per-directory docs-map lockfile.
+
+    Mirrors :func:`docs_lock_path`'s handling of a configurable, possibly
+    already-``.rrt/``-relative *lock_file* value.
+    """
+    p = Path(lock_file)
+    if p.is_absolute():
+        return p
+    return root / p if p.parts[0] == _RRT_DIR else root / _RRT_DIR / p
+
+
+def tree_manifest_path(root: Path) -> Path:
+    """Return the path to the uncompressed tree manifest."""
+    return root / _RRT_DIR / _TREE_MANIFEST_NAME
+
+
+def tree_manifest_gz_path(root: Path) -> Path:
+    """Return the path to the gzip-compressed tree manifest."""
+    return root / _RRT_DIR / _TREE_MANIFEST_GZ_NAME
 
 
 def hash_content(content: str) -> str:

--- a/src/repo_release_tools/state.py
+++ b/src/repo_release_tools/state.py
@@ -114,7 +114,10 @@ def now_utc() -> str:
 def _short_hash(h: str) -> str:
     """Return an 8-character short prefix from a hash string like 'sha256:...'.
 
-    Returns '?' on error or when the input is falsy.
+    Returns '?' on error or when the input is falsy. *h* ultimately comes
+    from lockfile TOML data, so this guards against a malformed value whose
+    ``__bool__``/``__eq__`` (or similar) raises rather than a plain string
+    operation failing — see test_state_exceptions.py.
     """
     try:
         if not h:
@@ -327,7 +330,11 @@ def tree_lock_is_current(
         new_count = tree_meta.get("entry_count", "?")
 
         # Compare raw counts when available (integers). Fall back to
-        # conservative equality if types differ.
+        # conservative equality if types differ. This is diagnostic-message
+        # formatting, not the drift decision itself (already made above) —
+        # a malformed lock value (e.g. an object with a broken __eq__) must
+        # not prevent the drift from being reported, so the broad guard here
+        # is intentional; see test_state_exceptions.py for the pinned cases.
         counts_equal = False
         try:
             counts_equal = locked_snapshot.get("entry_count") == tree_meta.get("entry_count")

--- a/src/repo_release_tools/sync/providers.py
+++ b/src/repo_release_tools/sync/providers.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import urllib.error
+import urllib.parse
 import urllib.request
 
 from repo_release_tools.sync.pypi import fetch_pypi_versions
@@ -41,9 +42,23 @@ def _fetch_json(
 # ---------------------------------------------------------------------------
 
 
+def _quote_npm_package(package: str) -> str:
+    """Percent-encode an npm package identifier, handling ``@scope/name`` form.
+
+    The npm registry expects a scoped package's ``/`` separator to be
+    percent-encoded as ``%2F`` (``@scope%2Fname``) — an unencoded ``/`` would
+    otherwise be a second path segment. Quote with ``safe="@"`` so the scope
+    marker stays literal, then encode the separating slash. Any *other*
+    slash in the input (not the single scope separator) is left encoded by
+    ``quote`` too, so it cannot introduce extra path segments (CWE-20).
+    """
+    quoted = urllib.parse.quote(package, safe="@")
+    return quoted.replace("/", "%2F")
+
+
 def _fetch_npm_versions(package: str, *, timeout: int = 10) -> list[str]:
     """Return all versions of *package* from the npm registry."""
-    url = f"https://registry.npmjs.org/{package}"
+    url = f"https://registry.npmjs.org/{_quote_npm_package(package)}"
     data = _fetch_json(url, timeout=timeout)
     if not isinstance(data, dict):
         return []
@@ -55,7 +70,10 @@ def _fetch_npm_versions(package: str, *, timeout: int = 10) -> list[str]:
 
 def _fetch_nuget_versions(package: str, *, timeout: int = 10) -> list[str]:
     """Return all versions of *package* from NuGet (package id is lowercased)."""
-    url = f"https://api.nuget.org/v3-flatcontainer/{package.lower()}/index.json"
+    url = (
+        "https://api.nuget.org/v3-flatcontainer/"
+        f"{urllib.parse.quote(package.lower(), safe='')}/index.json"
+    )
     data = _fetch_json(url, timeout=timeout)
     if not isinstance(data, dict):
         return []
@@ -67,7 +85,7 @@ def _fetch_nuget_versions(package: str, *, timeout: int = 10) -> list[str]:
 
 def _fetch_crates_versions(package: str, *, timeout: int = 10) -> list[str]:
     """Return all versions of *package* from crates.io (requires User-Agent)."""
-    url = f"https://crates.io/api/v1/crates/{package}/versions"
+    url = f"https://crates.io/api/v1/crates/{urllib.parse.quote(package, safe='')}/versions"
     data = _fetch_json(url, timeout=timeout, headers={"User-Agent": USER_AGENT})
     if not isinstance(data, dict):
         return []
@@ -83,9 +101,21 @@ def _fetch_crates_versions(package: str, *, timeout: int = 10) -> list[str]:
     return result
 
 
+def _quote_vendor_name_package(package: str) -> str:
+    """Percent-encode a Packagist ``vendor/name`` identifier, segment by segment.
+
+    Packagist routes on a literal two-segment ``vendor/name`` path, so the
+    single separating ``/`` must stay literal — but each segment (and any
+    *extra* ``/`` beyond the first, e.g. a ``../`` traversal attempt) is
+    percent-encoded with ``safe=""`` so the value cannot smuggle additional
+    path segments (CWE-20).
+    """
+    return "/".join(urllib.parse.quote(part, safe="") for part in package.split("/"))
+
+
 def _fetch_packagist_versions(package: str, *, timeout: int = 10) -> list[str]:
     """Return all versions of *package* from Packagist (vendor/name format)."""
-    url = f"https://packagist.org/packages/{package}.json"
+    url = f"https://packagist.org/packages/{_quote_vendor_name_package(package)}.json"
     data = _fetch_json(url, timeout=timeout)
     if not isinstance(data, dict):
         return []

--- a/src/repo_release_tools/version/__init__.py
+++ b/src/repo_release_tools/version/__init__.py
@@ -3,6 +3,7 @@
 from .calver import CALVER_SCHEMES, CalVersion
 from .semver import Version
 from .targets import (
+    VersionWriteEvent,
     check_autodetected_version_consistency,
     read_current_version,
     read_group_current_version,
@@ -16,6 +17,7 @@ __all__ = [
     "CALVER_SCHEMES",
     "CalVersion",
     "Version",
+    "VersionWriteEvent",
     "check_autodetected_version_consistency",
     "read_current_version",
     "read_group_current_version",

--- a/src/repo_release_tools/version/targets.py
+++ b/src/repo_release_tools/version/targets.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import re
 import tomllib
+from dataclasses import dataclass
 from pathlib import Path
 
 from repo_release_tools.config import PinTarget, RrtConfig, VersionGroup, VersionTarget
@@ -32,6 +33,21 @@ MAVEN_POM_PATTERN = re.compile(r"(<version>)([^<]+)(</version>)")
 GEMSPEC_VERSION_PATTERN = re.compile(r'(?m)^(\s*\w+\.version\s*=\s*)(["\'])([^"\']+)\2')
 # .NET .csproj: <Version>...</Version> tag.
 CSPROJ_VERSION_PATTERN = re.compile(r"(<Version>)([^<]+)(</Version>)")
+
+
+@dataclass(frozen=True, slots=True)
+class VersionWriteEvent:
+    """One version-target write, actual or dry-run-previewed.
+
+    Emitted by :func:`replace_version_in_file` and
+    :func:`replace_all_versions_atomic` instead of printing directly — the
+    core write primitives stay headless; callers render this event through
+    whichever printer matches their surface (CLI, hooks, MCP).
+    """
+
+    path: Path
+    new_version: str
+    dry_run: bool
 
 
 def _compute_updated_content(target: VersionTarget, text: str, new_version: str) -> str:
@@ -71,8 +87,13 @@ def replace_version_in_file(
     new_version: str,
     *,
     dry_run: bool,
-) -> None:
-    """Update a single configured version target."""
+) -> VersionWriteEvent:
+    """Update a single configured version target.
+
+    Returns a :class:`VersionWriteEvent` describing the write (or, in
+    dry-run mode, the write that would happen). This function performs no
+    rendering — callers are responsible for printing.
+    """
     path = target.path
     text = path.read_text(encoding="utf-8")
     current_version = read_version_string(target)
@@ -83,14 +104,10 @@ def replace_version_in_file(
     updated = _compute_updated_content(target, text, new_version)
 
     if dry_run:
-        p = DryRunPrinter(dry_run=True)
-        p.would_write(str(path), detail=f'version = "{new_version}"')
-        return
+        return VersionWriteEvent(path=path, new_version=new_version, dry_run=True)
 
     path.write_text(updated, encoding="utf-8")
-    msg = f'{path}  {GLYPHS.arrow.right}  version = "{new_version}"'
-    p = VerbosePrinter()
-    p.ok(msg)
+    return VersionWriteEvent(path=path, new_version=new_version, dry_run=False)
 
 
 def replace_all_versions_atomic(
@@ -98,17 +115,21 @@ def replace_all_versions_atomic(
     new_version: str,
     *,
     dry_run: bool,
-) -> None:
+) -> list[VersionWriteEvent]:
     """Update all version targets atomically: validate all substitutions first, then flush.
 
     If any target fails to produce a valid substitution, no files are written and
     the original content of any already-written files is restored.
+
+    Returns the list of :class:`VersionWriteEvent` describing every write (or,
+    in dry-run mode, every write that would happen), in target order. This
+    function performs no rendering — callers are responsible for printing.
     """
     if dry_run:
-        for target in targets:
-            p = DryRunPrinter(dry_run=True)
-            p.would_write(str(target.path), detail=f'version = "{new_version}"')
-        return
+        return [
+            VersionWriteEvent(path=target.path, new_version=new_version, dry_run=True)
+            for target in targets
+        ]
 
     # Phase 1: compute all updates in memory before touching disk.
     pending: list[tuple[Path, str, str]] = []  # (path, old_content, new_content)
@@ -135,9 +156,10 @@ def replace_all_versions_atomic(
                 pass
         raise
 
-    p = VerbosePrinter()
-    for path, _, _ in pending:
-        p.ok(f'{path}  {GLYPHS.arrow.right}  version = "{new_version}"')
+    return [
+        VersionWriteEvent(path=path, new_version=new_version, dry_run=False)
+        for path, _, _ in pending
+    ]
 
 
 def read_current_version(config: RrtConfig) -> Version:

--- a/src/repo_release_tools/version/targets.py
+++ b/src/repo_release_tools/version/targets.py
@@ -148,12 +148,20 @@ def replace_all_versions_atomic(
         for path, _old, new_content in pending:
             path.write_text(new_content, encoding="utf-8")
             written.append((path, _old))
-    except Exception:
+    except Exception as exc:
+        failed_restores: list[str] = []
         for path, original in written:
             try:
                 path.write_text(original, encoding="utf-8")
-            except OSError:
-                pass
+            except OSError as restore_exc:
+                failed_restores.append(f"{path}: {restore_exc}")
+        if failed_restores:
+            detail = "; ".join(failed_restores)
+            raise RuntimeError(
+                f"Atomic version write failed ({exc}) and rollback could not restore "
+                f"{len(failed_restores)} file(s): {detail}. The working tree is now "
+                "inconsistent and must be fixed manually."
+            ) from exc
         raise
 
     return [

--- a/src/repo_release_tools/workflow/git.py
+++ b/src/repo_release_tools/workflow/git.py
@@ -150,7 +150,7 @@ def current_branch(cwd: Path) -> str:
 
 def branch_exists(cwd: Path, branch: str) -> bool:
     """Return whether a local branch exists."""
-    return bool(capture(["git", "branch", "--list", branch], cwd))
+    return bool(capture(["git", "branch", "--list", "--", branch], cwd))
 
 
 def working_tree_clean(cwd: Path) -> bool:
@@ -166,7 +166,16 @@ def working_tree_clean(cwd: Path) -> bool:
 
 
 def commits_ahead(cwd: Path, base_ref: str) -> list[str]:
-    """Return short log lines for commits on HEAD not in the base ref."""
+    """Return short log lines for commits on HEAD not in the base ref.
+
+    Raises ``ValueError`` if *base_ref* starts with ``-``: the range expression
+    ``<base_ref>..HEAD`` is a single positional argument to ``git log`` that
+    cannot be guarded with a ``--`` separator (git would then treat the range
+    as a pathspec instead of a revision range), so a leading dash is rejected
+    outright to prevent option-injection (CWE-88).
+    """
+    if base_ref.startswith("-"):
+        raise ValueError(f"base_ref must not start with '-': {base_ref!r}")
     out = capture(["git", "log", f"{base_ref}..HEAD", "--pretty=format:%h %s"], cwd)
     return [line for line in out.splitlines() if line]
 
@@ -221,7 +230,16 @@ def upstream_branch(cwd: Path) -> str | None:
 
 
 def ref_exists(cwd: Path, ref: str) -> bool:
-    """Return whether *ref* resolves to an object in this repository."""
+    """Return whether *ref* resolves to an object in this repository.
+
+    Returns ``False`` (rather than invoking git) if *ref* starts with ``-``:
+    ``git rev-parse --verify`` parses its positional argument as an option
+    when it looks like one even after a ``--`` separator, so a leading dash
+    is rejected outright to prevent option-injection (CWE-88) instead of
+    being passed through to the subprocess.
+    """
+    if ref.startswith("-"):
+        return False
     result = subprocess.run(
         ["git", "rev-parse", "--verify", "--quiet", ref],
         cwd=cwd,

--- a/src/repo_release_tools/workflow/hooks.py
+++ b/src/repo_release_tools/workflow/hooks.py
@@ -231,6 +231,21 @@ def _normalize_repo_path(path: str, *, cwd: Path) -> str:
     return candidate.as_posix()
 
 
+def _contained_changelog_path(changelog_file: str, *, cwd: Path) -> Path | None:
+    """Resolve *changelog_file* against *cwd* and reject paths that escape it.
+
+    SEC-003: ``changelog_file`` is config-controlled; without a containment
+    check a value such as ``"../../evil.md"`` would resolve outside the work
+    tree (CWE-22). Returns the resolved path when it is contained within
+    *cwd*, or ``None`` when it escapes.
+    """
+    resolved_cwd = cwd.resolve()
+    resolved_path = (cwd / changelog_file).resolve()
+    if resolved_path.is_relative_to(resolved_cwd):
+        return resolved_path
+    return None
+
+
 def staged_files(cwd: Path) -> list[str]:
     """Return staged files for the current index."""
     out = git.capture(["git", "diff", "--cached", "--name-only", "--diff-filter=ACMR"], cwd)
@@ -753,7 +768,12 @@ def run_update_unreleased(
         p.verbose_line("  skipped (changelog meta-commit)")
         return 0
 
-    changelog_path = cwd / changelog_file
+    changelog_path = _contained_changelog_path(changelog_file, cwd=cwd)
+    if changelog_path is None:
+        return emit_failure(
+            "Changelog update failed.",
+            [f"Changelog file {changelog_file!r} resolves outside the repository root {cwd}."],
+        )
     if not changelog_path.exists():
         return emit_failure(
             "Changelog update failed.",
@@ -885,7 +905,12 @@ def run_post_correct(
     followed by ``"remove X"``), rewrites the file in-place, and optionally
     creates a follow-up commit.
     """
-    changelog_path = cwd / changelog_file
+    changelog_path = _contained_changelog_path(changelog_file, cwd=cwd)
+    if changelog_path is None:
+        return emit_failure(
+            "Changelog post-correction failed.",
+            [f"Changelog file {changelog_file!r} resolves outside the repository root {cwd}."],
+        )
     if not changelog_path.exists():
         return emit_failure(
             "Changelog post-correction failed.",

--- a/src/repo_release_tools/workflow/hooks.py
+++ b/src/repo_release_tools/workflow/hooks.py
@@ -766,7 +766,7 @@ def run_update_unreleased(
     updated = append_to_unreleased(original, subject, fmt)
     if updated != original:
         changelog_path.write_text(updated, encoding="utf-8")
-        git.run(["git", "add", changelog_file], cwd, dry_run=False, label="stage changelog")
+        git.run(["git", "add", "--", changelog_file], cwd, dry_run=False, label="stage changelog")
         p = VerbosePrinter(verbose=verbose)
         p.line(f"[Unreleased] section updated in {changelog_file}.", ok=True, stream=sys.stderr)
     else:
@@ -934,7 +934,7 @@ def run_post_correct(
     if commit:
         try:
             git.run(
-                ["git", "add", changelog_file],
+                ["git", "add", "--", changelog_file],
                 cwd,
                 dry_run=False,
                 label="git add changelog",

--- a/src/repo_release_tools/workflow/hooks.py
+++ b/src/repo_release_tools/workflow/hooks.py
@@ -1488,6 +1488,7 @@ def main(argv: list[str] | None = None) -> int:
             parsed.regenerate = False
             return cmd_artifacts(parsed)
         case "update-unreleased":
+            cwd = Path.cwd()
             if parsed.message_file is not None:
                 # Explicit file path — used by lefthook which passes {1} (the commit-msg file).
                 msg_path = Path(parsed.message_file)
@@ -1507,13 +1508,13 @@ def main(argv: list[str] | None = None) -> int:
                 subject = parsed.subject
             else:
                 # Fall back to reading the commit message file that git sets during commit hooks.
-                commit_editmsg = Path.cwd() / ".git" / "COMMIT_EDITMSG"
+                commit_editmsg = cwd / ".git" / "COMMIT_EDITMSG"
                 if commit_editmsg.exists():
                     subject = read_commit_subject(commit_editmsg)
                 else:
                     subject = ""
             return run_update_unreleased(
-                Path.cwd(),
+                cwd,
                 subject=subject,
                 changelog_file=parsed.changelog_file,
                 verbose=verbose,

--- a/tests/commands/test_bump.py
+++ b/tests/commands/test_bump.py
@@ -3,10 +3,8 @@
 from __future__ import annotations
 
 import argparse
-import io
 import os
 import sys
-import types
 from argparse import Namespace
 from collections.abc import Generator
 from contextlib import contextmanager
@@ -22,15 +20,8 @@ from repo_release_tools.commands.bump import (
     update_changelog,
 )
 from repo_release_tools.config import PinTarget, RrtConfig, VersionGroup, VersionTarget
-from repo_release_tools.ui import GLYPHS, render_ok
 from repo_release_tools.version.semver import Version
 from repo_release_tools.version.targets import VersionWriteEvent
-
-# Compatibility shim — maps legacy output.X names to the canonical ui API.
-output = types.SimpleNamespace(
-    ok=render_ok,
-    GLYPHS=GLYPHS,
-)
 
 
 def test_resolve_changelog_mode_prefers_requested_mode(tmp_path: Path) -> None:
@@ -2468,7 +2459,7 @@ def test_cmd_bump_deduplicates_pin_updates_and_stage_entries(
     assert add_calls[-1].count("docs/action.md") == 1
 
 
-def test_cmd_bump_uses_shared_progress_and_inline_lock_spinner(
+def test_cmd_bump_uses_inline_lock_spinner(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -2512,22 +2503,8 @@ def test_cmd_bump_uses_shared_progress_and_inline_lock_spinner(
         default_group_name="default",
     )
 
-    progress_updates: list[tuple[int, float]] = []
-    progress_clears: list[int] = []
     spinner_calls: list[tuple[str, str | None, object]] = []
     git_calls: list[tuple[list[str], bool]] = []
-    progress_instances: list[object] = []
-
-    class _FakeProgressLine:
-        def __init__(self, *, file: object = None) -> None:
-            self.file = file
-            progress_instances.append(self)
-
-        def update_bar(self, value: float, *, width: int = 20) -> None:
-            progress_updates.append((len(progress_instances) - 1, value))
-
-        def clear(self) -> None:
-            progress_clears.append(len(progress_instances) - 1)
 
     @contextmanager
     def fake_spinner_lines(
@@ -2568,7 +2545,6 @@ def test_cmd_bump_uses_shared_progress_and_inline_lock_spinner(
         lambda root, branch: False,
     )
     monkeypatch.setattr("repo_release_tools.commands.bump.git.current_branch", lambda root: "main")
-    monkeypatch.setattr("repo_release_tools.commands.bump.ProgressLine", _FakeProgressLine)
     monkeypatch.setattr("repo_release_tools.commands.bump.spinner_lines", fake_spinner_lines)
     monkeypatch.setattr("repo_release_tools.commands.bump.git.run", fake_git_run)
     monkeypatch.setattr(
@@ -2592,149 +2568,8 @@ def test_cmd_bump_uses_shared_progress_and_inline_lock_spinner(
     )
 
     assert result == 0
-    assert len(progress_instances) == 2
-    assert progress_updates == [(0, 0.5), (0, 1.0), (1, 0.5), (1, 1.0)]
-    assert (
-        progress_clears == [0, 0, 1, 1]
-    )  # clear() called before second item and again after the final update for each progress instance
     assert spinner_calls == [("Running lock command…", "$ uv lock -U", sys.stdout)]
     assert (["uv", "lock", "-U"], True) in git_calls
-
-
-class _TtyBuffer(io.StringIO):
-    """StringIO that reports itself as an interactive TTY."""
-
-    def isatty(self) -> bool:
-        return True
-
-
-def test_progress_bar_renders_25_50_75_100_on_same_line(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    """25 / 50 / 75 / 100% bar renders each use \\r in-place — no bare \\n between renders.
-
-    The real ``ProgressLine`` is used (not mocked) so that the actual escape-code
-    sequence written to the TTY buffer is verified.  The "same line" property means:
-
-    * Every bar render starts with ``\\r`` (carriage-return overwrite).
-    * The character immediately following each bar render is ``\\r`` (start of
-      the next clear sequence) or end-of-section — never a bare ``\\n``.
-    * Exactly three ``\\r\\x1b[2K`` clear sequences appear (one before each of
-      the 2nd, 3rd, and 4th iteration).
-    """
-    tty = _TtyBuffer()
-
-    targets = [VersionTarget(path=tmp_path / f"file{i}.toml", kind="pep621") for i in range(4)]
-    group = VersionGroup(
-        name="default",
-        release_branch="release/v{version}",
-        changelog_file=tmp_path / "CHANGELOG.md",
-        lock_command=[],
-        generated_files=[],
-        version_targets=targets,
-        pin_targets=[],
-    )
-    config = RrtConfig(
-        root=tmp_path,
-        config_file=tmp_path / ".rrt.toml",
-        version_groups=[group],
-        default_group_name="default",
-    )
-
-    def fake_replace_version(
-        targets: list[VersionTarget],
-        new_version: str,
-        *,
-        dry_run: bool,
-    ) -> list[VersionWriteEvent]:
-        return [
-            VersionWriteEvent(path=target.path, new_version=new_version, dry_run=dry_run)
-            for target in targets
-        ]
-
-    monkeypatch.setattr(
-        "repo_release_tools.commands.bump.load_or_autodetect_config",
-        lambda root: config,
-    )
-    monkeypatch.setattr(
-        "repo_release_tools.commands.bump.read_group_current_version",
-        lambda grp: Version.parse("1.0.0"),
-    )
-    monkeypatch.setattr(
-        "repo_release_tools.commands.bump.replace_all_versions_atomic",
-        fake_replace_version,
-    )
-    monkeypatch.setattr(
-        "repo_release_tools.commands.bump.git.working_tree_clean",
-        lambda root: True,
-    )
-    monkeypatch.setattr(
-        "repo_release_tools.commands.bump.git.branch_exists",
-        lambda root, branch: False,
-    )
-    monkeypatch.setattr("repo_release_tools.commands.bump.git.current_branch", lambda root: "main")
-    monkeypatch.setattr("repo_release_tools.commands.bump.git.run", lambda *a, **kw: "")
-    monkeypatch.setattr(
-        "repo_release_tools.commands.bump.run_preflight",
-        lambda *args, **kwargs: None,
-    )
-    monkeypatch.chdir(tmp_path)
-    # Route all stdout to the TTY buffer so ProgressLine and print() in bump.py
-    # both write to the same captured stream.
-    monkeypatch.setattr(sys, "stdout", tty)
-    # Ensure ProgressLine is not disabled by legacy-terminal detection.
-    monkeypatch.setattr("repo_release_tools.ui.progress.IS_LEGACY_TERMINAL", False)
-
-    result = cmd_bump(
-        Namespace(
-            bump="patch",
-            dry_run=False,
-            force=False,
-            no_commit=True,
-            no_changelog=True,
-            no_update=True,
-            no_pin_sync=True,
-            include_maintenance=False,
-            base_branch=None,
-            group=None,
-        ),
-    )
-
-    assert result == 0
-    raw = tty.getvalue()
-
-    # -- 1. All four expected bar renders appear in order --------------------
-    expected_bars = [
-        f"\r  {output.GLYPHS.progress.render_bar(v)}" for v in [0.25, 0.50, 0.75, 1.00]
-    ]
-    for bar in expected_bars:
-        assert bar in raw, f"Expected bar render not found: {bar!r}"
-
-    positions = [raw.index(b) for b in expected_bars]
-    assert positions == sorted(positions), "Bar renders appeared out of order"
-
-    # -- 2. Each bar render uses \r (same-line overwrite, not a new line) ----
-    for bar in expected_bars:
-        assert bar.startswith("\r"), f"Bar does not start with \\r: {bar!r}"
-
-    # -- 3. Intermediate bars (25/50/75%) are NOT followed by \n ----------------------
-    # They must be overwritten by the next clear() before a new status line is printed.
-    # The final bar (100%) may be followed by \n from the next section header — that
-    # \n comes from print(f"\n{section(...)}"), not from the bar render itself.
-    for bar in expected_bars[:-1]:
-        idx = raw.index(bar)
-        char_after = raw[idx + len(bar) : idx + len(bar) + 1]
-        assert char_after != "\n", (
-            f"Bar render {bar!r} is followed by \\n — it printed on a NEW line"
-        )
-    # The 100% bar itself must not contain a \n (the \n that follows is the section separator).
-    assert "\n" not in expected_bars[-1], "100% bar render itself contains \\n"
-
-    # -- 4. Exactly three clear sequences (one before each of iterations 2/3/4)
-    assert raw.count("\r\x1b[2K") == 4, (
-        f"Expected 4 clear sequences, found {raw.count(chr(13) + chr(27) + '[2K')}"
-    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/commands/test_bump.py
+++ b/tests/commands/test_bump.py
@@ -24,6 +24,7 @@ from repo_release_tools.commands.bump import (
 from repo_release_tools.config import PinTarget, RrtConfig, VersionGroup, VersionTarget
 from repo_release_tools.ui import GLYPHS, render_ok
 from repo_release_tools.version.semver import Version
+from repo_release_tools.version.targets import VersionWriteEvent
 
 # Compatibility shim — maps legacy output.X names to the canonical ui API.
 output = types.SimpleNamespace(
@@ -305,8 +306,12 @@ kind = "package_json"
         new_version: str,
         *,
         dry_run: bool,
-    ) -> None:
+    ) -> list[VersionWriteEvent]:
         version_calls.append((targets, new_version, dry_run))
+        return [
+            VersionWriteEvent(path=t.path, new_version=new_version, dry_run=dry_run)
+            for t in targets
+        ]
 
     monkeypatch.setattr(
         "repo_release_tools.commands.bump.replace_all_versions_atomic",
@@ -391,7 +396,7 @@ kind = "package_json"
     monkeypatch.setattr("repo_release_tools.commands.bump.git.current_branch", lambda root: "main")
     monkeypatch.setattr(
         "repo_release_tools.commands.bump.replace_all_versions_atomic",
-        lambda *a, **k: None,
+        lambda *a, **k: [],
     )
     monkeypatch.setattr("repo_release_tools.commands.bump.update_changelog", lambda *a, **k: None)
 
@@ -475,7 +480,7 @@ kind = "package_json"
     monkeypatch.setattr("repo_release_tools.commands.bump.git.current_branch", lambda root: "main")
     monkeypatch.setattr(
         "repo_release_tools.commands.bump.replace_all_versions_atomic",
-        lambda *a, **k: None,
+        lambda *a, **k: [],
     )
     monkeypatch.setattr("repo_release_tools.commands.bump.update_changelog", lambda *a, **k: None)
 
@@ -2088,7 +2093,7 @@ def test_cmd_bump_defaults_to_generate_for_squash_workflow(
     )
     monkeypatch.setattr(
         "repo_release_tools.commands.bump.replace_all_versions_atomic",
-        lambda target, version, dry_run: None,
+        lambda target, version, dry_run: [],
     )
     monkeypatch.setattr(
         "repo_release_tools.commands.bump.update_changelog",
@@ -2415,7 +2420,7 @@ def test_cmd_bump_deduplicates_pin_updates_and_stage_entries(
     )
     monkeypatch.setattr(
         "repo_release_tools.commands.bump.replace_all_versions_atomic",
-        lambda target, version, dry_run: None,
+        lambda target, version, dry_run: [],
     )
     monkeypatch.setattr(
         "repo_release_tools.commands.bump.replace_pin_in_file",
@@ -2642,9 +2647,11 @@ def test_progress_bar_renders_25_50_75_100_on_same_line(
         new_version: str,
         *,
         dry_run: bool,
-    ) -> None:  # noqa: ARG001
-        for target in targets:
-            print(output.ok(f'{target.path.name}  \u2192  version = "{new_version}"'), file=tty)
+    ) -> list[VersionWriteEvent]:
+        return [
+            VersionWriteEvent(path=target.path, new_version=new_version, dry_run=dry_run)
+            for target in targets
+        ]
 
     monkeypatch.setattr(
         "repo_release_tools.commands.bump.load_or_autodetect_config",

--- a/tests/commands/test_folder_cmd_extra.py
+++ b/tests/commands/test_folder_cmd_extra.py
@@ -39,7 +39,7 @@ class DummyAction:
 
 
 def test_cmd_folder_check_json_ok_and_not_ok(monkeypatch: Any, capsys: Any) -> None:
-    monkeypatch.setattr(folder_mod, "_load_folder_policy_config", lambda: None)
+    monkeypatch.setattr(folder_mod, "_load_folder_policy_config", lambda root: None)
 
     # report.ok == True -> return 0
     monkeypatch.setattr(
@@ -65,7 +65,7 @@ def test_cmd_folder_check_json_ok_and_not_ok(monkeypatch: Any, capsys: Any) -> N
 
 
 def test_cmd_folder_scaffold_json_and_dry_run(monkeypatch: Any, capsys: Any) -> None:
-    monkeypatch.setattr(folder_mod, "_load_folder_policy_config", lambda: None)
+    monkeypatch.setattr(folder_mod, "_load_folder_policy_config", lambda root: None)
     actions = [DummyAction("create", "a.txt", "detail")]
     monkeypatch.setattr(
         folder_mod,
@@ -98,7 +98,7 @@ def test_cmd_folder_design_nonexistent_root(capsys: Any, tmp_path: Any) -> None:
 
 
 def test_cmd_folder_check_human_readable(monkeypatch: Any, capsys: Any) -> None:
-    monkeypatch.setattr(folder_mod, "_load_folder_policy_config", lambda: None)
+    monkeypatch.setattr(folder_mod, "_load_folder_policy_config", lambda root: None)
 
     class V:
         def __init__(self, severity: str, path: str, message: str) -> None:
@@ -134,28 +134,30 @@ def test_cmd_folder_check_human_readable(monkeypatch: Any, capsys: Any) -> None:
     assert "p2: m2" in captured.err
 
 
-def test__load_folder_policy_config_handles_missing_tool(monkeypatch: Any) -> None:
+def test__load_folder_policy_config_handles_missing_tool(monkeypatch: Any, tmp_path: Any) -> None:
     # Simulate load_or_autodetect_config raising ValueError and the helper
     # recognizing it as the "missing rrt tool" case so the loader returns None.
     monkeypatch.setattr(
         folder_mod,
         "load_or_autodetect_config",
-        lambda cwd: (_ for _ in ()).throw(ValueError("no rrt")),
+        lambda root: (_ for _ in ()).throw(ValueError("no rrt")),
     )
     monkeypatch.setattr(folder_mod, "is_missing_tool_rrt_error", lambda exc: True)
-    result = folder_mod._load_folder_policy_config()
+    result = folder_mod._load_folder_policy_config(tmp_path)
     assert result is None
 
 
-def test__load_folder_policy_config_raises_on_other_valueerror(monkeypatch: Any) -> None:
+def test__load_folder_policy_config_raises_on_other_valueerror(
+    monkeypatch: Any, tmp_path: Any
+) -> None:
     monkeypatch.setattr(
         folder_mod,
         "load_or_autodetect_config",
-        lambda cwd: (_ for _ in ()).throw(ValueError("other")),
+        lambda root: (_ for _ in ()).throw(ValueError("other")),
     )
     monkeypatch.setattr(folder_mod, "is_missing_tool_rrt_error", lambda exc: False)
     with pytest.raises(ValueError):
-        folder_mod._load_folder_policy_config()
+        folder_mod._load_folder_policy_config(tmp_path)
 
 
 def test_scaffold_sets_executable(tmp_path: Any) -> None:

--- a/tests/commands/test_workspace.py
+++ b/tests/commands/test_workspace.py
@@ -17,6 +17,7 @@ from repo_release_tools.commands.workspace import (
 from repo_release_tools.config import RrtConfig, VersionGroup, VersionTarget
 from repo_release_tools.version.calver import CalVersion
 from repo_release_tools.version.semver import Version
+from repo_release_tools.version.targets import VersionWriteEvent
 
 
 def _make_pkg_config(pkg_path: Path, version: str = "1.0.0") -> RrtConfig:
@@ -226,8 +227,12 @@ def test_workspace_bump_uses_atomic_version_updates(
         new_version: str,
         *,
         dry_run: bool,
-    ) -> None:
+    ) -> list[VersionWriteEvent]:
         calls.append((targets, new_version, dry_run))
+        return [
+            VersionWriteEvent(path=t.path, new_version=new_version, dry_run=dry_run)
+            for t in targets
+        ]
 
     monkeypatch.setattr(
         "repo_release_tools.commands.workspace.load_or_autodetect_config",

--- a/tests/core/test_state_more.py
+++ b/tests/core/test_state_more.py
@@ -2,7 +2,15 @@ from pathlib import Path
 
 import pytest
 
-from repo_release_tools.state import _dict_to_toml, _toml_value, docs_lock_path
+from repo_release_tools.state import (
+    _dict_to_toml,
+    _toml_value,
+    docs_lock_path,
+    docs_map_lock_path,
+    drift_lock_path,
+    tree_manifest_gz_path,
+    tree_manifest_path,
+)
 
 
 def test_docs_lock_path_variants(tmp_path: Path) -> None:
@@ -17,6 +25,29 @@ def test_docs_lock_path_variants(tmp_path: Path) -> None:
 
     # default uses .rrt/docs.lock.toml
     assert docs_lock_path(root) == root / ".rrt" / "docs.lock.toml"
+
+
+def test_docs_map_lock_path_variants(tmp_path: Path) -> None:
+    root = tmp_path
+    # absolute path returned unchanged
+    abs_path = Path("/tmp/some_map.lock.toml")
+    assert docs_map_lock_path(root, str(abs_path)) == abs_path
+
+    # path starting with .rrt should be joined directly to root
+    p = docs_map_lock_path(root, ".rrt/custom_map.lock.toml")
+    assert p == root / ".rrt" / "custom_map.lock.toml"
+
+    # default uses .rrt/docs_map.lock.toml
+    assert docs_map_lock_path(root) == root / ".rrt" / "docs_map.lock.toml"
+
+
+def test_drift_lock_path(tmp_path: Path) -> None:
+    assert drift_lock_path(tmp_path) == tmp_path / ".rrt" / "drift.lock.toml"
+
+
+def test_tree_manifest_paths(tmp_path: Path) -> None:
+    assert tree_manifest_path(tmp_path) == tmp_path / ".rrt" / "tree.manifest.json"
+    assert tree_manifest_gz_path(tmp_path) == tmp_path / ".rrt" / "tree.manifest.json.gz"
 
 
 def test_toml_value_basic_types() -> None:

--- a/tests/e2e/test_policy_hooks_action.py
+++ b/tests/e2e/test_policy_hooks_action.py
@@ -10,10 +10,11 @@ Pins contract items from ``analysis/the/MODERNIZATION_BRIEF.md`` §5:
 * **C9** — commit-type -> changelog-section mapping (``rrt-hooks update-unreleased`` /
   ``check-changelog``): feat->Added, fix->Fixed, chore->Maintenance (no changelog
   required), ``fix!:``->Breaking Changes, scope rendered bold.
-* **D8** — the GitHub Action's changelog-status grep (``action.yml:130``) is anchored
-  ``^\\[Unreleased\\]`` and therefore never matches a standard ``## [Unreleased]``
-  heading. This is a live (likely unintended) defect, scheduled for a fix in Phase 6a
-  per the brief. Tests here characterize today's behavior only.
+* **D8** — the GitHub Action's changelog-status grep (``action.yml:134``) was anchored
+  ``^\\[Unreleased\\]`` and therefore never matched a standard ``## [Unreleased]``
+  heading. Fixed in Phase 6a to match ``^## \\[Unreleased\\]`` (mirroring
+  ``changelog.py``'s ``_UNRELEASED_HEADER_RE``); tests here now pin the corrected
+  three-way classification.
 
 All tests read the legacy code as an oracle: assertions reflect what
 ``src/repo_release_tools`` actually does today, not what the contract text implies it
@@ -423,52 +424,49 @@ All notable changes to this project will be documented in this file.
 # ---------------------------------------------------------------------------
 
 
-def test_d8_action_grep_pattern_never_matches_keep_a_changelog_heading(e2e_repo: Path) -> None:
-    """D8: the Action's changelog-status grep is anchored ``^\\[Unreleased\\]``.
+def test_d8_action_grep_pattern_matches_keep_a_changelog_heading(e2e_repo: Path) -> None:
+    """D8 (fixed): the Action's changelog-status grep is anchored ``^## \\[Unreleased\\]``.
 
-    # D8: Action grep never matches '## [Unreleased]' — scheduled fix in Phase 6a;
-    # this test documents the current (broken) classification and must be
-    # UPDATED when fixed.
+    # D8: Action grep now matches '## [Unreleased]' — fixed in Phase 6a.
+    # This test documents the corrected classification.
 
-    action.yml:130 runs ``grep -q '^\\[Unreleased\\]' "$changelog_file"`` against a
-    standard Keep-a-Changelog file whose heading is ``## [Unreleased]`` (with a
-    literal ``## `` prefix). The ``^`` anchor plus the missing ``## `` prefix in the
-    pattern means this grep can never match a real Keep-a-Changelog file - it always
-    falls through to the ``else`` branch. This test replicates the exact grep
-    invocation (not a re-implementation) against the harness's standard fixture
-    changelog to pin that observed (mis)behavior.
+    action.yml runs ``grep -q '^## \\[Unreleased\\]' "$changelog_file"`` against a
+    standard Keep-a-Changelog file whose heading is ``## [Unreleased]``. The pattern
+    now includes the literal ``## `` prefix, mirroring ``changelog.py``'s
+    ``_UNRELEASED_HEADER_RE``, so it matches a real Keep-a-Changelog file. This test
+    replicates the exact grep invocation (not a re-implementation) against the
+    harness's standard fixture changelog to pin the corrected behavior.
     """
     changelog_path = e2e_repo / "CHANGELOG.md"
     content = changelog_path.read_text(encoding="utf-8")
     assert "## [Unreleased]" in content, content  # sanity: fixture uses the standard heading
 
     grep_result = subprocess.run(
-        ["grep", "-q", r"^\[Unreleased\]", str(changelog_path)],
+        ["grep", "-q", r"^## \[Unreleased\]", str(changelog_path)],
         cwd=e2e_repo,
         capture_output=True,
         text=True,
         check=False,
     )
-    # `grep -q` exits 1 when no line matches. Pinning the broken-as-designed anchor:
-    assert grep_result.returncode == 1, f"stdout={grep_result.stdout}\nstderr={grep_result.stderr}"
+    # `grep -q` exits 0 when a line matches. Pinning the fixed anchor:
+    assert grep_result.returncode == 0, f"stdout={grep_result.stdout}\nstderr={grep_result.stderr}"
 
 
-def test_d8_action_three_way_classification_reports_clean_for_standard_heading(
+def test_d8_action_three_way_classification_reports_dirty_for_standard_heading(
     e2e_repo: Path,
 ) -> None:
-    """D8: replicating action.yml's surrounding shell logic, a populated [Unreleased]
+    """D8 (fixed): replicating action.yml's surrounding shell logic, a populated
 
-    section is misclassified as ``clean`` (not ``dirty``) because the anchored grep
-    never enters the branch that would count bullets and report ``dirty``.
+    [Unreleased] section is correctly classified as ``dirty`` because the fixed
+    grep pattern now enters the branch that counts bullets.
 
-    # D8: Action grep never matches '## [Unreleased]' — scheduled fix in Phase 6a;
-    # this test documents the current (broken) classification and must be
-    # UPDATED when fixed.
+    # D8: Action grep now matches '## [Unreleased]' — fixed in Phase 6a.
+    # This test documents the corrected classification.
 
-    This replicates action.yml:128-141 verbatim (same grep pattern, same awk
-    counter, same branch structure) against the harness's fixture, which has a
-    non-empty [Unreleased] section (a seed "Added" bullet) — a real user would
-    expect ``dirty`` here, but the Action's own shell logic reports ``clean``.
+    This replicates action.yml's changelog-status logic verbatim (same grep
+    pattern, same awk counter, same branch structure) against the harness's
+    fixture, which has a non-empty [Unreleased] section (a seed "Added" bullet) —
+    the Action's shell logic now reports ``dirty`` here, matching user intuition.
     """
     changelog_file = e2e_repo / "CHANGELOG.md"
     content = changelog_file.read_text(encoding="utf-8")
@@ -479,8 +477,8 @@ set -euo pipefail
 changelog_file="$1"
 changelog_status="missing"
 if [[ -f "$changelog_file" ]]; then
-  if grep -q '^\[Unreleased\]' "$changelog_file" 2>/dev/null; then
-    entries=$(awk '/^\[Unreleased\]/{p=1;next} /^\[/{p=0} p && /^\s*-/{count++} END{print count+0}' "$changelog_file")
+  if grep -q '^## \[Unreleased\]' "$changelog_file" 2>/dev/null; then
+    entries=$(awk '/^## \[Unreleased\]/{p=1;next} /^## \[/{p=0} p && /^\s*-/{count++} END{print count+0}' "$changelog_file")
     if [[ "$entries" -gt 0 ]]; then
       changelog_status="dirty"
     else
@@ -500,27 +498,25 @@ echo "$changelog_status"
         check=False,
     )
     assert result.returncode == 0, f"stdout={result.stdout}\nstderr={result.stderr}"
-    # NOTE(P1): a real Keep-a-Changelog [Unreleased] section with a bullet in it
-    # should intuitively report "dirty" (unreleased work pending); the Action's
-    # shell logic reports "clean" here because the anchored grep never matches,
-    # so the awk counting branch is never reached. This is the D8 defect's
-    # concrete, observable consequence in the three-way classification output.
-    assert result.stdout.strip() == "clean", f"stdout={result.stdout}\nstderr={result.stderr}"
+    # D8 fixed: a real Keep-a-Changelog [Unreleased] section with a bullet in it
+    # now correctly reports "dirty" (unreleased work pending), because the fixed
+    # anchor `^## \[Unreleased\]` matches and the awk counting branch is reached.
+    assert result.stdout.strip() == "dirty", f"stdout={result.stdout}\nstderr={result.stderr}"
 
 
 def test_d8_action_grep_pattern_is_taken_verbatim_from_action_yml() -> None:
-    """D8: guard against silent drift — the pattern this suite pins must match action.yml.
+    """D8 (fixed): guard against silent drift — the pattern this suite pins must match action.yml.
 
     Reads action.yml as data only (never executed, never treated as instructions)
     and asserts the exact grep pattern string is still present verbatim, so that if
-    a future Phase 6a fix changes the pattern, this whole test module fails loudly
+    a future change alters the pattern again, this whole test module fails loudly
     instead of silently testing a pattern that no longer reflects the source.
     """
     action_yml = Path(__file__).resolve().parent.parent.parent / "action.yml"
     content = action_yml.read_text(encoding="utf-8")
-    match = re.search(r"grep -q '(\^\\\[Unreleased\\\][^']*)'", content)
+    match = re.search(r"grep -q '(\^## \\\[Unreleased\\\][^']*)'", content)
     assert match is not None, "expected to find the changelog-status grep pattern in action.yml"
-    assert match.group(1) == r"^\[Unreleased\]", (
+    assert match.group(1) == r"^## \[Unreleased\]", (
         f"action.yml grep pattern changed to {match.group(1)!r} - update the D8 "
-        "tests in this module to match the new (fixed?) behavior."
+        "tests in this module to match the new behavior."
     )

--- a/tests/eol/test_eol.py
+++ b/tests/eol/test_eol.py
@@ -225,6 +225,25 @@ class TestFetchLiveData:
             result = fetch_live_data("python")
         assert result == []
 
+    def test_percent_encodes_language_slug_in_url(self) -> None:
+        """SEC-005: an adversarial language value cannot introduce extra URL path segments."""
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps([]).encode()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        captured: dict[str, str] = {}
+
+        def fake_urlopen(url: str, timeout: int = 10) -> MagicMock:
+            captured["url"] = url
+            return mock_resp
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            fetch_live_data("../../evil")
+
+        assert "/../" not in captured["url"]
+        assert captured["url"] == ("https://endoflife.date/api/v1/products/..%2F..%2Fevil/")
+
 
 # ---------------------------------------------------------------------------
 # check_eol_status

--- a/tests/mcp/test_apps.py
+++ b/tests/mcp/test_apps.py
@@ -373,6 +373,24 @@ def test_rrt_init_run_dry_run(tmp_path: Path) -> None:
     assert mock_run.call_args.kwargs["timeout"] == 20.0
 
 
+def test_rrt_init_run_rejects_unknown_target_without_invoking_subprocess(
+    tmp_path: Path,
+) -> None:
+    """SEC-007: an unallowlisted `target` must never reach subprocess argv."""
+    tools = _registered(tmp_path)
+    ctx = _ctx(tmp_path)
+    mock_run = MagicMock()
+
+    async def _run() -> str:
+        with patch("subprocess.run", mock_run):
+            return await tools["rrt_init_run"](ctx, target="rrt-toml; rm -rf /")
+
+    result = asyncio.run(_run())
+    assert "[error]" in result
+    assert "Invalid target" in result
+    mock_run.assert_not_called()
+
+
 def test_rrt_init_run_apply(tmp_path: Path) -> None:
     tools = _registered(tmp_path)
     ctx = _ctx(tmp_path)

--- a/tests/sync/test_providers.py
+++ b/tests/sync/test_providers.py
@@ -108,6 +108,36 @@ def test_fetch_versions_npm_non_dict_response(monkeypatch: pytest.MonkeyPatch) -
     assert providers.fetch_versions("lodash", "npm") == []
 
 
+def test_fetch_versions_npm_scoped_package_encodes_slash(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SEC-005: a scoped package's '/' separator is percent-encoded as %2F."""
+    payload = {"versions": {"1.0.0": {}}}
+    monkeypatch.setattr(
+        providers.urllib.request,
+        "urlopen",
+        _make_urlopen(payload, assert_url="registry.npmjs.org/@types%2Fnode"),
+    )
+    out = providers.fetch_versions("@types/node", "npm")
+    assert set(out) == {"1.0.0"}
+
+
+def test_fetch_versions_npm_rejects_extra_path_segments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SEC-005: an adversarial package name cannot introduce extra URL path segments."""
+    captured: dict[str, str] = {}
+
+    def fake_urlopen(req: urllib.request.Request, timeout: int = 10) -> _Resp:
+        captured["url"] = req.full_url
+        return _Resp(json.dumps({"versions": {}}).encode())
+
+    monkeypatch.setattr(providers.urllib.request, "urlopen", fake_urlopen)
+    providers.fetch_versions("../../evil", "npm")
+    assert "/../" not in captured["url"]
+    assert captured["url"] == "https://registry.npmjs.org/..%2F..%2Fevil"
+
+
 # ---------------------------------------------------------------------------
 # nuget
 # ---------------------------------------------------------------------------
@@ -166,6 +196,22 @@ def test_fetch_versions_nuget_missing_versions_key(monkeypatch: pytest.MonkeyPat
     assert providers.fetch_versions("Newtonsoft.Json", "nuget") == []
 
 
+def test_fetch_versions_nuget_rejects_extra_path_segments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SEC-005: an adversarial package name cannot introduce extra URL path segments."""
+    captured: dict[str, str] = {}
+
+    def fake_urlopen(req: urllib.request.Request, timeout: int = 10) -> _Resp:
+        captured["url"] = req.full_url
+        return _Resp(json.dumps({"versions": []}).encode())
+
+    monkeypatch.setattr(providers.urllib.request, "urlopen", fake_urlopen)
+    providers.fetch_versions("../../evil", "nuget")
+    assert "/../" not in captured["url"]
+    assert captured["url"] == ("https://api.nuget.org/v3-flatcontainer/..%2F..%2Fevil/index.json")
+
+
 # ---------------------------------------------------------------------------
 # crates
 # ---------------------------------------------------------------------------
@@ -219,6 +265,22 @@ def test_fetch_versions_crates_missing_versions_key(monkeypatch: pytest.MonkeyPa
         _make_urlopen({"crate": {}}),
     )
     assert providers.fetch_versions("serde", "crates") == []
+
+
+def test_fetch_versions_crates_rejects_extra_path_segments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SEC-005: an adversarial package name cannot introduce extra URL path segments."""
+    captured: dict[str, str] = {}
+
+    def fake_urlopen(req: urllib.request.Request, timeout: int = 10) -> _Resp:
+        captured["url"] = req.full_url
+        return _Resp(json.dumps({"versions": []}).encode())
+
+    monkeypatch.setattr(providers.urllib.request, "urlopen", fake_urlopen)
+    providers.fetch_versions("../../evil", "crates")
+    assert "/../" not in captured["url"]
+    assert captured["url"] == ("https://crates.io/api/v1/crates/..%2F..%2Fevil/versions")
 
 
 # ---------------------------------------------------------------------------
@@ -279,6 +341,21 @@ def test_fetch_versions_packagist_missing_versions_key(monkeypatch: pytest.Monke
         _make_urlopen({"package": {"name": "symfony/console"}}),
     )
     assert providers.fetch_versions("symfony/console", "packagist") == []
+
+
+def test_fetch_versions_packagist_percent_encodes_each_segment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SEC-005: each vendor/name segment is percent-encoded; the separator stays literal."""
+    captured: dict[str, str] = {}
+
+    def fake_urlopen(req: urllib.request.Request, timeout: int = 10) -> _Resp:
+        captured["url"] = req.full_url
+        return _Resp(json.dumps({"package": {"versions": {}}}).encode())
+
+    monkeypatch.setattr(providers.urllib.request, "urlopen", fake_urlopen)
+    providers.fetch_versions("vendor name/pkg?name", "packagist")
+    assert captured["url"] == "https://packagist.org/packages/vendor%20name/pkg%3Fname.json"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/version/test_version_targets.py
+++ b/tests/version/test_version_targets.py
@@ -9,6 +9,7 @@ import pytest
 
 from repo_release_tools.config import RrtConfig, VersionGroup, VersionTarget
 from repo_release_tools.version.targets import (
+    VersionWriteEvent,
     _detect_json_indent,
     check_autodetected_version_consistency,
     read_current_version,
@@ -87,9 +88,11 @@ def test_replace_python_version_dry_run_no_write(
     original = '__version__ = "1.0.0"\n'
     f.write_text(original, encoding="utf-8")
     target = VersionTarget(path=f, kind="python_version")
-    replace_version_in_file(target, "1.1.0", dry_run=True)
+    event = replace_version_in_file(target, "1.1.0", dry_run=True)
     assert f.read_text(encoding="utf-8") == original
-    assert "Would update" in capsys.readouterr().out
+    # The write primitive is headless: it returns an event and prints nothing.
+    assert capsys.readouterr().out == ""
+    assert event == VersionWriteEvent(path=f, new_version="1.1.0", dry_run=True)
 
 
 def test_replace_python_version_same_version_raises(tmp_path: Path) -> None:
@@ -221,9 +224,10 @@ def test_replace_go_version_dry_run_no_write(
     original = 'package version\n\nconst Version = "1.0.0"\n'
     f.write_text(original, encoding="utf-8")
     target = VersionTarget(path=f, kind="go_version")
-    replace_version_in_file(target, "2.0.0", dry_run=True)
+    event = replace_version_in_file(target, "2.0.0", dry_run=True)
     assert f.read_text(encoding="utf-8") == original
-    assert "Would update" in capsys.readouterr().out
+    assert capsys.readouterr().out == ""
+    assert event == VersionWriteEvent(path=f, new_version="2.0.0", dry_run=True)
 
 
 # ---------------------------------------------------------------------------
@@ -478,9 +482,10 @@ def test_replace_version_in_file_kind_pattern_dry_run(
     original = 'dependencies = ["ruff==0.15.18"]\n'
     f.write_text(original, encoding="utf-8")
     target = VersionTarget(path=f, kind="pattern", pattern=r'"ruff==(\d+\.\d+\.\d+)"')
-    replace_version_in_file(target, "1.0.0", dry_run=True)
+    event = replace_version_in_file(target, "1.0.0", dry_run=True)
     assert f.read_text(encoding="utf-8") == original  # file unchanged
-    assert "Would update" in capsys.readouterr().out
+    assert capsys.readouterr().out == ""
+    assert event == VersionWriteEvent(path=f, new_version="1.0.0", dry_run=True)
 
 
 def test_replace_all_versions_atomic_kind_pattern(tmp_path: Path) -> None:
@@ -725,11 +730,12 @@ def test_update_version_targets_atomic_dry_run(
     f.write_text('__version__ = "1.0.0"\n', encoding="utf-8")
     target = VersionTarget(path=f, kind="python_version")
 
-    replace_all_versions_atomic([target], "2.0.0", dry_run=True)
+    events = replace_all_versions_atomic([target], "2.0.0", dry_run=True)
 
     # File must NOT be written in dry-run mode
     assert f.read_text() == '__version__ = "1.0.0"\n'
-    assert "2.0.0" in capsys.readouterr().out
+    assert capsys.readouterr().out == ""
+    assert events == [VersionWriteEvent(path=f, new_version="2.0.0", dry_run=True)]
 
 
 def test_update_version_targets_atomic_writes_file(tmp_path: Path) -> None:

--- a/tests/version/test_version_targets.py
+++ b/tests/version/test_version_targets.py
@@ -815,8 +815,8 @@ def test_replace_all_versions_atomic_same_version_raises(tmp_path: Path) -> None
         replace_all_versions_atomic([target], "1.0.0", dry_run=False)
 
 
-def test_replace_all_versions_atomic_rollback_oserror_suppressed(tmp_path: Path) -> None:
-    """Phase-2 write failure triggers rollback; OSError in rollback is silently ignored."""
+def test_replace_all_versions_atomic_rollback_failure_is_surfaced(tmp_path: Path) -> None:
+    """Phase-2 write failure triggers rollback; a failed restore is reported, not swallowed."""
     f1 = tmp_path / "a.py"
     f1.write_text('__version__ = "1.0.0"\n', encoding="utf-8")
     f2 = tmp_path / "b.py"
@@ -843,5 +843,14 @@ def test_replace_all_versions_atomic_rollback_oserror_suppressed(tmp_path: Path)
         _real_write(self, data, encoding=encoding, errors=errors, newline=newline)
 
     with patch.object(Path, "write_text", _write):
-        with pytest.raises(PermissionError, match="disk full"):
+        with pytest.raises(RuntimeError) as exc_info:
             replace_all_versions_atomic([target1, target2], "2.0.0", dry_run=False)
+
+    message = str(exc_info.value)
+    # The original failure and the rollback failure are both surfaced, with the
+    # affected path named, so an operator can find and fix the file by hand.
+    assert "disk full" in message
+    assert "can't restore" in message
+    assert str(f1) in message
+    assert exc_info.value.__cause__ is not None
+    assert isinstance(exc_info.value.__cause__, PermissionError)

--- a/tests/workflow/test_git_helpers.py
+++ b/tests/workflow/test_git_helpers.py
@@ -161,7 +161,7 @@ def test_current_branch_branch_exists_and_commits_ahead_delegate(
     def fake_capture(cmd: list[str], cwd: Path) -> str:
         if cmd == ["git", "branch", "--show-current"]:
             return "feature/current"
-        if cmd == ["git", "branch", "--list", "release/v1.2.3"]:
+        if cmd == ["git", "branch", "--list", "--", "release/v1.2.3"]:
             return "  release/v1.2.3"
         if cmd == ["git", "log", "origin/main..HEAD", "--pretty=format:%h %s"]:
             return "abc123 feat: add parser\n\nxyz789 fix: typo\n"
@@ -175,6 +175,33 @@ def test_current_branch_branch_exists_and_commits_ahead_delegate(
         "abc123 feat: add parser",
         "xyz789 fix: typo",
     ]
+
+
+def test_branch_exists_uses_dashdash_separator(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """SEC-004: a dash-prefixed branch name must not be parsed as a git option."""
+    captured: list[list[str]] = []
+
+    def fake_capture(cmd: list[str], cwd: Path) -> str:
+        captured.append(cmd)
+        return ""
+
+    monkeypatch.setattr(git, "capture", fake_capture)
+
+    assert git.branch_exists(tmp_path, "--force") is False
+    assert captured == [["git", "branch", "--list", "--", "--force"]]
+
+
+def test_commits_ahead_rejects_dash_prefixed_base_ref(tmp_path: Path) -> None:
+    """SEC-004: ``<base_ref>..HEAD`` is a single positional revision-range argument
+
+    that ``--`` cannot safely guard (it would be reinterpreted as a pathspec), so a
+    leading dash is rejected outright instead of reaching the subprocess.
+    """
+    with pytest.raises(ValueError, match=r"base_ref must not start with '-'"):
+        git.commits_ahead(tmp_path, "--output=/tmp/evil")
 
 
 def test_working_tree_clean_and_ahead_behind_handle_multiple_outcomes(
@@ -332,6 +359,23 @@ def test_ref_exists_checks_rev_parse(monkeypatch: pytest.MonkeyPatch, tmp_path: 
     monkeypatch.setattr(subprocess, "run", fake_run)
 
     assert git.ref_exists(tmp_path, "HEAD~1") is True
+
+
+def test_ref_exists_rejects_dash_prefixed_ref_without_invoking_git(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """SEC-004: a dash-prefixed ref must not reach ``git rev-parse --verify``.
+
+    Unlike a plain positional path, ``--`` does not reliably stop option parsing
+    for ``rev-parse``, so a leading dash is rejected before the subprocess call.
+    """
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("git must not run")),
+    )
+
+    assert git.ref_exists(tmp_path, "--output=/tmp/evil") is False
 
 
 def test_in_progress_operation_detects_rebase_and_merge(

--- a/tests/workflow/test_hooks.py
+++ b/tests/workflow/test_hooks.py
@@ -326,7 +326,46 @@ def test_run_update_unreleased_and_changelog_checks(
         == 0
     )
     assert "add parser" in changelog.read_text(encoding="utf-8")
-    assert git_runs == [["git", "add", "CHANGELOG.md"]]
+    assert git_runs == [["git", "add", "--", "CHANGELOG.md"]]
+
+
+def test_run_update_unreleased_uses_dashdash_separator_for_dash_prefixed_filename(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """SEC-004: a config-controlled changelog filename starting with '-' must not be
+
+    interpreted as a git option; the ``--`` separator forces positional treatment.
+    """
+    changelog_name = "-uploads.md"
+    changelog = tmp_path / changelog_name
+    changelog.write_text("# Changelog\n\n## [Unreleased]\n\n", encoding="utf-8")
+
+    monkeypatch.setattr(hooks, "_detect_changelog_workflow", lambda cwd: "incremental")
+    monkeypatch.setattr(hooks, "commit_subject_requires_changelog", lambda subject: True)
+    monkeypatch.setattr(hooks, "is_changelog_meta_commit", lambda subject: False)
+    monkeypatch.setattr(hooks, "detect_changelog_format", lambda changelog_file: "markdown")
+    monkeypatch.setattr(
+        hooks,
+        "append_to_unreleased",
+        lambda content, subject, fmt: content + "### Added\n- add parser\n",
+    )
+    git_runs: list[list[str]] = []
+    monkeypatch.setattr(
+        hooks.git,
+        "run",
+        lambda cmd, cwd, *, dry_run, label: git_runs.append(cmd),
+    )
+
+    assert (
+        hooks.run_update_unreleased(
+            tmp_path,
+            subject="feat: add parser",
+            changelog_file=changelog_name,
+        )
+        == 0
+    )
+    assert git_runs == [["git", "add", "--", changelog_name]]
 
 
 def test_run_changelog_check_covers_non_changelog_and_unreleased_failure(
@@ -1053,7 +1092,43 @@ def test_run_post_correct_commits_when_requested(
         == 0
     )
     assert git_runs == [
-        ["git", "add", "CHANGELOG.md"],
+        ["git", "add", "--", "CHANGELOG.md"],
+        ["git", "commit", "-m", "chore: post-correct changelog after squash merge [skip ci]"],
+    ]
+
+
+def test_run_post_correct_uses_dashdash_separator_for_dash_prefixed_filename(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """SEC-004: a config-controlled changelog filename starting with '-' must not be
+
+    interpreted as a git option when staged after squash post-correction.
+    """
+    changelog_name = "-uploads.md"
+    changelog = tmp_path / changelog_name
+    changelog.write_text("# Changelog\n\n- add x\n- add x\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        hooks,
+        "collect_squash_changelog_hunks",
+        lambda cwd, ref="HEAD", changelog_file=hooks.DEFAULT_CHANGELOG: (
+            ["- add x", "- add x"],
+            frozenset({3, 4}),
+        ),
+    )
+    git_runs: list[list[str]] = []
+    monkeypatch.setattr(
+        hooks.git,
+        "run",
+        lambda cmd, cwd, *, dry_run, label: git_runs.append(cmd),
+    )
+
+    assert (
+        hooks.run_post_correct(tmp_path, ref="HEAD", changelog_file=changelog_name, commit=True)
+        == 0
+    )
+    assert git_runs == [
+        ["git", "add", "--", changelog_name],
         ["git", "commit", "-m", "chore: post-correct changelog after squash merge [skip ci]"],
     ]
 

--- a/tests/workflow/test_hooks.py
+++ b/tests/workflow/test_hooks.py
@@ -106,6 +106,23 @@ def test_path_and_git_helpers_cover_remaining_branches(
     assert hooks.changed_files_for_ref(tmp_path, "HEAD") == ["one", "two"]
 
 
+def test_contained_changelog_path_rejects_escapes(tmp_path: Path) -> None:
+    """SEC-003: ``_contained_changelog_path`` rejects paths that escape cwd."""
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+
+    assert (
+        hooks._contained_changelog_path("CHANGELOG.md", cwd=repo_root)
+        == (repo_root / "CHANGELOG.md").resolve()
+    )
+    assert (
+        hooks._contained_changelog_path("nested/CHANGELOG.md", cwd=repo_root)
+        == (repo_root / "nested" / "CHANGELOG.md").resolve()
+    )
+    assert hooks._contained_changelog_path("../../evil.md", cwd=repo_root) is None
+    assert hooks._contained_changelog_path("../evil.md", cwd=repo_root) is None
+
+
 def test_changelog_requirement_helpers() -> None:
     assert hooks.commit_type_requires_changelog("feat") is True
     assert hooks.commit_type_requires_changelog("chore") is False
@@ -1044,6 +1061,29 @@ def test_run_update_unreleased_handles_missing_file(
     )
 
 
+def test_run_update_unreleased_rejects_path_outside_repo_root(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """SEC-003: a changelog_file that resolves outside cwd must be rejected."""
+    monkeypatch.setattr(hooks, "_detect_changelog_workflow", lambda cwd: "incremental")
+    monkeypatch.setattr(hooks, "commit_subject_requires_changelog", lambda subject: True)
+    monkeypatch.setattr(hooks, "is_changelog_meta_commit", lambda subject: False)
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    outside_target = tmp_path / "evil.md"
+    outside_target.write_text("# outside\n", encoding="utf-8")
+
+    result = hooks.run_update_unreleased(
+        repo_root,
+        subject="feat: add parser",
+        changelog_file="../evil.md",
+    )
+
+    assert result == 1
+    assert outside_target.read_text(encoding="utf-8") == "# outside\n"
+
+
 def test_run_update_unreleased_no_change_path(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -1210,6 +1250,21 @@ def test_run_post_correct_missing_file_and_commit_failure(
         hooks.run_post_correct(tmp_path, ref="HEAD", changelog_file="CHANGELOG.md", commit=True)
         == 1
     )
+
+
+def test_run_post_correct_rejects_path_outside_repo_root(tmp_path: Path) -> None:
+    """SEC-003: a changelog_file that resolves outside cwd must be rejected."""
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    outside_target = tmp_path / "evil.md"
+    outside_target.write_text("# outside\n", encoding="utf-8")
+
+    result = hooks.run_post_correct(
+        repo_root, ref="HEAD", changelog_file="../evil.md", commit=False
+    )
+
+    assert result == 1
+    assert outside_target.read_text(encoding="utf-8") == "# outside\n"
 
 
 def test_main_update_unreleased_uses_message_file_and_commit_editmsg(


### PR DESCRIPTION
## Summary

Merge-order corrective PR. #147 (Phase 1) merged into `main` at 20:13:32, but #148 (Phase 6a) and #149 (Phase 2) were merged into the intermediate branches #147/#148 were stacked on — 52 and 74 seconds *after* #147 already landed on `main`. Since `main` was updated before those two PRs' target branches picked up the new work, and both intermediate branches were auto-deleted post-merge, `main` never actually received Phase 6a or Phase 2. Verified: neither PR's tip commit was an ancestor of `origin/main` (`git merge-base --is-ancestor` both returned false).

This PR carries the same 16 commits (rebased cleanly onto current `main` — no file overlap with what's landed on `main` since #147: just dependency bumps and a coverage-baseline tweak) with no functional changes from the originally-reviewed #148/#149 content:

**Phase 6a — security hardening (8 commits)**
- SEC-001 — `action.yml` env-var indirection instead of inline `${{ inputs.* }}` interpolation
- D8 (approved behavior change) — changelog-status grep corrected to match `## [Unreleased]`; sentinel e2e tests flipped as designed
- SEC-006 — `jq`-built health-summary JSON instead of string interpolation
- SEC-004 — `--` separators / leading-dash guards for git argv positionals
- SEC-003 — changelog paths that escape the repo root are rejected
- SEC-005 — package/slug values percent-encoded before API-URL interpolation
- SEC-007 — MCP `rrt_init_run` target validated against an allowlist

**Phase 2 — cross-cutting seams (8 commits)**
- `version/targets.py` stops printing — returns `VersionWriteEvent`s, rendering moved to `commands/_version_render.py`
- Honest rollback — failed restores are named in a raised error instead of silently swallowed
- Decorative no-op progress bars removed from `cmd_bump`
- All `.rrt/` lock/manifest filenames centralized in `state.py`
- `Path.cwd()` hoisted where genuinely deep (71 → 66), including a latent `--root`-ignoring bug fix in folder-policy loading
- Broad-except narrowing investigated and deliberately deferred (documented in-code)

## Test plan

- [x] `uv run pytest -q -m "not runtime and not e2e"` — 2,922 passed, coverage 100.00%
- [x] `uv run pytest -m e2e --no-cov` — 71 passed
- [x] `uvx pre-commit run --all-files` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjTsHn8U7Lmp9Uax8tNBHG