### PR TITLE
refactor: config field-spec walker + typed Options dataclasses (modernization phase 3)

### DIFF
--- a/.rrt/tree.lock.toml
+++ b/.rrt/tree.lock.toml
@@ -1,10 +1,10 @@
 [meta]
-generated_at = "2026-07-10T15:51:53+00:00"
+generated_at = "2026-07-10T19:55:16+00:00"
 rrt_version = "1.11.2"
 
 [snapshot]
-entry_count = 404
-tree_hash = "sha256:b2e36809441ccedd898f31684d3e4b1777d0b71616eaa3f69be8b9c820b18f1f"
-updated_at = "2026-07-10T15:51:53+00:00"
+entry_count = 405
+tree_hash = "sha256:71defce402a940d53c86424384ed5ec9628779970d8ceb0b706dcd86a028f730"
+updated_at = "2026-07-10T19:55:16+00:00"
 ignored_count = 32
 phantom_empty_dirs = []

--- a/src/repo_release_tools/commands/_common.py
+++ b/src/repo_release_tools/commands/_common.py
@@ -1,0 +1,90 @@
+"""Shared config-loading error handling for `commands/*.py` handlers.
+
+`load_or_autodetect_config` raises three distinct error shapes that every
+command entry point must translate into the same guidance-printing output:
+``FileNotFoundError`` (no supported config file at all), ``ValueError``
+signalling a missing ``[tool.rrt]`` table (checked via
+:func:`~repo_release_tools.config.is_missing_tool_rrt_error`), any other
+``ValueError``, and ``RuntimeError``. Before this module existed, the
+``try/except`` block that renders these four outcomes was copy-pasted with
+small print-call variations across ``bump.py``, ``doctor.py``,
+``release_notes.py``, ``tag.py``, ``release_cmd.py``, ``ci_version.py``, and
+``release_repair.py``.
+
+:func:`describe_config_load_error` centralizes the *decision* (which of the
+four outcomes occurred, and what text/severity it implies) without owning
+*how* the caller prints or returns — call sites differ enough in those two
+respects (some print two lines, some print one; some use ``p.line`` for the
+guidance line, others use ``p.action``/``p.warn``; return values range over
+``int``, ``None``, and a 3-tuple) that forcing a single print routine would
+either drift a call site's exact bytes or require as many parameters as the
+copy-pasted code had branches. Centralizing the *classification* removes all
+of the duplicated ``isinstance``/``is_missing_tool_rrt_error`` branching and
+the repeated `format_missing_tool_rrt_guidance` composition, while leaving
+each call site's existing print calls (already covered by tests asserting
+exact output) untouched in shape.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from repo_release_tools.config import (
+    format_missing_tool_rrt_guidance,
+    is_missing_tool_rrt_error,
+    iter_config_files,
+)
+
+
+@dataclass(frozen=True)
+class ConfigLoadError:
+    """Classified outcome of a failed ``load_or_autodetect_config`` call.
+
+    ``kind`` is one of ``"no_config_file"`` (``FileNotFoundError``),
+    ``"missing_tool_rrt"`` (a ``ValueError`` recognized by
+    :func:`is_missing_tool_rrt_error`), or ``"other"`` (any other
+    ``ValueError`` or a ``RuntimeError``).
+
+    ``text`` is the pre-rendered `format_missing_tool_rrt_guidance` output
+    for ``"no_config_file"``/``"missing_tool_rrt"``, or ``str(exc)`` for
+    ``"other"``. It is always a plain ``str`` (never ``None``) so callers can
+    pass it straight to a printer without an extra narrowing check; which
+    meaning it carries is determined by ``kind``.
+    """
+
+    kind: str
+    text: str
+
+
+def describe_config_load_error(
+    exc: FileNotFoundError | ValueError | RuntimeError,
+    root: Path,
+    *,
+    no_config_file_checked: list[Path] | None = None,
+) -> ConfigLoadError:
+    """Classify an exception raised by ``load_or_autodetect_config(root)``.
+
+    *exc* is one of the three exception types ``load_or_autodetect_config``
+    raises; callers narrow to this union via their own ``except`` clause
+    before calling in, so no other exception type reaches this function.
+
+    *no_config_file_checked* controls the file list passed to
+    `format_missing_tool_rrt_guidance` for the ``FileNotFoundError`` case:
+    most call sites pass ``[]`` (nothing was found so nothing was checked),
+    but ``doctor.py`` and ``tag.py`` pass ``iter_config_files(root)``
+    instead. Defaults to ``[]`` to match the majority (canonical) behavior.
+    Only evaluated for the ``FileNotFoundError`` branch.
+    """
+    if isinstance(exc, FileNotFoundError):
+        checked = no_config_file_checked if no_config_file_checked is not None else []
+        return ConfigLoadError(
+            kind="no_config_file",
+            text=format_missing_tool_rrt_guidance(root, checked),
+        )
+    if isinstance(exc, ValueError) and is_missing_tool_rrt_error(exc):
+        return ConfigLoadError(
+            kind="missing_tool_rrt",
+            text=format_missing_tool_rrt_guidance(root, iter_config_files(root)),
+        )
+    return ConfigLoadError(kind="other", text=str(exc))

--- a/src/repo_release_tools/commands/action_cmd.py
+++ b/src/repo_release_tools/commands/action_cmd.py
@@ -54,6 +54,7 @@ from __future__ import annotations
 
 import argparse
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 from repo_release_tools import __version__
@@ -89,14 +90,47 @@ jobs:
 """
 
 
+@dataclass(frozen=True)
+class InitOptions:
+    """Typed view of ``argparse.Namespace`` for ``rrt action init``.
+
+    Built once via :meth:`from_args` at the top of :func:`cmd_init` so all
+    flags it reads have typed read sites instead of ``getattr(args, ...,
+    default)`` / ``args.x`` calls throughout the function body.
+    """
+
+    dry_run: bool
+    force: bool
+    verbose: int
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> InitOptions:
+        """Build an :class:`InitOptions` from a parsed ``argparse.Namespace``.
+
+        ``dry_run`` and ``force`` are given real defaults by action_cmd.py's
+        own register(), so a Namespace produced by argparse always carries
+        both and they are read directly. ``verbose`` is set globally by
+        cli.py's parser, but every test in tests/commands/test_action_cmd.py
+        that exercises cmd_init calls it with
+        ``Namespace(dry_run=..., force=...)`` that never sets ``verbose``,
+        so the getattr fallback here absorbs that gap.
+        """
+        return cls(
+            dry_run=args.dry_run,
+            force=args.force,
+            verbose=getattr(args, "verbose", 0) or 0,
+        )
+
+
 def cmd_init(args: argparse.Namespace) -> int:
     """Write a starter GitHub Actions workflow using repo-release-tools."""
-    verbose: int = getattr(args, "verbose", 0) or 0
+    opts = InitOptions.from_args(args)
+    verbose = opts.verbose
     root = Path.cwd()
     workflow_path = root / WORKFLOW_PATH
     workflow_text = _workflow_text()
 
-    if workflow_path.exists() and not args.force and not args.dry_run:
+    if workflow_path.exists() and not opts.force and not opts.dry_run:
         p = VerbosePrinter(verbose=verbose)
         p.line(
             f"{WORKFLOW_PATH} already exists. Use --force to overwrite it.",
@@ -105,11 +139,11 @@ def cmd_init(args: argparse.Namespace) -> int:
         )
         return 1
 
-    p = DryRunPrinter(args.dry_run, verbose=verbose)
+    p = DryRunPrinter(opts.dry_run, verbose=verbose)
     p.blank_line()
     p.header("Action init", File=str(WORKFLOW_PATH))
 
-    if args.dry_run:
+    if opts.dry_run:
         p.would_write(str(WORKFLOW_PATH))
         p.section("Preview")
         p.line(highlight_terminal(workflow_text, "yaml"))

--- a/src/repo_release_tools/commands/agents_cmd.py
+++ b/src/repo_release_tools/commands/agents_cmd.py
@@ -46,6 +46,7 @@ import argparse
 import contextlib
 import sys
 from collections.abc import Iterable
+from dataclasses import dataclass
 from pathlib import Path
 
 from repo_release_tools.integrations.agent_assets import BUNDLED_AGENTS, BundledAgent
@@ -127,6 +128,47 @@ def _show_available_install_targets(*, cwd: Path, home: Path) -> None:
     p.footer("pass --target DEST to install (see targets above)")
 
 
+@dataclass(frozen=True)
+class InstallOptions:
+    """Typed view of ``argparse.Namespace`` for ``rrt agents install``.
+
+    Built once via :meth:`from_args` at the top of :func:`cmd_install` so all
+    flags it reads have typed read sites instead of ``getattr(args, ...,
+    default)`` / ``args.x`` calls throughout the function body.
+    """
+
+    targets: list[str] | None
+    agents: list[str] | None
+    dry_run: bool
+    force: bool
+    verbose: int
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> InstallOptions:
+        """Build an :class:`InstallOptions` from a parsed ``argparse.Namespace``.
+
+        ``targets``, ``dry_run``, and ``force`` are given real defaults by
+        agents_cmd.py's own register(), and every test in
+        tests/commands/test_agents_cmd.py that exercises cmd_install
+        constructs its Namespace with all three set explicitly, so they are
+        read directly. ``agents`` is also given a real default (None) by
+        register(), but many tests in tests/commands/test_agents_cmd.py
+        (e.g. test_cmd_install_writes_local_agents,
+        test_cmd_install_no_targets_dry_run_shows_available) build a
+        Namespace that omits ``agents`` entirely, so the getattr fallback
+        here absorbs that gap. ``verbose`` is set globally by cli.py's
+        parser, but no test Namespace here ever sets it, so the getattr
+        fallback here absorbs that gap too.
+        """
+        return cls(
+            targets=args.targets,
+            agents=getattr(args, "agents", None),
+            dry_run=args.dry_run,
+            force=args.force,
+            verbose=getattr(args, "verbose", 0) or 0,
+        )
+
+
 def cmd_install(args: argparse.Namespace) -> int:
     """Install bundled user agents into one or more agent directories.
 
@@ -134,11 +176,12 @@ def cmd_install(args: argparse.Namespace) -> int:
     agent by name. When the requested agent declares a `family:` metadata key,
     the entire family is installed instead.
     """
-    verbose: int = getattr(args, "verbose", 0) or 0
+    opts = InstallOptions.from_args(args)
+    verbose = opts.verbose
     cwd = Path.cwd()
     home = Path.home()
-    if not args.targets:
-        if args.dry_run:
+    if not opts.targets:
+        if opts.dry_run:
             _show_available_install_targets(cwd=cwd, home=home)
             return 0
         available = ", ".join(sorted(AGENT_TARGET_PATHS))
@@ -146,12 +189,12 @@ def cmd_install(args: argparse.Namespace) -> int:
             f"No --target specified. Pass --target DEST (e.g. --target claude-local). Available: {available}.",
         )
 
-    install_plan = _resolve_install_plan(args.targets, cwd=cwd, home=home)
+    install_plan = _resolve_install_plan(opts.targets, cwd=cwd, home=home)
 
     # Determine selected agents based on optional --agent flags.
     selected_agents = list(BUNDLED_AGENTS)
-    if getattr(args, "agents", None):
-        requested_names = args.agents
+    if opts.agents:
+        requested_names = opts.agents
         # Build an ordered, deduplicated selection preserving the canonical order.
         requested_set: set[str] = set()
         interim: list[BundledAgent] = []
@@ -172,7 +215,7 @@ def cmd_install(args: argparse.Namespace) -> int:
                 requested_set.add(a.name)
         selected_agents = ordered
 
-    p = DryRunPrinter(args.dry_run, verbose=verbose)
+    p = DryRunPrinter(opts.dry_run, verbose=verbose)
     p.blank_line()
     p.header(
         "Agent install",
@@ -184,7 +227,7 @@ def cmd_install(args: argparse.Namespace) -> int:
     for target_name, agents_dir in install_plan:
         for agent in selected_agents:
             destination = agents_dir / f"{agent.name}.agent.md"
-            if destination.exists() and not args.force:
+            if destination.exists() and not opts.force:
                 conflicts.append((target_name, agent.name, destination))
 
     if conflicts:
@@ -194,7 +237,7 @@ def cmd_install(args: argparse.Namespace) -> int:
                 f"{target_name} already has {agent_name} at {location}. Use --force to overwrite it.",
             )
 
-    if args.dry_run:
+    if opts.dry_run:
         for target_name, agents_dir in install_plan:
             for agent in selected_agents:
                 destination = agents_dir / f"{agent.name}.agent.md"

--- a/src/repo_release_tools/commands/branch.py
+++ b/src/repo_release_tools/commands/branch.py
@@ -174,21 +174,58 @@ def _count_status_changes(status_lines: list[str]) -> tuple[int, int]:
     return staged, unstaged
 
 
+@dataclass(frozen=True)
+class NewOptions:
+    """Typed view of ``argparse.Namespace`` for ``rrt branch new``.
+
+    Built once via :meth:`from_args` at the top of :func:`cmd_new` so all
+    flags it reads have typed read sites instead of ``getattr(args, ...,
+    default)`` / ``args.x`` calls throughout the function body.
+    """
+
+    type: str
+    description: list[str]
+    scope: str | None
+    dry_run: bool
+    verbose: int
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> NewOptions:
+        """Build a :class:`NewOptions` from a parsed ``argparse.Namespace``.
+
+        ``type``, ``description``, ``scope``, and ``dry_run`` are all
+        positional/required or given real defaults by branch.py's own
+        add_common_branch_arguments(), and every test in
+        tests/commands/test_branch.py that exercises cmd_new sets all four
+        explicitly, so they are read directly. ``verbose`` is set globally by
+        cli.py's parser, but no test Namespace here ever sets it, so the
+        getattr fallback here absorbs that gap.
+        """
+        return cls(
+            type=args.type,
+            description=args.description,
+            scope=args.scope,
+            dry_run=args.dry_run,
+            verbose=getattr(args, "verbose", 0) or 0,
+        )
+
+
 def cmd_new(args: argparse.Namespace) -> int:
     """Create a new branch."""
-    verbose: int = getattr(args, "verbose", 0) or 0
+    opts = NewOptions.from_args(args)
+    verbose = opts.verbose
     root = Path.cwd()
-    description = join_description(args.description)
-    branch = BranchName(type=args.type, description=description, scope=args.scope)
+    description = join_description(opts.description)
+    branch = BranchName(type=opts.type, description=description, scope=opts.scope)
     branch_name = branch.slug()
     commit_title = branch.commit_title()
 
-    base = "<current>" if args.dry_run else git.current_branch(root)
-    p = DryRunPrinter(args.dry_run, verbose=verbose)
+    base = "<current>" if opts.dry_run else git.current_branch(root)
+    p = DryRunPrinter(opts.dry_run, verbose=verbose)
     p.blank_line()
     p.header("New branch", Base=base, Branch=branch_name, Title=commit_title)
 
-    if not args.dry_run and git.branch_exists(root, branch_name):
+    if not opts.dry_run and git.branch_exists(root, branch_name):
         p.line(
             f"Branch '{branch_name}' already exists. Delete it first or choose a different description.",
             ok=False,
@@ -204,14 +241,14 @@ def cmd_new(args: argparse.Namespace) -> int:
     git.run(
         ["git", "checkout", "-b", branch_name],
         root,
-        dry_run=args.dry_run,
+        dry_run=opts.dry_run,
         label="git checkout -b",
     )
 
     if dirty:
         action_text = (
             "Would move uncommitted changes to the new branch."
-            if args.dry_run
+            if opts.dry_run
             else "Uncommitted changes moved to the new branch."
         )
         p.action(action_text)
@@ -226,7 +263,7 @@ def cmd_new(args: argparse.Namespace) -> int:
             p.action(f"…and {len(status_lines) - STATUS_MAX} more")
     else:
         clean_message = (
-            "No uncommitted changes would be moved." if args.dry_run else "Working tree clean."
+            "No uncommitted changes would be moved." if opts.dry_run else "Working tree clean."
         )
         p.ok(clean_message)
 
@@ -249,14 +286,53 @@ def _parse_current_branch(branch: str) -> tuple[str, str]:
     return commit_type, slug
 
 
+@dataclass(frozen=True)
+class RenameOptions:
+    """Typed view of ``argparse.Namespace`` for ``rrt branch rename``.
+
+    Built once via :meth:`from_args` at the top of :func:`cmd_rename` so all
+    flags it reads have typed read sites instead of ``getattr(args, ...,
+    default)`` / ``args.x`` calls throughout the function body.
+    """
+
+    type: str | None
+    scope: str | None
+    no_scope: bool
+    description: list[str]
+    dry_run: bool
+    verbose: int
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> RenameOptions:
+        """Build a :class:`RenameOptions` from a parsed ``argparse.Namespace``.
+
+        ``type``, ``scope``, ``no_scope``, ``description``, and ``dry_run``
+        are all given real defaults by branch.py's own register() for the
+        rename subparser, and every test in tests/commands/test_branch.py
+        that exercises cmd_rename sets all five explicitly, so they are read
+        directly. ``verbose`` is set globally by cli.py's parser, but no
+        test Namespace here ever sets it, so the getattr fallback here
+        absorbs that gap.
+        """
+        return cls(
+            type=args.type,
+            scope=args.scope,
+            no_scope=args.no_scope,
+            description=args.description,
+            dry_run=args.dry_run,
+            verbose=getattr(args, "verbose", 0) or 0,
+        )
+
+
 def cmd_rename(args: argparse.Namespace) -> int:
     """Rename the current branch, changing any combination of type / scope / description."""
-    verbose: int = getattr(args, "verbose", 0) or 0
+    opts = RenameOptions.from_args(args)
+    verbose = opts.verbose
     root = Path.cwd()
-    no_scope: bool = getattr(args, "no_scope", False)
-    new_type_arg: str | None = getattr(args, "type", None)
-    scope: str | None = getattr(args, "scope", None)
-    description_words: list[str] = list(getattr(args, "description", None) or [])
+    no_scope = opts.no_scope
+    new_type_arg = opts.type
+    scope = opts.scope
+    description_words = list(opts.description or [])
 
     # Validate: at least one change must be requested
     if not new_type_arg and not scope and not no_scope and not description_words:
@@ -331,7 +407,7 @@ def cmd_rename(args: argparse.Namespace) -> int:
         )
         return 1
 
-    p = DryRunPrinter(args.dry_run, verbose=verbose)
+    p = DryRunPrinter(opts.dry_run, verbose=verbose)
     p.blank_line()
     p.header(
         "Rename branch",
@@ -342,7 +418,7 @@ def cmd_rename(args: argparse.Namespace) -> int:
         },
     )
 
-    if not args.dry_run:
+    if not opts.dry_run:
         if git.branch_exists(root, new_name):
             p.line(
                 f"Branch '{new_name}' already exists. Delete it first or choose a different name.",
@@ -362,25 +438,64 @@ def cmd_rename(args: argparse.Namespace) -> int:
     return 0
 
 
+@dataclass(frozen=True)
+class RescueOptions:
+    """Typed view of ``argparse.Namespace`` for ``rrt branch rescue``.
+
+    Built once via :meth:`from_args` at the top of :func:`cmd_rescue` so all
+    flags it reads have typed read sites instead of ``getattr(args, ...,
+    default)`` / ``args.x`` calls throughout the function body.
+    """
+
+    type: str
+    description: list[str]
+    scope: str | None
+    dry_run: bool
+    since: str | None
+    verbose: int
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> RescueOptions:
+        """Build a :class:`RescueOptions` from a parsed ``argparse.Namespace``.
+
+        ``type``, ``description``, ``scope``, ``dry_run``, and ``since`` are
+        all positional/required or given real defaults by branch.py's own
+        register() for the rescue subparser, and every test in
+        tests/commands/test_branch.py that exercises cmd_rescue sets all
+        five explicitly, so they are read directly. ``verbose`` is set
+        globally by cli.py's parser, but no test Namespace here ever sets
+        it, so the getattr fallback here absorbs that gap.
+        """
+        return cls(
+            type=args.type,
+            description=args.description,
+            scope=args.scope,
+            dry_run=args.dry_run,
+            since=args.since,
+            verbose=getattr(args, "verbose", 0) or 0,
+        )
+
+
 def cmd_rescue(args: argparse.Namespace) -> int:
     """Rescue commits into a new branch."""
-    verbose: int = getattr(args, "verbose", 0) or 0
+    opts = RescueOptions.from_args(args)
+    verbose = opts.verbose
     root = Path.cwd()
-    description = join_description(args.description)
-    branch = BranchName(type=args.type, description=description, scope=args.scope)
+    description = join_description(opts.description)
+    branch = BranchName(type=opts.type, description=description, scope=opts.scope)
     branch_name = branch.slug()
     commit_title = branch.commit_title()
 
-    origin_branch = "main" if args.dry_run else git.current_branch(root)
-    if args.since:
-        log_lines = [] if args.dry_run else git.commits_ahead(root, args.since)
-        reset_target = args.since
+    origin_branch = "main" if opts.dry_run else git.current_branch(root)
+    if opts.since:
+        log_lines = [] if opts.dry_run else git.commits_ahead(root, opts.since)
+        reset_target = opts.since
     else:
         remote_ref = f"origin/{origin_branch}"
-        log_lines = [] if args.dry_run else git.commits_ahead(root, remote_ref)
+        log_lines = [] if opts.dry_run else git.commits_ahead(root, remote_ref)
         reset_target = remote_ref
 
-    p = DryRunPrinter(args.dry_run, verbose=verbose)
+    p = DryRunPrinter(opts.dry_run, verbose=verbose)
     p.blank_line()
     p.header(
         "Rescue commits",
@@ -389,8 +504,8 @@ def cmd_rescue(args: argparse.Namespace) -> int:
         **{"Reset to": reset_target, "Title": commit_title},
     )
 
-    if not log_lines and not args.dry_run:
-        ref_label = args.since or f"origin/{origin_branch}"
+    if not log_lines and not opts.dry_run:
+        ref_label = opts.since or f"origin/{origin_branch}"
         p.line(
             f"No commits found ahead of '{ref_label}'. Nothing to rescue. Use --since <sha> to override.",
             ok=False,
@@ -403,10 +518,10 @@ def cmd_rescue(args: argparse.Namespace) -> int:
         for line in log_lines:
             p.list_item(line)
     else:
-        ahead = args.since or f"origin/{origin_branch}"
+        ahead = opts.since or f"origin/{origin_branch}"
         p.would_run(f"git log {ahead}..HEAD --oneline")
 
-    if not args.dry_run and git.branch_exists(root, branch_name):
+    if not opts.dry_run and git.branch_exists(root, branch_name):
         p.line(
             f"Branch '{branch_name}' already exists. Delete it first or choose a different description.",
             ok=False,
@@ -419,7 +534,7 @@ def cmd_rescue(args: argparse.Namespace) -> int:
     git.run(
         ["git", "checkout", "-b", branch_name],
         root,
-        dry_run=args.dry_run,
+        dry_run=opts.dry_run,
         label="git checkout -b rescue",
     )
 
@@ -428,13 +543,13 @@ def cmd_rescue(args: argparse.Namespace) -> int:
     git.run(
         ["git", "checkout", origin_branch],
         root,
-        dry_run=args.dry_run,
+        dry_run=opts.dry_run,
         label="git checkout origin",
     )
     git.run(
         ["git", "reset", "--hard", reset_target],
         root,
-        dry_run=args.dry_run,
+        dry_run=opts.dry_run,
         label="git reset --hard",
     )
 
@@ -443,11 +558,11 @@ def cmd_rescue(args: argparse.Namespace) -> int:
     git.run(
         ["git", "checkout", branch_name],
         root,
-        dry_run=args.dry_run,
+        dry_run=opts.dry_run,
         label="git checkout rescue",
     )
 
-    rescued_count = "Selected" if args.dry_run else str(len(log_lines))
+    rescued_count = "Selected" if opts.dry_run else str(len(log_lines))
     p.blank_line()
     p.footer(
         f"Done. {rescued_count} commit(s) rescued into '{branch_name}'. "

--- a/src/repo_release_tools/commands/bump.py
+++ b/src/repo_release_tools/commands/bump.py
@@ -67,6 +67,7 @@ import argparse
 import contextlib
 import dataclasses
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 from repo_release_tools.changelog import (
@@ -268,11 +269,66 @@ def update_changelog(
     p.ok(f"{path} updated")
 
 
+@dataclass(frozen=True)
+class Options:
+    """Typed view of ``argparse.Namespace`` for ``rrt bump``.
+
+    Built once via :meth:`from_args` at the top of :func:`cmd_bump` so every
+    flag has a single, typed read site instead of scattered
+    ``getattr(args, ..., default)`` calls throughout the function body.
+    """
+
+    bump: str
+    group: str | None
+    dry_run: bool
+    force: bool
+    no_commit: bool
+    no_verify: bool
+    no_changelog: bool
+    no_pin_sync: bool
+    no_update: bool
+    include_maintenance: bool
+    changelog_mode: str | None
+    base_branch: str | None
+    calver_scheme: str
+    verbose: int
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> Options:
+        """Build an :class:`Options` from a parsed ``argparse.Namespace``."""
+        # NOTE: every flag below is given a real default by bump.py's own
+        # register() (or, for --verbose, by cli.py's global parser), so a
+        # Namespace produced by argparse always carries every attribute.
+        # The getattr fallbacks here exist only because some unit tests in
+        # tests/commands/test_bump.py construct sparse argparse.Namespace
+        # objects by hand (e.g. Namespace(bump="minor", dry_run=False, ...))
+        # instead of going through register(); this is the single
+        # translation point that absorbs that, so the rest of cmd_bump can
+        # read opts.x unconditionally.
+        return cls(
+            bump=getattr(args, "bump", ""),
+            group=getattr(args, "group", None),
+            dry_run=getattr(args, "dry_run", False),
+            force=getattr(args, "force", False),
+            no_commit=getattr(args, "no_commit", False),
+            no_verify=getattr(args, "no_verify", False),
+            no_changelog=getattr(args, "no_changelog", False),
+            no_pin_sync=getattr(args, "no_pin_sync", False),
+            no_update=getattr(args, "no_update", False),
+            include_maintenance=getattr(args, "include_maintenance", False),
+            changelog_mode=getattr(args, "changelog_mode", None),
+            base_branch=getattr(args, "base_branch", None),
+            calver_scheme=getattr(args, "calver_scheme", "YYYY.MM.DD"),
+            verbose=getattr(args, "verbose", 0) or 0,
+        )
+
+
 def cmd_bump(args: argparse.Namespace) -> int:
     """Bump project version using [tool.rrt]."""
-    verbose: int = getattr(args, "verbose", 0) or 0
+    opts = Options.from_args(args)
+    verbose: int = opts.verbose
     root = find_repo_root(Path.cwd())
-    force = getattr(args, "force", False)
+    force = opts.force
     try:
         config = load_or_autodetect_config(root)
     except (FileNotFoundError, ValueError, RuntimeError) as exc:
@@ -296,7 +352,7 @@ def cmd_bump(args: argparse.Namespace) -> int:
             return 1
 
     try:
-        group = config.resolve_group(args.group)
+        group = config.resolve_group(opts.group)
     except ValueError as exc:
         p = VerbosePrinter(verbose=verbose)
         p.line(str(exc), ok=False, stream=sys.stderr)
@@ -304,8 +360,8 @@ def cmd_bump(args: argparse.Namespace) -> int:
 
     current = read_group_current_version(group)
     _BUMP_KINDS = {"major", "minor", "patch", "pre-release", "calver", *PRE_RELEASE_CHANNELS}
-    if args.bump == "calver":
-        calver_scheme = getattr(args, "calver_scheme", "YYYY.MM.DD")
+    if opts.bump == "calver":
+        calver_scheme = opts.calver_scheme
         try:
             current_calver = CalVersion.parse(str(current))
         except ValueError:
@@ -315,24 +371,24 @@ def cmd_bump(args: argparse.Namespace) -> int:
         else:
             new_str = str(current_calver.bump())
         new = new_str  # type: ignore[assignment]
-    elif args.bump in _BUMP_KINDS:
-        new = current.bump(args.bump)  # type: ignore[assignment]
+    elif opts.bump in _BUMP_KINDS:
+        new = current.bump(opts.bump)  # type: ignore[assignment]
     else:
         try:
-            new = Version.parse(args.bump)  # type: ignore[assignment]
+            new = Version.parse(opts.bump)  # type: ignore[assignment]
         except ValueError:
             try:
-                new = CalVersion.parse(args.bump)  # type: ignore[assignment]
+                new = CalVersion.parse(opts.bump)  # type: ignore[assignment]
             except ValueError:
                 p = VerbosePrinter(verbose=verbose)
-                p.line(f"Invalid bump value: {args.bump!r}", ok=False, stream=sys.stderr)
+                p.line(f"Invalid bump value: {opts.bump!r}", ok=False, stream=sys.stderr)
                 return 1
 
     branch_name = group.release_branch.format(version=new)
-    current_branch = "<current>" if args.dry_run else git.current_branch(root)
-    base = args.base_branch or current_branch
+    current_branch = "<current>" if opts.dry_run else git.current_branch(root)
+    base = opts.base_branch or current_branch
 
-    p = DryRunPrinter(args.dry_run, verbose=verbose)
+    p = DryRunPrinter(opts.dry_run, verbose=verbose)
     p.blank_line()
     p.header(
         "Version bump",
@@ -343,13 +399,13 @@ def cmd_bump(args: argparse.Namespace) -> int:
 
     branch_exists = False
     try:
-        run_preflight(config, dry_run=args.dry_run, group=group)
+        run_preflight(config, dry_run=opts.dry_run, group=group)
     except PreflightError as exc:
         p = VerbosePrinter(verbose=verbose)
         p.line(str(exc), ok=False, stream=sys.stderr)
         return 1
 
-    if not args.dry_run:
+    if not opts.dry_run:
         branch_exists = git.branch_exists(root, branch_name)
         if branch_exists and not force:
             p = VerbosePrinter(verbose=verbose)
@@ -369,20 +425,20 @@ def cmd_bump(args: argparse.Namespace) -> int:
     p.section("Updating version strings")
 
     all_pins = group.pin_targets + config.global_pin_targets
-    no_pin_sync = getattr(args, "no_pin_sync", False)
+    no_pin_sync = opts.no_pin_sync
     if all_pins and not no_pin_sync:
         p.section("Updating doc pins")
 
     # Build a pin-free view when no_pin_sync is set so apply_version skips pins.
     apply_group = dataclasses.replace(group, pin_targets=[]) if no_pin_sync else group
     apply_config = dataclasses.replace(config, global_pin_targets=[]) if no_pin_sync else config
-    changed_paths = apply_version(apply_group, str(new), apply_config, dry_run=args.dry_run)
+    changed_paths = apply_version(apply_group, str(new), apply_config, dry_run=opts.dry_run)
 
-    if not args.no_changelog:
+    if not opts.no_changelog:
         p.section("Updating changelog")
         effective_changelog_mode = resolve_changelog_mode(
             config,
-            getattr(args, "changelog_mode", None),
+            opts.changelog_mode,
         )
         update_changelog(
             RrtConfig(
@@ -392,16 +448,16 @@ def cmd_bump(args: argparse.Namespace) -> int:
                 default_group_name=group.name,
             ),
             str(new),
-            include_maintenance=args.include_maintenance,
-            dry_run=args.dry_run,
+            include_maintenance=opts.include_maintenance,
+            dry_run=opts.dry_run,
             changelog_mode=effective_changelog_mode,
         )
 
-    if group.lock_command and not args.no_update:
+    if group.lock_command and not opts.no_update:
         p.section("Refreshing lockfiles")
         spinner = (
             contextlib.nullcontext()
-            if args.dry_run
+            if opts.dry_run
             else spinner_lines(
                 "Running lock command…",
                 detail=f"$ {' '.join(group.lock_command)}",
@@ -412,18 +468,18 @@ def cmd_bump(args: argparse.Namespace) -> int:
             git.run(
                 group.lock_command,
                 root,
-                dry_run=args.dry_run,
+                dry_run=opts.dry_run,
                 label="lock command",
                 suppress_announce=True,
             )
 
-    if group.generated_assets and not args.no_update:
+    if group.generated_assets and not opts.no_update:
         p.section("Refreshing generated assets")
         for asset in group.generated_assets:
             command_preview = " ".join(asset.command)
             spinner = (
                 contextlib.nullcontext()
-                if args.dry_run
+                if opts.dry_run
                 else spinner_lines(
                     "Running generated asset command…",
                     detail=f"$ {command_preview}",
@@ -435,12 +491,12 @@ def cmd_bump(args: argparse.Namespace) -> int:
                     git.run(
                         asset.command,
                         root,
-                        dry_run=args.dry_run,
+                        dry_run=opts.dry_run,
                         label=f"generated asset command ({asset.path.relative_to(root)})",
                         suppress_announce=True,
                     )
             except RuntimeError as exc:
-                if args.dry_run:
+                if opts.dry_run:
                     p.warn(
                         f"Generated asset command for {asset.path.relative_to(root)} failed in dry-run: {exc}",
                     )
@@ -450,7 +506,7 @@ def cmd_bump(args: argparse.Namespace) -> int:
 
             if not asset.path.exists():
                 message = f"Generated asset {asset.path.relative_to(root)} not found after refresh command"
-                if args.dry_run:
+                if opts.dry_run:
                     p.warn(message)
                 else:
                     p.line(message, ok=False, stream=sys.stderr)
@@ -461,7 +517,7 @@ def cmd_bump(args: argparse.Namespace) -> int:
     git.run(
         ["git", "checkout", create_flag, branch_name],
         root,
-        dry_run=args.dry_run,
+        dry_run=opts.dry_run,
         label=f"git checkout {create_flag}",
     )
 
@@ -473,36 +529,36 @@ def cmd_bump(args: argparse.Namespace) -> int:
     for asset in group.generated_assets:
         if asset.path.exists():
             files_to_stage.append(str(asset.path.relative_to(root)))
-    if group.changelog_file.exists() and not args.no_changelog:
+    if group.changelog_file.exists() and not opts.no_changelog:
         files_to_stage.append(str(group.changelog_file.relative_to(root)))
     git.run(
         ["git", "add", *dict.fromkeys(files_to_stage)],
         root,
-        dry_run=args.dry_run,
+        dry_run=opts.dry_run,
         label="git add",
     )
 
-    if not args.no_commit:
-        git.run(["git", "add", "-u"], root, dry_run=args.dry_run, label="git add -u")
+    if not opts.no_commit:
+        git.run(["git", "add", "-u"], root, dry_run=opts.dry_run, label="git add -u")
         commit_msg = f"chore: bump version to v{new}"
         commit_cmd = ["git", "commit", "-m", commit_msg]
-        if getattr(args, "no_verify", False):
+        if opts.no_verify:
             commit_cmd.append("--no-verify")
         try:
-            git.run(commit_cmd, root, dry_run=args.dry_run, label="git commit")
+            git.run(commit_cmd, root, dry_run=opts.dry_run, label="git commit")
         except RuntimeError:
             # A pre-commit hook (e.g. rrt-cli-docs) may have auto-regenerated
             # files during this pass — pre-commit always fails that pass even
             # though the fix is now correct. Re-stage and retry once.
-            git.run(["git", "add", "-u"], root, dry_run=args.dry_run, label="git add -u")
-            git.run(commit_cmd, root, dry_run=args.dry_run, label="git commit")
+            git.run(["git", "add", "-u"], root, dry_run=opts.dry_run, label="git add -u")
+            git.run(commit_cmd, root, dry_run=opts.dry_run, label="git commit")
         done_msg = f"Done. Branch '{branch_name}' created with commit: {commit_msg!r}"
         p.footer(done_msg)
     else:
         done_msg = f"Done. Branch '{branch_name}' created and files staged."
         p.meta("Base branch", base)
         p.footer(done_msg)
-    if args.dry_run:
+    if opts.dry_run:
         # Provide an explicit dry-run completion line expected by some tests
         p.line("no files were modified")
     return 0

--- a/src/repo_release_tools/commands/bump.py
+++ b/src/repo_release_tools/commands/bump.py
@@ -77,15 +77,14 @@ from repo_release_tools.changelog import (
     insert_generated_section,
     promote_unreleased,
 )
+from repo_release_tools.commands._common import describe_config_load_error
 from repo_release_tools.commands._version_render import render_version_write_events
 from repo_release_tools.config import (
     RrtConfig,
     VersionGroup,
     find_repo_root,
     format_autodetected_config_notice,
-    format_missing_tool_rrt_guidance,
-    is_missing_tool_rrt_error,
-    iter_config_files,
+    iter_config_files,  # noqa: F401 -- re-exported for test monkeypatch compatibility
     load_or_autodetect_config,
 )
 from repo_release_tools.preflight import PreflightError, run_preflight
@@ -276,27 +275,17 @@ def cmd_bump(args: argparse.Namespace) -> int:
     force = getattr(args, "force", False)
     try:
         config = load_or_autodetect_config(root)
-    except FileNotFoundError:
+    except (FileNotFoundError, ValueError, RuntimeError) as exc:
+        err = describe_config_load_error(exc, root)
         p = VerbosePrinter(verbose=verbose)
-        p.line("No supported rrt config file found.", ok=False, stream=sys.stderr)
-        p.line(format_missing_tool_rrt_guidance(root, []), ok=False, stream=sys.stderr)
-        return 1
-    except ValueError as exc:
-        if is_missing_tool_rrt_error(exc):
-            p = VerbosePrinter(verbose=verbose)
+        if err.kind == "no_config_file":
+            p.line("No supported rrt config file found.", ok=False, stream=sys.stderr)
+            p.line(err.text, ok=False, stream=sys.stderr)
+        elif err.kind == "missing_tool_rrt":
             p.line("No [tool.rrt] configuration found.", ok=False, stream=sys.stderr)
-            p.line(
-                format_missing_tool_rrt_guidance(root, iter_config_files(root)),
-                ok=False,
-                stream=sys.stderr,
-            )
-            return 1
-        p = VerbosePrinter(verbose=verbose)
-        p.line(str(exc), ok=False, stream=sys.stderr)
-        return 1
-    except RuntimeError as exc:
-        p = VerbosePrinter(verbose=verbose)
-        p.line(str(exc), ok=False, stream=sys.stderr)
+            p.line(err.text, ok=False, stream=sys.stderr)
+        else:
+            p.line(err.text, ok=False, stream=sys.stderr)
         return 1
 
     if config.autodetected:

--- a/src/repo_release_tools/commands/changelog_compare.py
+++ b/src/repo_release_tools/commands/changelog_compare.py
@@ -61,6 +61,7 @@ import argparse
 import json
 import re
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 from repo_release_tools.changelog import ChangelogFormat, detect_changelog_format
@@ -163,8 +164,41 @@ def _print_comparison(
             write(f"  + (only in {to_ver}) {entry}\n")
 
 
+@dataclass(frozen=True)
+class CompareOptions:
+    """Typed view of ``argparse.Namespace`` for ``rrt changelog compare``.
+
+    Built once via :meth:`from_args` at the top of :func:`cmd_changelog_compare`
+    so all flags it reads have typed read sites instead of
+    ``getattr(args, ..., default)`` calls throughout the function body.
+    """
+
+    from_version: str
+    to_version: str
+    compare_format: str
+    group: str | None
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> CompareOptions:
+        """Build a :class:`CompareOptions` from a parsed ``argparse.Namespace``.
+
+        Every field here is a positional argument or is given a real default
+        by changelog_compare.py's own register_subcommand(), so a Namespace
+        produced by argparse always carries all four. The local ``_args()``
+        helper in tests/commands/test_changelog_compare.py also always sets
+        all four, so no getattr fallback is needed for any field.
+        """
+        return cls(
+            from_version=args.from_version,
+            to_version=args.to_version,
+            compare_format=args.compare_format,
+            group=args.group,
+        )
+
+
 def cmd_changelog_compare(args: argparse.Namespace) -> int:
     """Compare two changelog release sections."""
+    opts = CompareOptions.from_args(args)
     root = find_repo_root(Path.cwd())
     try:
         config: RrtConfig = load_or_autodetect_config(root)
@@ -172,9 +206,8 @@ def cmd_changelog_compare(args: argparse.Namespace) -> int:
         sys.stderr.write(error(f"Could not load rrt config: {exc}") + "\n")
         return 1
 
-    group_name: str | None = getattr(args, "group", None)
     try:
-        group: VersionGroup = config.resolve_group(group_name)
+        group: VersionGroup = config.resolve_group(opts.group)
     except Exception as exc:
         sys.stderr.write(error(str(exc)) + "\n")
         return 1
@@ -187,8 +220,8 @@ def cmd_changelog_compare(args: argparse.Namespace) -> int:
     content = changelog_path.read_text(encoding="utf-8")
     fmt = detect_changelog_format(changelog_path)
 
-    from_ver: str = args.from_version
-    to_ver: str = args.to_version
+    from_ver = opts.from_version
+    to_ver = opts.to_version
 
     from_text = _extract_section_text(content, from_ver, fmt)
     to_text = _extract_section_text(content, to_ver, fmt)
@@ -204,7 +237,7 @@ def cmd_changelog_compare(args: argparse.Namespace) -> int:
 
     diff = _compare_sections(from_sections, to_sections)
 
-    output_format: str = getattr(args, "compare_format", "text")
+    output_format = opts.compare_format
 
     if output_format == "json":
         sys.stdout.write(

--- a/src/repo_release_tools/commands/ci_version.py
+++ b/src/repo_release_tools/commands/ci_version.py
@@ -55,14 +55,12 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+from repo_release_tools.commands._common import describe_config_load_error
 from repo_release_tools.commands._version_render import render_version_write_events
 from repo_release_tools.config import (
     VALID_CI_FORMATS,
     find_repo_root,
     format_autodetected_config_notice,
-    format_missing_tool_rrt_guidance,
-    is_missing_tool_rrt_error,
-    iter_config_files,
     load_or_autodetect_config,
 )
 from repo_release_tools.ui import (
@@ -183,26 +181,17 @@ def _resolve_base(args: argparse.Namespace, root: Path) -> str | None:
                 return None
         group = config.resolve_group(getattr(args, "group", None))
         return str(read_group_current_version(group))
-    except FileNotFoundError:
+    except (FileNotFoundError, ValueError, RuntimeError) as exc:
+        err = describe_config_load_error(exc, root)
         p = VerbosePrinter()
-        p.line("No supported rrt config file found.", ok=False, stream=sys.stderr)
-        p.action(format_missing_tool_rrt_guidance(root, []), stream=sys.stderr)
-        return None
-    except ValueError as exc:
-        if is_missing_tool_rrt_error(exc):
-            p = VerbosePrinter()
+        if err.kind == "no_config_file":
+            p.line("No supported rrt config file found.", ok=False, stream=sys.stderr)
+            p.action(err.text, stream=sys.stderr)
+        elif err.kind == "missing_tool_rrt":
             p.line("No [tool.rrt] configuration found.", ok=False, stream=sys.stderr)
-            p.action(
-                format_missing_tool_rrt_guidance(root, iter_config_files(root)),
-                stream=sys.stderr,
-            )
-            return None
-        p = VerbosePrinter()
-        p.line(str(exc), ok=False, stream=sys.stderr)
-        return None
-    except RuntimeError as exc:
-        p = VerbosePrinter()
-        p.line(str(exc), ok=False, stream=sys.stderr)
+            p.action(err.text, stream=sys.stderr)
+        else:
+            p.line(err.text, ok=False, stream=sys.stderr)
         return None
 
 
@@ -254,26 +243,17 @@ def cmd_ci_version_apply(args: argparse.Namespace) -> int:
             p = VerbosePrinter(verbose=verbose)
             p.line(format_autodetected_config_notice(config), ok=False, stream=sys.stderr)
         group = config.resolve_group(getattr(args, "group", None))
-    except FileNotFoundError:
+    except (FileNotFoundError, ValueError, RuntimeError) as exc:
+        err = describe_config_load_error(exc, root)
         p = VerbosePrinter(verbose=verbose)
-        p.line("No supported rrt config file found.", ok=False, stream=sys.stderr)
-        p.action(format_missing_tool_rrt_guidance(root, []), stream=sys.stderr)
-        return 1
-    except ValueError as exc:
-        if is_missing_tool_rrt_error(exc):
-            p = VerbosePrinter(verbose=verbose)
+        if err.kind == "no_config_file":
+            p.line("No supported rrt config file found.", ok=False, stream=sys.stderr)
+            p.action(err.text, stream=sys.stderr)
+        elif err.kind == "missing_tool_rrt":
             p.line("No [tool.rrt] configuration found.", ok=False, stream=sys.stderr)
-            p.action(
-                format_missing_tool_rrt_guidance(root, iter_config_files(root)),
-                stream=sys.stderr,
-            )
-            return 1
-        p = VerbosePrinter(verbose=verbose)
-        p.line(str(exc), ok=False, stream=sys.stderr)
-        return 1
-    except RuntimeError as exc:
-        p = VerbosePrinter(verbose=verbose)
-        p.line(str(exc), ok=False, stream=sys.stderr)
+            p.action(err.text, stream=sys.stderr)
+        else:
+            p.line(err.text, ok=False, stream=sys.stderr)
         return 1
 
     ci_targets = [t for t in group.version_targets if t.ci_format in VALID_CI_FORMATS]

--- a/src/repo_release_tools/commands/doctor.py
+++ b/src/repo_release_tools/commands/doctor.py
@@ -80,11 +80,10 @@ from repo_release_tools.changelog import (
     detect_changelog_format,
     has_unreleased_section,
 )
+from repo_release_tools.commands._common import describe_config_load_error
 from repo_release_tools.config import (
     find_repo_root,
     format_autodetected_config_notice,
-    format_missing_tool_rrt_guidance,
-    is_missing_tool_rrt_error,
     iter_config_files,
     load_or_autodetect_config,
 )
@@ -295,26 +294,18 @@ def cmd_doctor(args: argparse.Namespace) -> int:
 
     try:
         config = load_or_autodetect_config(root)
-    except FileNotFoundError:
-        checked = iter_config_files(root)
-        p = VerbosePrinter(verbose=verbose)
-        p.line(format_missing_tool_rrt_guidance(root, checked), ok=False, stream=sys.stderr)
+    except FileNotFoundError as exc:
+        err = describe_config_load_error(exc, root, no_config_file_checked=iter_config_files(root))
+        VerbosePrinter(verbose=verbose).line(err.text, ok=False, stream=sys.stderr)
         return 1
-    except ValueError as exc:
-        if is_missing_tool_rrt_error(exc):
-            p = VerbosePrinter(verbose=verbose)
+    except (ValueError, RuntimeError) as exc:
+        err = describe_config_load_error(exc, root)
+        p = VerbosePrinter(verbose=verbose)
+        if err.kind == "missing_tool_rrt":
             p.warn("No [tool.rrt] configuration found.", stream=sys.stderr)
-            p.action(
-                format_missing_tool_rrt_guidance(root, iter_config_files(root)),
-                stream=sys.stderr,
-            )
-            return 1
-        p = VerbosePrinter(verbose=verbose)
-        p.line(str(exc), ok=False, stream=sys.stderr)
-        return 1
-    except RuntimeError as exc:
-        p = VerbosePrinter(verbose=verbose)
-        p.line(str(exc), ok=False, stream=sys.stderr)
+            p.action(err.text, stream=sys.stderr)
+        else:
+            p.line(err.text, ok=False, stream=sys.stderr)
         return 1
 
     p = VerbosePrinter(verbose=verbose)

--- a/src/repo_release_tools/commands/env_cmd.py
+++ b/src/repo_release_tools/commands/env_cmd.py
@@ -48,15 +48,43 @@ import argparse
 import json
 import os
 import sys
+from dataclasses import dataclass
 
 from repo_release_tools.ui import VerbosePrinter
 
 ENV_EPILOG = "  $ rrt env\n  $ rrt env --json"
 
 
+@dataclass(frozen=True)
+class EnvOptions:
+    """Typed view of ``argparse.Namespace`` for ``rrt env``.
+
+    Built once via :meth:`from_args` at the top of :func:`cmd_env` so both
+    flags it reads have typed read sites instead of ``getattr(args, ...,
+    default)`` / ``args.x`` calls throughout the function body.
+    """
+
+    json: bool
+    verbose: int
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> EnvOptions:
+        """Build an :class:`EnvOptions` from a parsed ``argparse.Namespace``.
+
+        ``json`` is given a real default by env_cmd.py's own register(), so a
+        Namespace produced by argparse always carries it and is read
+        directly. ``verbose`` is set globally by cli.py's parser, but every
+        test in tests/commands/test_env_cmd.py that exercises cmd_env calls
+        it with ``argparse.Namespace(json=...)`` that never sets ``verbose``,
+        so the getattr fallback here absorbs that gap.
+        """
+        return cls(json=args.json, verbose=getattr(args, "verbose", 0) or 0)
+
+
 def cmd_env(args: argparse.Namespace) -> int:
     """Render environment details for the current process."""
-    verbose: int = getattr(args, "verbose", 0) or 0
+    opts = EnvOptions.from_args(args)
+    verbose = opts.verbose
     values = [
         ("Platform", sys.platform),
         ("Python", sys.version.split()[0]),
@@ -67,7 +95,7 @@ def cmd_env(args: argparse.Namespace) -> int:
         ("RRT_COLOR", os.environ.get("RRT_COLOR", "<unset>")),
     ]
 
-    if args.json:
+    if opts.json:
         sys.stdout.write(json.dumps(dict(values), indent=2) + "\n")
         return 0
 
@@ -93,13 +121,38 @@ def _find_duplicates(path_value: str) -> list[str]:
     return dups
 
 
+@dataclass(frozen=True)
+class EnvCheckOptions:
+    """Typed view of ``argparse.Namespace`` for ``rrt env check``.
+
+    Built once via :meth:`from_args` at the top of :func:`cmd_env_check` so
+    the single flag it reads has a typed read site instead of a bare
+    ``getattr(args, ..., default)`` call.
+    """
+
+    verbose: int
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> EnvCheckOptions:
+        """Build an :class:`EnvCheckOptions` from a parsed ``argparse.Namespace``.
+
+        ``verbose`` is set globally by cli.py's parser, so a Namespace
+        produced by argparse always carries it. The getattr fallback exists
+        only because every test in tests/commands/test_env_cmd.py that
+        exercises cmd_env_check calls it with
+        ``argparse.Namespace(json=False)`` that never sets ``verbose``.
+        """
+        return cls(verbose=getattr(args, "verbose", 0) or 0)
+
+
 def cmd_env_check(args: argparse.Namespace) -> int:
     """Run a small set of environment sanity checks.
 
     Currently checks for duplicate entries in PATH and PYTHONPATH. Returns
     exit code 0 when no issues are found and 1 when any duplicate is detected.
     """
-    verbose: int = getattr(args, "verbose", 0) or 0
+    opts = EnvCheckOptions.from_args(args)
+    verbose = opts.verbose
 
     p = VerbosePrinter(verbose=verbose)
 

--- a/src/repo_release_tools/commands/git_commit.py
+++ b/src/repo_release_tools/commands/git_commit.py
@@ -128,11 +128,46 @@ def cmd_commit_all(args: argparse.Namespace) -> int:
     return run_commit(args, stage_all=True)
 
 
+@dataclass(frozen=True)
+class SquashLocalOptions:
+    """Typed view of ``argparse.Namespace`` for ``rrt git squash-local``.
+
+    Built once via :meth:`from_args` at the top of :func:`cmd_squash_local` so
+    every flag has a single, typed read site instead of scattered
+    ``getattr(args, ..., default)`` / ``args.x`` calls throughout the
+    function body.
+    """
+
+    base_ref: str | None
+    dry_run: bool
+    verbose: int
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> SquashLocalOptions:
+        """Build a :class:`SquashLocalOptions` from a parsed ``argparse.Namespace``.
+
+        ``base_ref`` and ``dry_run`` are given real defaults by git_commit.py's
+        own register_commit() (squash-local's own parser), so a Namespace produced
+        by argparse always carries both. ``verbose`` is set globally by cli.py's
+        parser, but every test in tests/commands/test_git_commit.py that exercises
+        cmd_squash_local constructs a sparse argparse.Namespace by hand (e.g.
+        Namespace(base_ref=None, description=[...], type="feat", scope=None,
+        breaking=False, dry_run=False)) that never sets ``verbose``, so the
+        getattr fallback here absorbs that gap.
+        """
+        return cls(
+            base_ref=args.base_ref,
+            dry_run=args.dry_run,
+            verbose=getattr(args, "verbose", 0) or 0,
+        )
+
+
 def cmd_squash_local(args: argparse.Namespace) -> int:
     """Squash local commits since a base ref into one conventional commit."""
-    verbose: int = getattr(args, "verbose", 0) or 0
+    opts = SquashLocalOptions.from_args(args)
+    verbose = opts.verbose
     root = Path.cwd()
-    if not args.dry_run and not git.working_tree_clean(root):
+    if not opts.dry_run and not git.working_tree_clean(root):
         p = VerbosePrinter(verbose=verbose)
         p.line(
             "Working tree has uncommitted changes. Commit or stash them first.",
@@ -141,7 +176,7 @@ def cmd_squash_local(args: argparse.Namespace) -> int:
         )
         return 1
 
-    base_ref = args.base_ref or git.upstream_branch(root)
+    base_ref = opts.base_ref or git.upstream_branch(root)
     if base_ref is None:
         p = VerbosePrinter(verbose=verbose)
         p.line(
@@ -178,7 +213,7 @@ def cmd_squash_local(args: argparse.Namespace) -> int:
         )
         return 1
 
-    p = DryRunPrinter(args.dry_run, verbose=verbose)
+    p = DryRunPrinter(opts.dry_run, verbose=verbose)
     p.blank_line()
     p.header(
         "Squash local",
@@ -195,10 +230,10 @@ def cmd_squash_local(args: argparse.Namespace) -> int:
     git.run(
         ["git", "reset", "--soft", squash_base],
         root,
-        dry_run=args.dry_run,
+        dry_run=opts.dry_run,
         label="git reset --soft",
     )
-    git.run(["git", "commit", "-m", subject], root, dry_run=args.dry_run, label="git commit")
+    git.run(["git", "commit", "-m", subject], root, dry_run=opts.dry_run, label="git commit")
 
     p.blank_line()
     p.footer(f"Done. Squashed {len(commits)} commit(s) into {subject!r}.")

--- a/src/repo_release_tools/commands/git_inspect.py
+++ b/src/repo_release_tools/commands/git_inspect.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import argparse
 import re
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 from repo_release_tools.commands._git_shared import (
@@ -73,9 +74,33 @@ def sync_problem(branch_name: str, *, base_ref: str | None, ahead: int, behind: 
     return f"Branch {branch_name!r} is behind {base_ref} by {behind} commit(s). Sync is needed."
 
 
+@dataclass(frozen=True)
+class StatusOptions:
+    """Typed view of ``argparse.Namespace`` for ``rrt git status``.
+
+    Built once via :meth:`from_args` at the top of :func:`cmd_status` so the
+    single flag it reads has a typed read site instead of a bare
+    ``getattr(args, ..., default)`` call.
+    """
+
+    verbose: int
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> StatusOptions:
+        """Build a :class:`StatusOptions` from a parsed ``argparse.Namespace``.
+
+        ``verbose`` is set globally by cli.py's parser, so a Namespace produced
+        by argparse always carries it. The getattr fallback exists only because
+        several tests in tests/commands/test_git_inspect.py call cmd_status with
+        a bare ``argparse.Namespace()`` that never sets ``verbose``.
+        """
+        return cls(verbose=getattr(args, "verbose", 0) or 0)
+
+
 def cmd_status(args: argparse.Namespace) -> int:
     """Show a compact repository status view."""
-    verbose: int = getattr(args, "verbose", 0) or 0
+    opts = StatusOptions.from_args(args)
+    verbose = opts.verbose
     root = Path.cwd()
     if not git.is_git_repository(root):
         p = VerbosePrinter(verbose=verbose)
@@ -114,9 +139,36 @@ def cmd_status(args: argparse.Namespace) -> int:
     return 0
 
 
+@dataclass(frozen=True)
+class LogOptions:
+    """Typed view of ``argparse.Namespace`` for ``rrt git log``.
+
+    Built once via :meth:`from_args` at the top of :func:`cmd_log` so both
+    flags it reads have typed read sites instead of ``getattr(args, ...,
+    default)`` / ``args.x`` calls throughout the function body.
+    """
+
+    verbose: int
+    limit: int
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> LogOptions:
+        """Build a :class:`LogOptions` from a parsed ``argparse.Namespace``.
+
+        ``limit`` is given a real default (10) by git_inspect.py's own
+        register_inspect(), so a Namespace produced by argparse always
+        carries it and is read directly. ``verbose`` is set globally by
+        cli.py's parser, but tests/commands/test_git_inspect.py calls
+        cmd_log with ``argparse.Namespace(limit=...)`` that never sets
+        ``verbose``, so the getattr fallback here absorbs that gap.
+        """
+        return cls(verbose=getattr(args, "verbose", 0) or 0, limit=args.limit)
+
+
 def cmd_log(args: argparse.Namespace) -> int:
     """Show a compact git log view using rrt glyphs."""
-    verbose: int = getattr(args, "verbose", 0) or 0
+    opts = LogOptions.from_args(args)
+    verbose = opts.verbose
     root = Path.cwd()
     if not git.is_git_repository(root):
         p = VerbosePrinter(verbose=verbose)
@@ -124,14 +176,14 @@ def cmd_log(args: argparse.Namespace) -> int:
         return 1
 
     raw = git.capture(
-        ["git", "log", f"-n{args.limit}", "--pretty=format:%h%x09%s%x09%D"],
+        ["git", "log", f"-n{opts.limit}", "--pretty=format:%h%x09%s%x09%D"],
         root,
     )
     lines = [line for line in raw.splitlines() if line.strip()]
 
     p = VerbosePrinter(verbose=verbose)
     p.blank_line()
-    p.header("Git log", Count=str(len(lines)), Limit=str(args.limit))
+    p.header("Git log", Count=str(len(lines)), Limit=str(opts.limit))
 
     if not lines:
         p.warn("No commits found.")
@@ -146,9 +198,40 @@ def cmd_log(args: argparse.Namespace) -> int:
     return 0
 
 
+@dataclass(frozen=True)
+class DoctorOptions:
+    """Typed view of ``argparse.Namespace`` for ``rrt git doctor``.
+
+    Built once via :meth:`from_args` at the top of :func:`cmd_doctor` so both
+    flags it reads have typed read sites instead of ``getattr(args, ...,
+    default)`` / ``args.x`` calls throughout the function body.
+    """
+
+    verbose: int
+    changelog_file: str
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> DoctorOptions:
+        """Build a :class:`DoctorOptions` from a parsed ``argparse.Namespace``.
+
+        ``changelog_file`` is given a real default ("CHANGELOG.md") by
+        git_inspect.py's own register_inspect(), so a Namespace produced by
+        argparse always carries it and is read directly. ``verbose`` is set
+        globally by cli.py's parser, but every test in
+        tests/commands/test_git_inspect.py that exercises cmd_doctor calls it
+        with ``argparse.Namespace(changelog_file="CHANGELOG.md")`` that never
+        sets ``verbose``, so the getattr fallback here absorbs that gap.
+        """
+        return cls(
+            verbose=getattr(args, "verbose", 0) or 0,
+            changelog_file=args.changelog_file,
+        )
+
+
 def cmd_doctor(args: argparse.Namespace) -> int:
     """Run a compact repository health report for rrt workflows."""
-    verbose: int = getattr(args, "verbose", 0) or 0
+    opts = DoctorOptions.from_args(args)
+    verbose = opts.verbose
     root = Path.cwd()
     if not git.is_git_repository(root):
         p = VerbosePrinter(verbose=verbose)
@@ -190,9 +273,9 @@ def cmd_doctor(args: argparse.Namespace) -> int:
             root,
         )
         changed = [line for line in changed_files.splitlines() if line.strip()]
-        if not changelog_is_updated(changed, changelog_file=args.changelog_file, cwd=root):
+        if not changelog_is_updated(changed, changelog_file=opts.changelog_file, cwd=root):
             changelog_problem = (
-                f"Branch {branch_name!r} suggests changelog work, but {args.changelog_file} "
+                f"Branch {branch_name!r} suggests changelog work, but {opts.changelog_file} "
                 "is not part of HEAD."
             )
 
@@ -236,7 +319,7 @@ def cmd_doctor(args: argparse.Namespace) -> int:
         ),
         (
             changelog_problem is None,
-            f"Changelog state is valid for {args.changelog_file}.",
+            f"Changelog state is valid for {opts.changelog_file}.",
             changelog_problem or "",
         ),
     ]
@@ -272,9 +355,34 @@ def cmd_doctor(args: argparse.Namespace) -> int:
     return 1
 
 
+@dataclass(frozen=True)
+class CheckDirtyTreeOptions:
+    """Typed view of ``argparse.Namespace`` for ``rrt git check-dirty-tree``.
+
+    Built once via :meth:`from_args` at the top of :func:`cmd_check_dirty_tree`
+    so the single flag it reads has a typed read site instead of a bare
+    ``getattr(args, ..., default)`` call.
+    """
+
+    verbose: int
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> CheckDirtyTreeOptions:
+        """Build a :class:`CheckDirtyTreeOptions` from a parsed ``argparse.Namespace``.
+
+        ``verbose`` is set globally by cli.py's parser, so a Namespace produced
+        by argparse always carries it. The getattr fallback exists only because
+        several tests in tests/commands/test_git_inspect.py call
+        cmd_check_dirty_tree with a bare ``argparse.Namespace()`` that never
+        sets ``verbose``.
+        """
+        return cls(verbose=getattr(args, "verbose", 0) or 0)
+
+
 def cmd_check_dirty_tree(args: argparse.Namespace) -> int:
     """Return non-zero when the working tree is dirty."""
-    verbose: int = getattr(args, "verbose", 0) or 0
+    opts = CheckDirtyTreeOptions.from_args(args)
+    verbose = opts.verbose
     root = Path.cwd()
     if not git.is_git_repository(root):
         p = VerbosePrinter(verbose=verbose)
@@ -310,9 +418,37 @@ def cmd_check_dirty_tree(args: argparse.Namespace) -> int:
     return 1
 
 
+@dataclass(frozen=True)
+class SyncStatusOptions:
+    """Typed view of ``argparse.Namespace`` for ``rrt git sync-status``.
+
+    Built once via :meth:`from_args` at the top of :func:`cmd_sync_status` so
+    both flags it reads have typed read sites instead of ``getattr(args, ...,
+    default)`` / ``args.x`` calls throughout the function body.
+    """
+
+    verbose: int
+    base_ref: str | None
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> SyncStatusOptions:
+        """Build a :class:`SyncStatusOptions` from a parsed ``argparse.Namespace``.
+
+        ``base_ref`` is given a real default (None) by git_inspect.py's own
+        register_inspect(), so a Namespace produced by argparse always
+        carries it and is read directly. ``verbose`` is set globally by
+        cli.py's parser, but every test in tests/commands/test_git_inspect.py
+        that exercises cmd_sync_status calls it with
+        ``argparse.Namespace(base_ref=...)`` that never sets ``verbose``, so
+        the getattr fallback here absorbs that gap.
+        """
+        return cls(verbose=getattr(args, "verbose", 0) or 0, base_ref=args.base_ref)
+
+
 def cmd_sync_status(args: argparse.Namespace) -> int:
     """Analyze merge/rebase blockers and divergence against a sync base."""
-    verbose: int = getattr(args, "verbose", 0) or 0
+    opts = SyncStatusOptions.from_args(args)
+    verbose = opts.verbose
     root = Path.cwd()
     if not git.is_git_repository(root):
         p = VerbosePrinter(verbose=verbose)
@@ -320,7 +456,7 @@ def cmd_sync_status(args: argparse.Namespace) -> int:
         return 1
 
     branch_name = git.current_branch(root) or "<detached>"
-    base_ref = args.base_ref or git.upstream_branch(root)
+    base_ref = opts.base_ref or git.upstream_branch(root)
     if base_ref is not None and not git.ref_exists(root, base_ref):
         p = VerbosePrinter(verbose=verbose)
         p.line(f"Base ref {base_ref!r} does not exist.", ok=False, stream=sys.stderr)
@@ -422,9 +558,42 @@ def _parse_diff_hunk_header(raw: str) -> tuple[int, int] | None:
     return (int(match.group("old")), int(match.group("new")))
 
 
+@dataclass(frozen=True)
+class DiffOptions:
+    """Typed view of ``argparse.Namespace`` for ``rrt git diff``.
+
+    Built once via :meth:`from_args` at the top of :func:`cmd_diff` so all
+    flags it reads have typed read sites instead of ``getattr(args, ...,
+    default)`` / ``args.x`` calls throughout the function body.
+    """
+
+    verbose: int
+    staged: bool
+    against: str | None
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> DiffOptions:
+        """Build a :class:`DiffOptions` from a parsed ``argparse.Namespace``.
+
+        ``staged`` and ``against`` are given real defaults by git_inspect.py's
+        own register_inspect(), so a Namespace produced by argparse always
+        carries both and they are read directly. ``verbose`` is set globally
+        by cli.py's parser, but every test in
+        tests/commands/test_git_inspect.py that exercises cmd_diff calls it
+        with ``argparse.Namespace(staged=..., against=...)`` that never sets
+        ``verbose``, so the getattr fallback here absorbs that gap.
+        """
+        return cls(
+            verbose=getattr(args, "verbose", 0) or 0,
+            staged=args.staged,
+            against=args.against,
+        )
+
+
 def cmd_diff(args: argparse.Namespace) -> int:
     """Show a compact git diff using DiffGlyphs."""
-    verbose: int = getattr(args, "verbose", 0) or 0
+    opts = DiffOptions.from_args(args)
+    verbose = opts.verbose
     root = Path.cwd()
     if not git.is_git_repository(root):
         p = VerbosePrinter(verbose=verbose)
@@ -432,10 +601,10 @@ def cmd_diff(args: argparse.Namespace) -> int:
         return 1
 
     cmd = ["git", "diff", "--unified=3"]
-    if args.staged:
+    if opts.staged:
         cmd.append("--staged")
-    if args.against:
-        cmd.append(args.against)
+    if opts.against:
+        cmd.append(opts.against)
 
     try:
         raw = git.capture_checked(cmd, root)

--- a/src/repo_release_tools/commands/git_sync.py
+++ b/src/repo_release_tools/commands/git_sync.py
@@ -25,6 +25,7 @@ import argparse
 import datetime as dt
 import shutil
 import sys
+from dataclasses import dataclass
 from fnmatch import fnmatch
 from pathlib import Path
 
@@ -67,9 +68,42 @@ def require_explicit_confirmation(args: argparse.Namespace) -> bool:
     return bool(args.yes_i_know_this_destroys_history)
 
 
+@dataclass(frozen=True)
+class SyncOptions:
+    """Typed view of ``argparse.Namespace`` for ``rrt git sync``.
+
+    Built once via :meth:`from_args` at the top of :func:`cmd_sync` so both
+    flags it reads have typed read sites instead of ``getattr(args, ...,
+    default)`` / ``args.x`` calls throughout the function body.
+    """
+
+    verbose: int
+    merge: bool
+    dry_run: bool
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> SyncOptions:
+        """Build a :class:`SyncOptions` from a parsed ``argparse.Namespace``.
+
+        ``merge`` and ``dry_run`` are given real defaults by git_sync.py's own
+        register_sync(), so a Namespace produced by argparse always carries
+        both and they are read directly. ``verbose`` is set globally by
+        cli.py's parser, but every test in tests/commands/test_git_sync.py
+        that exercises cmd_sync calls it with
+        ``argparse.Namespace(merge=..., dry_run=...)`` that never sets
+        ``verbose``, so the getattr fallback here absorbs that gap.
+        """
+        return cls(
+            verbose=getattr(args, "verbose", 0) or 0,
+            merge=args.merge,
+            dry_run=args.dry_run,
+        )
+
+
 def cmd_sync(args: argparse.Namespace) -> int:
     """Fetch, stash when needed, and pull the current branch."""
-    verbose: int = getattr(args, "verbose", 0) or 0
+    opts = SyncOptions.from_args(args)
+    verbose = opts.verbose
     root = Path.cwd()
     if not git.is_git_repository(root):
         p = VerbosePrinter(verbose=verbose)
@@ -112,8 +146,8 @@ def cmd_sync(args: argparse.Namespace) -> int:
         if len(conflicts) > STATUS_MAX:
             p.action(f"…and {len(conflicts) - STATUS_MAX} more", stream=sys.stderr)
         return 1
-    p = DryRunPrinter(args.dry_run, verbose=verbose)
-    strategy = "merge" if args.merge else "rebase"
+    p = DryRunPrinter(opts.dry_run, verbose=verbose)
+    strategy = "merge" if opts.merge else "rebase"
     p.blank_line()
     p.header(
         "Sync",
@@ -127,23 +161,23 @@ def cmd_sync(args: argparse.Namespace) -> int:
     )
     p.section("Syncing")
     with spinner_lines("Fetching…"):
-        git.run(["git", "fetch", "--prune"], root, dry_run=args.dry_run, label="git fetch")
+        git.run(["git", "fetch", "--prune"], root, dry_run=opts.dry_run, label="git fetch")
     if dirty:
         git.run(
             ["git", "stash", "push", "-u", "-m", SYNC_STASH_MESSAGE],
             root,
-            dry_run=args.dry_run,
+            dry_run=opts.dry_run,
             label="git stash push",
         )
 
     pull_command = ["git", "pull"]
-    if not args.merge:
+    if not opts.merge:
         pull_command.append("--rebase")
 
     try:
-        git.run(pull_command, root, dry_run=args.dry_run, label="git pull")
+        git.run(pull_command, root, dry_run=opts.dry_run, label="git pull")
     except RuntimeError:
-        if dirty and not args.dry_run:
+        if dirty and not opts.dry_run:
             p.line(
                 "Pull failed. The auto-stash remains on the stash stack.",
                 ok=False,
@@ -152,25 +186,60 @@ def cmd_sync(args: argparse.Namespace) -> int:
         raise
 
     if dirty:
-        git.run(["git", "stash", "pop"], root, dry_run=args.dry_run, label="git stash pop")
+        git.run(["git", "stash", "pop"], root, dry_run=opts.dry_run, label="git stash pop")
 
     p.blank_line()
     p.footer(f"Done. {branch_name} is synced from {upstream} using {strategy}.")
     return 0
 
 
+@dataclass(frozen=True)
+class MoveOptions:
+    """Typed view of ``argparse.Namespace`` for ``rrt git move``.
+
+    Built once via :meth:`from_args` at the top of :func:`cmd_move` so all
+    flags it reads have typed read sites instead of ``getattr(args, ...,
+    default)`` / ``args.x`` calls throughout the function body.
+    """
+
+    verbose: int
+    target: str
+    create: bool
+    dry_run: bool
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> MoveOptions:
+        """Build a :class:`MoveOptions` from a parsed ``argparse.Namespace``.
+
+        ``target``, ``create``, and ``dry_run`` are given real values/defaults
+        by git_sync.py's own register_sync(), so a Namespace produced by
+        argparse always carries all three and they are read directly.
+        ``verbose`` is set globally by cli.py's parser, but every test in
+        tests/commands/test_git_sync.py that exercises cmd_move calls it with
+        ``argparse.Namespace(target=..., create=..., dry_run=...)`` that
+        never sets ``verbose``, so the getattr fallback here absorbs that gap.
+        """
+        return cls(
+            verbose=getattr(args, "verbose", 0) or 0,
+            target=args.target,
+            create=args.create,
+            dry_run=args.dry_run,
+        )
+
+
 def cmd_move(args: argparse.Namespace) -> int:
     """Switch branches safely by stashing and restoring local changes."""
-    verbose: int = getattr(args, "verbose", 0) or 0
+    opts = MoveOptions.from_args(args)
+    verbose = opts.verbose
     root = Path.cwd()
     if not git.is_git_repository(root):
         p = VerbosePrinter(verbose=verbose)
         p.line(f"{root} is not inside a Git work tree.", ok=False, stream=sys.stderr)
         return 1
-    p = DryRunPrinter(args.dry_run, verbose=verbose)
+    p = DryRunPrinter(opts.dry_run, verbose=verbose)
     current = git.current_branch(root) or "<detached>"
     dirty = not git.working_tree_clean(root)
-    target_label = f"new branch {args.target}" if args.create else args.target
+    target_label = f"new branch {opts.target}" if opts.create else opts.target
     p.blank_line()
     p.header(
         "Move",
@@ -183,17 +252,17 @@ def cmd_move(args: argparse.Namespace) -> int:
         git.run(
             ["git", "stash", "push", "-u", "-m", MOVE_STASH_MESSAGE],
             root,
-            dry_run=args.dry_run,
+            dry_run=opts.dry_run,
             label="git stash push",
         )
 
     checkout = (
-        ["git", "checkout", "-b", args.target] if args.create else ["git", "checkout", args.target]
+        ["git", "checkout", "-b", opts.target] if opts.create else ["git", "checkout", opts.target]
     )
     try:
-        git.run(checkout, root, dry_run=args.dry_run, label="git checkout")
+        git.run(checkout, root, dry_run=opts.dry_run, label="git checkout")
     except RuntimeError:
-        if dirty and not args.dry_run:
+        if dirty and not opts.dry_run:
             p.line(
                 "Branch switch failed. The auto-stash remains on the stash stack.",
                 ok=False,
@@ -202,39 +271,138 @@ def cmd_move(args: argparse.Namespace) -> int:
         raise
 
     if dirty:
-        git.run(["git", "stash", "pop"], root, dry_run=args.dry_run, label="git stash pop")
+        git.run(["git", "stash", "pop"], root, dry_run=opts.dry_run, label="git stash pop")
 
     p.blank_line()
-    p.footer(f"Done. Switched to {args.target!r}.")
+    p.footer(f"Done. Switched to {opts.target!r}.")
     return 0
+
+
+@dataclass(frozen=True)
+class UndoSafeOptions:
+    """Typed view of ``argparse.Namespace`` for ``rrt git undo-safe``.
+
+    Built once via :meth:`from_args` at the top of :func:`cmd_undo_safe` so
+    all flags it reads have typed read sites instead of ``getattr(args, ...,
+    default)`` / ``args.x`` calls throughout the function body.
+    """
+
+    verbose: int
+    target: str
+    keep_staged: bool
+    dry_run: bool
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> UndoSafeOptions:
+        """Build an :class:`UndoSafeOptions` from a parsed ``argparse.Namespace``.
+
+        ``target``, ``keep_staged``, and ``dry_run`` are given real
+        values/defaults by git_sync.py's own register_sync(), so a Namespace
+        produced by argparse always carries all three and they are read
+        directly. ``verbose`` is set globally by cli.py's parser, but every
+        test in tests/commands/test_git_sync.py that exercises
+        cmd_undo_safe calls it with
+        ``argparse.Namespace(target=..., keep_staged=..., dry_run=...)`` that
+        never sets ``verbose``, so the getattr fallback here absorbs that gap.
+        """
+        return cls(
+            verbose=getattr(args, "verbose", 0) or 0,
+            target=args.target,
+            keep_staged=args.keep_staged,
+            dry_run=args.dry_run,
+        )
 
 
 def cmd_undo_safe(args: argparse.Namespace) -> int:
     """Undo the last commit while keeping work in the index or working tree."""
-    verbose: int = getattr(args, "verbose", 0) or 0
-    mode = "--soft" if args.keep_staged else "--mixed"
-    p = DryRunPrinter(args.dry_run, verbose=verbose)
+    opts = UndoSafeOptions.from_args(args)
+    verbose = opts.verbose
+    mode = "--soft" if opts.keep_staged else "--mixed"
+    p = DryRunPrinter(opts.dry_run, verbose=verbose)
     p.blank_line()
     p.header(
         "Undo safe",
-        Target=args.target,
-        Mode="keep staged" if args.keep_staged else "keep files",
+        Target=opts.target,
+        Mode="keep staged" if opts.keep_staged else "keep files",
     )
 
     git.run(
-        ["git", "reset", mode, args.target],
+        ["git", "reset", mode, opts.target],
         Path.cwd(),
-        dry_run=args.dry_run,
+        dry_run=opts.dry_run,
         label="git reset",
     )
     p.blank_line()
-    p.footer(f"Done. Reset to {args.target!r} using {mode}.")
+    p.footer(f"Done. Reset to {opts.target!r} using {mode}.")
     return 0
+
+
+@dataclass(frozen=True)
+class RebootstrapOptions:
+    """Typed view of ``argparse.Namespace`` for ``rrt git rebootstrap``.
+
+    Built once via :meth:`from_args` at the top of :func:`cmd_rebootstrap` so
+    all flags it reads have typed read sites instead of ``getattr(args, ...,
+    default)`` / ``args.x`` calls throughout the function body.
+    """
+
+    verbose: int
+    yes_i_know_this_destroys_history: bool
+    hard_init: bool
+    empty_first: bool
+    allow_remote: bool
+    branch: str | None
+    message: str | None
+    empty_message: str
+    dry_run: bool
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> RebootstrapOptions:
+        """Build a :class:`RebootstrapOptions` from a parsed ``argparse.Namespace``.
+
+        Every flag other than ``yes_i_know_this_destroys_history`` and
+        ``verbose`` is given a real value/default by git_sync.py's own
+        register_sync(), so a Namespace produced by argparse always carries
+        it. But cmd_rebootstrap's original body only reads
+        ``yes_i_know_this_destroys_history`` before its first early return
+        (the missing-confirmation guard) and reads every other field only
+        after that guard passes. tests/commands/test_git_sync.py exploits
+        that short-circuit: test_cmd_rebootstrap_requires_confirmation and
+        test_cmd_rebootstrap_rejects_missing_git_dir construct
+        ``argparse.Namespace(yes_i_know_this_destroys_history=False)`` (the
+        second one has no attributes at all reachable before the git_dir
+        check), omitting hard_init/empty_first/allow_remote/branch/message/
+        empty_message/dry_run entirely. Since Options is built eagerly at
+        the top of cmd_rebootstrap -- before that guard runs -- every field
+        needs a getattr fallback to preserve the original lazy-access
+        behavior; the guard itself still runs first inside cmd_rebootstrap
+        and returns before any of these defaulted values would be used.
+        """
+        return cls(
+            verbose=getattr(args, "verbose", 0) or 0,
+            yes_i_know_this_destroys_history=getattr(
+                args,
+                "yes_i_know_this_destroys_history",
+                False,
+            ),
+            hard_init=getattr(args, "hard_init", False),
+            empty_first=getattr(args, "empty_first", False),
+            allow_remote=getattr(args, "allow_remote", False),
+            branch=getattr(args, "branch", None),
+            message=getattr(args, "message", None),
+            empty_message=getattr(
+                args,
+                "empty_message",
+                DEFAULT_REBOOTSTRAP_EMPTY_MESSAGE,
+            ),
+            dry_run=getattr(args, "dry_run", False),
+        )
 
 
 def cmd_rebootstrap(args: argparse.Namespace) -> int:
     """Remove repository history and create a fresh initial history."""
-    verbose: int = getattr(args, "verbose", 0) or 0
+    opts = RebootstrapOptions.from_args(args)
+    verbose = opts.verbose
     root = Path.cwd()
     git_dir = git.git_dir(root) or (root / ".git")
     if not git_dir.exists():
@@ -250,13 +418,13 @@ def cmd_rebootstrap(args: argparse.Namespace) -> int:
         )
         return 1
 
-    if args.hard_init and args.empty_first:
+    if opts.hard_init and opts.empty_first:
         p = VerbosePrinter(verbose=verbose)
         p.line("Use either --hard-init or --empty-first, not both.", ok=False, stream=sys.stderr)
         return 1
 
     remotes = git.remote_names(root)
-    if remotes and not args.allow_remote:
+    if remotes and not opts.allow_remote:
         p = VerbosePrinter(verbose=verbose)
         p.line(
             "Refusing to rebootstrap a repository with configured remotes. Use --allow-remote if that is intentional.",
@@ -265,44 +433,44 @@ def cmd_rebootstrap(args: argparse.Namespace) -> int:
         )
         return 1
 
-    branch_name = args.branch or git.current_branch(root) or "main"
+    branch_name = opts.branch or git.current_branch(root) or "main"
     backup_path = backup_path_for_git_dir(root)
-    commit_message = args.message
+    commit_message = opts.message
     if commit_message is None:
         commit_message = (
-            DEFAULT_REBOOTSTRAP_EMPTY_MESSAGE if args.hard_init else DEFAULT_REBOOTSTRAP_MESSAGE
+            DEFAULT_REBOOTSTRAP_EMPTY_MESSAGE if opts.hard_init else DEFAULT_REBOOTSTRAP_MESSAGE
         )
-    p = DryRunPrinter(args.dry_run, verbose=verbose)
+    p = DryRunPrinter(opts.dry_run, verbose=verbose)
     p.blank_line()
     p.header(
         "Rebootstrap history",
         Branch=branch_name,
-        Mode="empty hard-init" if args.hard_init else "snapshot current files",
+        Mode="empty hard-init" if opts.hard_init else "snapshot current files",
         Backup=str(backup_path),
         **{
-            "Remote guard": "ignored" if args.allow_remote else "enabled",
+            "Remote guard": "ignored" if opts.allow_remote else "enabled",
             "Commit": commit_message,
         },
     )
     p.section("Reinitializing")
-    if args.dry_run:
+    if opts.dry_run:
         p.would_run(f"mv {git_dir} {backup_path}")
         git.run(["git", "init", "-b", branch_name], root, dry_run=True, label="git init")
-        if args.hard_init:
+        if opts.hard_init:
             git.run(
                 ["git", "commit", "--allow-empty", "-m", commit_message],
                 root,
                 dry_run=True,
                 label="git commit --allow-empty",
             )
-        elif args.empty_first:
+        elif opts.empty_first:
             git.run(
-                ["git", "commit", "--allow-empty", "-m", args.empty_message],
+                ["git", "commit", "--allow-empty", "-m", opts.empty_message],
                 root,
                 dry_run=True,
                 label="git commit --allow-empty",
             )
-        if not args.hard_init:
+        if not opts.hard_init:
             git.run(["git", "add", "."], root, dry_run=True, label="git add")
             git.run(["git", "commit", "-m", commit_message], root, dry_run=True, label="git commit")
         p.footer("Done. Reinit preview complete.")
@@ -313,21 +481,21 @@ def cmd_rebootstrap(args: argparse.Namespace) -> int:
 
     try:
         git.run(["git", "init", "-b", branch_name], root, dry_run=False, label="git init")
-        if args.hard_init:
+        if opts.hard_init:
             git.run(
                 ["git", "commit", "--allow-empty", "-m", commit_message],
                 root,
                 dry_run=False,
                 label="git commit --allow-empty",
             )
-        elif args.empty_first:
+        elif opts.empty_first:
             git.run(
-                ["git", "commit", "--allow-empty", "-m", args.empty_message],
+                ["git", "commit", "--allow-empty", "-m", opts.empty_message],
                 root,
                 dry_run=False,
                 label="git commit --allow-empty",
             )
-        if not args.hard_init:
+        if not opts.hard_init:
             git.run(["git", "add", "."], root, dry_run=False, label="git add")
             git.run(
                 ["git", "commit", "-m", commit_message],
@@ -346,7 +514,7 @@ def cmd_rebootstrap(args: argparse.Namespace) -> int:
         return 1
 
     p.blank_line()
-    if args.hard_init:
+    if opts.hard_init:
         p.ok(f"Done. Repository history hard-initialized on {branch_name!r}.")
     else:
         p.ok(f"Done. Repository history reinitialized on {branch_name!r}.")
@@ -354,9 +522,37 @@ def cmd_rebootstrap(args: argparse.Namespace) -> int:
     return 0
 
 
+@dataclass(frozen=True)
+class PurgeCacheOptions:
+    """Typed view of ``argparse.Namespace`` for ``rrt git purge-cache``.
+
+    Built once via :meth:`from_args` at the top of :func:`cmd_purge_cache` so
+    the flag it reads has a typed read site instead of a bare
+    ``getattr(args, ..., default)`` call.
+    """
+
+    verbose: int
+    dry_run: bool
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> PurgeCacheOptions:
+        """Build a :class:`PurgeCacheOptions` from a parsed ``argparse.Namespace``.
+
+        ``dry_run`` is given a real default by git_sync.py's own
+        register_sync(), so a Namespace produced by argparse always carries
+        it and is read directly. ``verbose`` is set globally by cli.py's
+        parser, but every test in tests/commands/test_git_sync.py that
+        exercises cmd_purge_cache calls it with
+        ``argparse.Namespace(dry_run=...)`` that never sets ``verbose``, so
+        the getattr fallback here absorbs that gap.
+        """
+        return cls(verbose=getattr(args, "verbose", 0) or 0, dry_run=args.dry_run)
+
+
 def cmd_purge_cache(args: argparse.Namespace) -> int:
     """Expire reflogs and run git garbage collection."""
-    verbose: int = getattr(args, "verbose", 0) or 0
+    opts = PurgeCacheOptions.from_args(args)
+    verbose = opts.verbose
     root = Path.cwd()
     if not git.is_git_repository(root):
         p = VerbosePrinter(verbose=verbose)
@@ -364,7 +560,7 @@ def cmd_purge_cache(args: argparse.Namespace) -> int:
         return 1
 
     dirty = not git.working_tree_clean(root)
-    p = DryRunPrinter(args.dry_run, verbose=verbose)
+    p = DryRunPrinter(opts.dry_run, verbose=verbose)
     p.blank_line()
     p.header(
         "Purge cache",
@@ -380,36 +576,92 @@ def cmd_purge_cache(args: argparse.Namespace) -> int:
     git.run(
         ["git", "reflog", "expire", "--expire=now", "--all"],
         root,
-        dry_run=args.dry_run,
+        dry_run=opts.dry_run,
         label="git reflog expire",
     )
-    git.run(["git", "gc", "--prune=now"], root, dry_run=args.dry_run, label="git gc")
+    git.run(["git", "gc", "--prune=now"], root, dry_run=opts.dry_run, label="git gc")
 
     p.blank_line()
     p.footer("Done. Git cache maintenance complete.")
     return 0
 
 
+@dataclass(frozen=True)
+class PublishSnapshotOptions:
+    """Typed view of ``argparse.Namespace`` for ``rrt git publish-snapshot``.
+
+    Built once via :meth:`from_args` at the top of :func:`cmd_publish_snapshot`
+    so all flags it reads have typed read sites instead of
+    ``getattr(args, ..., default)`` / ``args.x`` calls throughout the
+    function body.
+    """
+
+    verbose: int
+    target: str | None
+    remote: str | None
+    branch: str | None
+    message: str | None
+    exclude: tuple[str, ...]
+    yes_i_know_this_overwrites_remote_history: bool
+    dry_run: bool
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> PublishSnapshotOptions:
+        """Build a :class:`PublishSnapshotOptions` from a parsed ``argparse.Namespace``.
+
+        Both `workflow/hooks.py`'s "publish-snapshot" case and git_sync.py's
+        own register_sync() define an identical publish-snapshot flag set
+        (target, --remote, --branch, --message, --exclude,
+        --yes-i-know-this-overwrites-remote-history, --dry-run), verified by
+        diffing the two parsers field-for-field, so ``target``, ``remote``,
+        ``branch``, ``message``, ``yes_i_know_this_overwrites_remote_history``,
+        and ``dry_run`` are read directly with no fallback needed for either
+        caller. ``exclude`` still needs a getattr fallback: real argparse
+        (both hooks.py's and git_sync.py's parsers) defaults it to ``None``
+        via ``action="append", default=None``, and several tests in
+        tests/commands/test_git_sync.py (e.g.
+        test_publish_snapshot_aborts_when_remote_equals_origin) construct a
+        sparse argparse.Namespace that omits ``exclude`` entirely. ``verbose``
+        is set globally by cli.py's parser (and explicitly by hooks.py before
+        calling cmd_publish_snapshot), but every test in
+        tests/commands/test_git_sync.py that exercises cmd_publish_snapshot
+        never sets it, so the getattr fallback here absorbs that gap too.
+        """
+        return cls(
+            verbose=getattr(args, "verbose", 0) or 0,
+            target=args.target,
+            remote=args.remote,
+            branch=args.branch,
+            message=args.message,
+            exclude=tuple(getattr(args, "exclude", None) or ()),
+            yes_i_know_this_overwrites_remote_history=bool(
+                args.yes_i_know_this_overwrites_remote_history,
+            ),
+            dry_run=args.dry_run,
+        )
+
+
 def cmd_publish_snapshot(args: argparse.Namespace) -> int:
     """Force-push a single-commit snapshot of tracked content to a secondary remote."""
-    verbose: int = getattr(args, "verbose", 0) or 0
+    opts = PublishSnapshotOptions.from_args(args)
+    verbose = opts.verbose
     root = Path.cwd()
     if not git.is_git_repository(root):
         p = VerbosePrinter(verbose=verbose)
         p.line(f"{root} is not inside a Git work tree.", ok=False, stream=sys.stderr)
         return 1
 
-    remote = args.remote
-    branch = args.branch
-    message = args.message
-    exclude_patterns = tuple(getattr(args, "exclude", None) or ())
-    if getattr(args, "target", None):
+    remote = opts.remote
+    branch = opts.branch
+    message = opts.message
+    exclude_patterns = opts.exclude
+    if opts.target:
         config = load_or_autodetect_config(root)
-        target = config.publish_targets.get(args.target)
+        target = config.publish_targets.get(opts.target)
         if target is None:
             p = VerbosePrinter(verbose=verbose)
             p.line(
-                f"No publish target named {args.target!r} in [tool.rrt.publish_targets].",
+                f"No publish target named {opts.target!r} in [tool.rrt.publish_targets].",
                 ok=False,
                 stream=sys.stderr,
             )
@@ -443,8 +695,8 @@ def cmd_publish_snapshot(args: argparse.Namespace) -> int:
         )
         return 1
 
-    confirmed = bool(args.yes_i_know_this_overwrites_remote_history)
-    dry_run = args.dry_run or not confirmed
+    confirmed = opts.yes_i_know_this_overwrites_remote_history
+    dry_run = opts.dry_run or not confirmed
     original_branch = git.current_branch(root) or "main"
     tmp_branch = git.unique_snapshot_branch_name(root)
 

--- a/src/repo_release_tools/commands/hooks_cmd.py
+++ b/src/repo_release_tools/commands/hooks_cmd.py
@@ -49,6 +49,7 @@ import contextlib
 import json
 import sys
 from collections.abc import Iterable
+from dataclasses import dataclass
 from pathlib import Path
 from sysconfig import get_path
 from typing import Any, cast
@@ -509,13 +510,48 @@ def _show_available_install_targets(*, cwd: Path, home: Path) -> None:
     p.footer("pass --target DEST to install (see targets above)")
 
 
+@dataclass(frozen=True)
+class InstallOptions:
+    """Typed view of ``argparse.Namespace`` for ``rrt hooks install``.
+
+    Built once via :meth:`from_args` at the top of :func:`cmd_install` so all
+    flags it reads have typed read sites instead of ``getattr(args, ...,
+    default)`` / ``args.x`` calls throughout the function body.
+    """
+
+    targets: list[str] | None
+    dry_run: bool
+    force: bool
+    verbose: int
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> InstallOptions:
+        """Build an :class:`InstallOptions` from a parsed ``argparse.Namespace``.
+
+        ``targets``, ``dry_run``, and ``force`` are given real defaults by
+        hooks_cmd.py's own register(), and every test in
+        tests/commands/test_hooks_cmd.py that exercises cmd_install
+        constructs its Namespace with all three set explicitly, so they are
+        read directly. ``verbose`` is set globally by cli.py's parser, but
+        no test Namespace here ever sets it, so the getattr fallback here
+        absorbs that gap.
+        """
+        return cls(
+            targets=args.targets,
+            dry_run=args.dry_run,
+            force=args.force,
+            verbose=getattr(args, "verbose", 0) or 0,
+        )
+
+
 def cmd_install(args: argparse.Namespace) -> int:
     """Install bundled hook scripts into one or more hook directories."""
-    verbose: int = getattr(args, "verbose", 0) or 0
+    opts = InstallOptions.from_args(args)
+    verbose = opts.verbose
     cwd = Path.cwd()
     home = Path.home()
-    if not args.targets:
-        if args.dry_run:
+    if not opts.targets:
+        if opts.dry_run:
             _show_available_install_targets(cwd=cwd, home=home)
             return 0
         available = ", ".join(sorted(HOOK_TARGET_PATHS))
@@ -523,9 +559,9 @@ def cmd_install(args: argparse.Namespace) -> int:
             f"No --target specified. Pass --target DEST (e.g. --target claude-local). Available: {available}.",
         )
 
-    install_plan = _resolve_install_plan(args.targets, cwd=cwd, home=home)
+    install_plan = _resolve_install_plan(opts.targets, cwd=cwd, home=home)
 
-    p = DryRunPrinter(args.dry_run, verbose=verbose)
+    p = DryRunPrinter(opts.dry_run, verbose=verbose)
     p.blank_line()
     total_files = sum(len(hook_files) for _, _, hook_files in install_plan)
     p.header(
@@ -538,7 +574,7 @@ def cmd_install(args: argparse.Namespace) -> int:
     for target_name, hooks_dir, hook_files in install_plan:
         for filename, _ in hook_files:
             destination = hooks_dir / filename
-            if destination.exists() and not args.force:
+            if destination.exists() and not opts.force:
                 conflicts.append((target_name, filename, destination))
 
     if conflicts:
@@ -548,7 +584,7 @@ def cmd_install(args: argparse.Namespace) -> int:
                 f"{target_name} already has {filename} at {location}. Use --force to overwrite it.",
             )
 
-    if args.dry_run:
+    if opts.dry_run:
         for target_name, hooks_dir, hook_files in install_plan:
             for filename, _ in hook_files:
                 destination = hooks_dir / filename

--- a/src/repo_release_tools/commands/init.py
+++ b/src/repo_release_tools/commands/init.py
@@ -67,6 +67,7 @@ import argparse
 import json as _json
 import sys
 import tomllib
+from dataclasses import dataclass
 from pathlib import Path
 
 from repo_release_tools.config import (
@@ -89,11 +90,48 @@ INIT_EPILOG = (
 )
 
 
+@dataclass(frozen=True)
+class InitOptions:
+    """Typed view of ``argparse.Namespace`` for ``rrt init``.
+
+    Built once via :meth:`from_args` at the top of :func:`cmd_init` so all
+    flags it reads have typed read sites instead of ``getattr(args, ...,
+    default)`` calls throughout the function body.
+    """
+
+    dry_run: bool
+    force: bool
+    target: str
+    verbose: int
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> InitOptions:
+        """Build an :class:`InitOptions` from a parsed ``argparse.Namespace``.
+
+        ``dry_run`` and ``force`` are given real defaults by init.py's own
+        register(), and every test in tests/commands/test_init.py that
+        exercises cmd_init sets both explicitly, so they are read directly.
+        ``target`` is also given a real default ("rrt-toml") by register(),
+        but several tests (e.g. test_cmd_init_writes_rrt_toml,
+        test_cmd_init_dry_run_does_not_write_file) construct a Namespace
+        that omits ``target`` entirely, so the getattr fallback here
+        absorbs that gap. ``verbose`` is set globally by cli.py's parser,
+        but no test Namespace here ever sets it, so the getattr fallback
+        here absorbs that gap too.
+        """
+        return cls(
+            dry_run=args.dry_run,
+            force=args.force,
+            target=getattr(args, "target", "rrt-toml"),
+            verbose=getattr(args, "verbose", 0) or 0,
+        )
+
+
 def cmd_init(args: argparse.Namespace) -> int:
     """Write a recommended rrt configuration block."""
-    _: int = getattr(args, "verbose", 0) or 0
+    opts = InitOptions.from_args(args)
     root = Path.cwd()
-    target_fmt = getattr(args, "target", "rrt-toml")
+    target_fmt = opts.target
     match target_fmt:
         case "pyproject":
             return _init_manifest(args, root, manifest="pyproject.toml", section_label="[tool.rrt]")

--- a/src/repo_release_tools/commands/install_cmd.py
+++ b/src/repo_release_tools/commands/install_cmd.py
@@ -64,6 +64,7 @@ import argparse
 import sys
 from argparse import Namespace
 from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass
 
 from repo_release_tools.commands import agents_cmd, hooks_cmd, skill
 from repo_release_tools.ui import DryRunPrinter, VerbosePrinter
@@ -125,19 +126,55 @@ def _show_available_targets() -> None:
     p.footer("pass --target DEST to install (see targets above)")
 
 
+@dataclass(frozen=True)
+class InstallOptions:
+    """Typed view of ``argparse.Namespace`` for ``rrt install``.
+
+    Built once via :meth:`from_args` at the top of :func:`cmd_install` so all
+    flags it reads have typed read sites instead of ``getattr(args, ...,
+    default)`` / ``args.x`` calls throughout the function body.
+    """
+
+    surfaces: list[str] | None
+    targets: list[str] | None
+    dry_run: bool
+    force: bool
+    verbose: int
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> InstallOptions:
+        """Build an :class:`InstallOptions` from a parsed ``argparse.Namespace``.
+
+        ``surfaces``, ``targets``, ``dry_run``, and ``force`` are given real
+        defaults by install_cmd.py's own register(), and every test in
+        tests/commands/test_install_cmd.py that exercises cmd_install
+        constructs its Namespace with all four set explicitly, so they are
+        read directly. ``verbose`` is set globally by cli.py's parser, but no
+        test Namespace here ever sets it, so the getattr fallback here
+        absorbs that gap.
+        """
+        return cls(
+            surfaces=args.surfaces,
+            targets=args.targets,
+            dry_run=args.dry_run,
+            force=args.force,
+            verbose=getattr(args, "verbose", 0) or 0,
+        )
+
+
 def cmd_install(args: argparse.Namespace) -> int:
     """Install one or more bundled surfaces into one or more targets."""
-    verbose: int = getattr(args, "verbose", 0) or 0
-    targets = _dedupe(args.targets or [])
+    opts = InstallOptions.from_args(args)
+    targets = _dedupe(opts.targets or [])
     if not targets:
-        if args.dry_run:
+        if opts.dry_run:
             _show_available_targets()
             return 0
         return _emit_install_error(
             "No --target specified. Pass --target DEST (e.g. --target claude-local).",
         )
 
-    surfaces = _resolve_surfaces(args.surfaces)
+    surfaces = _resolve_surfaces(opts.surfaces)
     registry = _surface_registry()
     for surface in surfaces:
         target_map, _ = registry[surface]
@@ -148,18 +185,18 @@ def cmd_install(args: argparse.Namespace) -> int:
                 f"{surface} does not support target(s): {joined}. Available: {available}.",
             )
 
-    p = DryRunPrinter(args.dry_run, verbose=verbose)
+    p = DryRunPrinter(opts.dry_run, verbose=opts.verbose)
     p.blank_line()
     p.header("Install", Surfaces=str(len(surfaces)), Targets=str(len(targets)))
 
     for surface in surfaces:
         _, handler = registry[surface]
         p.section(f"Surface: {surface}")
-        result = handler(Namespace(targets=targets, dry_run=args.dry_run, force=args.force))
+        result = handler(Namespace(targets=targets, dry_run=opts.dry_run, force=opts.force))
         if result != 0:
             return result
 
-    if args.dry_run:
+    if opts.dry_run:
         p.blank_line()
         p.footer("no files were modified")
     return 0

--- a/src/repo_release_tools/commands/mcp_cmd.py
+++ b/src/repo_release_tools/commands/mcp_cmd.py
@@ -23,6 +23,7 @@ import argparse
 import re
 import sys
 from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 
 from repo_release_tools.ui import DryRunPrinter
@@ -70,11 +71,54 @@ def register(mcp: FastMCP) -> None:
 '''
 
 
+@dataclass(frozen=True)
+class ToolNewOptions:
+    """Typed view of ``argparse.Namespace`` for ``rrt mcp tool new``.
+
+    Built once via :meth:`from_args` at the top of :func:`cmd_mcp_tool_new`
+    so all flags it reads have typed read sites instead of
+    ``getattr(args, ..., default)`` calls throughout the function body.
+    """
+
+    name: str
+    title: str | None
+    description: str | None
+    into: str | None
+    dry_run: bool
+    force: bool
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> ToolNewOptions:
+        """Build a :class:`ToolNewOptions` from a parsed ``argparse.Namespace``.
+
+        ``name`` is positional/required and ``title``, ``description``,
+        ``into``, ``dry_run``, and ``force`` are all given real defaults by
+        mcp_cmd.py's own register(). No cmd_* dispatch in
+        `workflow/hooks.py` calls cmd_mcp_tool_new (this file has no
+        hooks.py entry at all), and the only test file exercising this
+        command, tests/commands/test_mcp_scaffold.py, goes through the
+        local ``_args()`` helper which always sets all six fields
+        explicitly (the two bare ``argparse.Namespace()`` calls in that
+        file target the unrelated ``_default_help`` handlers, not
+        cmd_mcp_tool_new). This command does not read ``verbose`` at all.
+        So no getattr fallback is needed for any field.
+        """
+        return cls(
+            name=args.name,
+            title=args.title,
+            description=args.description,
+            into=args.into,
+            dry_run=args.dry_run,
+            force=args.force,
+        )
+
+
 def cmd_mcp_tool_new(args: argparse.Namespace) -> int:
     """Scaffold a new MCP tool module from a name + optional title/description."""
-    p = DryRunPrinter(getattr(args, "dry_run", False))
+    opts = ToolNewOptions.from_args(args)
+    p = DryRunPrinter(opts.dry_run)
 
-    name: str = args.name
+    name = opts.name
     if not _NAME_RE.match(name):
         p.line(
             f"Invalid tool name: {name!r}. "
@@ -84,16 +128,16 @@ def cmd_mcp_tool_new(args: argparse.Namespace) -> int:
         )
         return 1
 
-    title: str = getattr(args, "title", None) or _humanize(name)
-    description: str = getattr(args, "description", None) or f"MCP tool stub for {name}."
+    title = opts.title or _humanize(name)
+    description = opts.description or f"MCP tool stub for {name}."
 
-    into = getattr(args, "into", None)
+    into = opts.into
     if into:
         target = Path(into).resolve()
     else:
         target = Path.cwd() / "src" / "repo_release_tools" / "mcp" / "tools" / f"{name}_tools.py"
 
-    if target.exists() and not getattr(args, "force", False):
+    if target.exists() and not opts.force:
         p.line(
             f"Refusing to overwrite existing file: {target}. Use --force to override.",
             ok=False,

--- a/src/repo_release_tools/commands/project_cmd.py
+++ b/src/repo_release_tools/commands/project_cmd.py
@@ -20,6 +20,7 @@ import argparse
 import json
 import sys
 from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 
 from repo_release_tools.config.project_meta import (
@@ -31,13 +32,50 @@ from repo_release_tools.ui import VerbosePrinter
 _VALID_KEYS = ("name", "version", "description", "authors", "license", "urls", "source")
 
 
+@dataclass(frozen=True)
+class InfoOptions:
+    """Typed view of ``argparse.Namespace`` for ``rrt project info``.
+
+    Built once via :meth:`from_args` at the top of :func:`cmd_project_info` so
+    all flags it reads have typed read sites instead of ``getattr(args, ...,
+    default)`` calls throughout the function body.
+    """
+
+    root: Path
+    project_format: str
+    key: str | None
+    output: str | None
+    verbose: int
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> InfoOptions:
+        """Build an :class:`InfoOptions` from a parsed ``argparse.Namespace``.
+
+        ``root``, ``project_format``, ``key``, and ``output`` are given real
+        defaults by project_cmd.py's own register(), and every test in
+        tests/commands/test_project_cmd.py that exercises cmd_project_info
+        goes through the local ``_args()`` helper which always sets all four,
+        so they are read directly. ``verbose`` is set globally by cli.py's
+        parser, but ``_args()`` never sets it, so the getattr fallback here
+        absorbs that gap.
+        """
+        return cls(
+            root=Path(args.root).resolve(),
+            project_format=args.project_format,
+            key=args.key,
+            output=args.output,
+            verbose=getattr(args, "verbose", 0) or 0,
+        )
+
+
 def cmd_project_info(args: argparse.Namespace) -> int:
     """Emit project metadata read from the manifest."""
-    verbose: int = getattr(args, "verbose", 0) or 0
-    root = Path(getattr(args, "root", ".")).resolve()
-    fmt: str = getattr(args, "project_format", "text")
-    key: str | None = getattr(args, "key", None)
-    output_path: str | None = getattr(args, "output", None)
+    opts = InfoOptions.from_args(args)
+    verbose = opts.verbose
+    root = opts.root
+    fmt = opts.project_format
+    key = opts.key
+    output_path = opts.output
 
     if not root.is_dir():
         VerbosePrinter(verbose=verbose).line(

--- a/src/repo_release_tools/commands/release_cmd.py
+++ b/src/repo_release_tools/commands/release_cmd.py
@@ -67,6 +67,7 @@ import re
 import sys
 from pathlib import Path
 
+from repo_release_tools.commands._common import describe_config_load_error
 from repo_release_tools.commands.release_notes import register_subcommand as _register_notes
 from repo_release_tools.commands.release_repair import register_subcommand as _register_repair
 from repo_release_tools.config import (
@@ -75,8 +76,6 @@ from repo_release_tools.config import (
     _describe_version_target,
     find_repo_root,
     format_autodetected_config_notice,
-    format_missing_tool_rrt_guidance,
-    is_missing_tool_rrt_error,
     iter_config_files,
     load_or_autodetect_config,
 )
@@ -177,26 +176,18 @@ def cmd_release_check(args: argparse.Namespace) -> int:  # noqa: ARG001
 
     try:
         config = load_or_autodetect_config(root)
-    except FileNotFoundError:
-        checked = iter_config_files(root)
-        p = VerbosePrinter(verbose=verbose)
-        p.line(format_missing_tool_rrt_guidance(root, checked), ok=False, stream=sys.stderr)
+    except FileNotFoundError as exc:
+        err = describe_config_load_error(exc, root, no_config_file_checked=iter_config_files(root))
+        VerbosePrinter(verbose=verbose).line(err.text, ok=False, stream=sys.stderr)
         return 1
-    except ValueError as exc:
-        if is_missing_tool_rrt_error(exc):
-            p = VerbosePrinter(verbose=verbose)
+    except (ValueError, RuntimeError) as exc:
+        err = describe_config_load_error(exc, root)
+        p = VerbosePrinter(verbose=verbose)
+        if err.kind == "missing_tool_rrt":
             p.warn("No [tool.rrt] configuration found.", stream=sys.stderr)
-            p.action(
-                format_missing_tool_rrt_guidance(root, iter_config_files(root)),
-                stream=sys.stderr,
-            )
-            return 1
-        p = VerbosePrinter(verbose=verbose)
-        p.line(str(exc), ok=False, stream=sys.stderr)
-        return 1
-    except RuntimeError as exc:
-        p = VerbosePrinter(verbose=verbose)
-        p.line(str(exc), ok=False, stream=sys.stderr)
+            p.action(err.text, stream=sys.stderr)
+        else:
+            p.line(err.text, ok=False, stream=sys.stderr)
         return 1
 
     p = VerbosePrinter(verbose=verbose)

--- a/src/repo_release_tools/commands/release_notes.py
+++ b/src/repo_release_tools/commands/release_notes.py
@@ -72,10 +72,9 @@ from repo_release_tools.changelog import (
     get_unreleased_section_body,
     has_unreleased_section,
 )
+from repo_release_tools.commands._common import describe_config_load_error
 from repo_release_tools.config import (
     find_repo_root,
-    format_missing_tool_rrt_guidance,
-    is_missing_tool_rrt_error,
     iter_config_files,
     load_or_autodetect_config,
 )
@@ -143,27 +142,18 @@ def cmd_release_notes(args: argparse.Namespace) -> int:
 
     try:
         config = load_or_autodetect_config(root)
-    except FileNotFoundError:
-        checked = iter_config_files(root)
-        p = VerbosePrinter(verbose=verbose)
-        p.line(format_missing_tool_rrt_guidance(root, checked), ok=False, stream=sys.stderr)
+    except FileNotFoundError as exc:
+        err = describe_config_load_error(exc, root, no_config_file_checked=iter_config_files(root))
+        VerbosePrinter(verbose=verbose).line(err.text, ok=False, stream=sys.stderr)
         return 1
-    except ValueError as exc:
-        if is_missing_tool_rrt_error(exc):
-            p = VerbosePrinter(verbose=verbose)
+    except (ValueError, RuntimeError) as exc:
+        err = describe_config_load_error(exc, root)
+        p = VerbosePrinter(verbose=verbose)
+        if err.kind == "missing_tool_rrt":
             p.line("No [tool.rrt] configuration found.", ok=False, stream=sys.stderr)
-            p.line(
-                format_missing_tool_rrt_guidance(root, iter_config_files(root)),
-                ok=False,
-                stream=sys.stderr,
-            )
-            return 1
-        p = VerbosePrinter(verbose=verbose)
-        p.line(str(exc), ok=False, stream=sys.stderr)
-        return 1
-    except RuntimeError as exc:
-        p = VerbosePrinter(verbose=verbose)
-        p.line(str(exc), ok=False, stream=sys.stderr)
+            p.line(err.text, ok=False, stream=sys.stderr)
+        else:
+            p.line(err.text, ok=False, stream=sys.stderr)
         return 1
 
     try:

--- a/src/repo_release_tools/commands/release_notes.py
+++ b/src/repo_release_tools/commands/release_notes.py
@@ -63,6 +63,7 @@ from __future__ import annotations
 import argparse
 import subprocess
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 from repo_release_tools.changelog import (
@@ -116,6 +117,50 @@ def _format_gh_release(body: str, contributors: list[str]) -> str:
     return "\n".join(lines) + "\n"
 
 
+@dataclass(frozen=True)
+class ReleaseNotesOptions:
+    """Typed view of ``argparse.Namespace`` for ``rrt release notes``.
+
+    Built once via :meth:`from_args` at the top of :func:`cmd_release_notes`
+    so all flags it reads have typed read sites instead of
+    ``getattr(args, ..., default)`` calls throughout the function body.
+    """
+
+    notes_format: str
+    group: str | None
+    version: str | None
+    latest_released: bool
+    output: str | None
+    verbose: int
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> ReleaseNotesOptions:
+        """Build a :class:`ReleaseNotesOptions` from a parsed ``argparse.Namespace``.
+
+        ``notes_format`` and ``group`` are given real defaults by
+        release_notes.py's own register_subcommand(), and every test that
+        exercises cmd_release_notes across both
+        tests/commands/test_release_notes.py (via the local ``_args()``
+        helper) and tests/commands/test_release_cmd.py (which constructs
+        ``argparse.Namespace(notes_format=..., group=...)`` directly) always
+        sets both, so they are read directly. ``version``, ``latest_released``,
+        and ``output`` are also given real defaults by register_subcommand()
+        (``None``, ``False``, ``None``), but every test in
+        tests/commands/test_release_cmd.py omits all three from its sparse
+        Namespace, so the getattr fallbacks here absorb that gap. ``verbose``
+        is set globally by cli.py's parser, but no test Namespace here ever
+        sets it, so the getattr fallback here absorbs that gap too.
+        """
+        return cls(
+            notes_format=args.notes_format,
+            group=args.group,
+            version=getattr(args, "version", None),
+            latest_released=getattr(args, "latest_released", False),
+            output=getattr(args, "output", None),
+            verbose=getattr(args, "verbose", 0) or 0,
+        )
+
+
 def cmd_release_notes(args: argparse.Namespace) -> int:
     """Emit a changelog section as a formatted release body.
 
@@ -124,12 +169,13 @@ def cmd_release_notes(args: argparse.Namespace) -> int:
     or ``--latest-released`` to auto-pick the topmost versioned section. Use
     ``--output PATH`` to write the body to a file instead of stdout.
     """
-    verbose: int = getattr(args, "verbose", 0) or 0
+    opts = ReleaseNotesOptions.from_args(args)
+    verbose = opts.verbose
     root = find_repo_root(Path.cwd())
-    output_format = getattr(args, "notes_format", "md")
-    requested_version: str | None = getattr(args, "version", None)
-    latest_released: bool = getattr(args, "latest_released", False)
-    output_path: str | None = getattr(args, "output", None)
+    output_format = opts.notes_format
+    requested_version = opts.version
+    latest_released = opts.latest_released
+    output_path = opts.output
 
     if requested_version and latest_released:
         p = VerbosePrinter(verbose=verbose)
@@ -157,7 +203,7 @@ def cmd_release_notes(args: argparse.Namespace) -> int:
         return 1
 
     try:
-        group = config.resolve_group(getattr(args, "group", None))
+        group = config.resolve_group(opts.group)
     except ValueError as exc:
         p = VerbosePrinter(verbose=verbose)
         p.line(str(exc), ok=False, stream=sys.stderr)

--- a/src/repo_release_tools/commands/release_repair.py
+++ b/src/repo_release_tools/commands/release_repair.py
@@ -54,6 +54,7 @@ from repo_release_tools.changelog import (
     get_unreleased_entries,
     insert_generated_section,
 )
+from repo_release_tools.commands._common import describe_config_load_error
 from repo_release_tools.commands._version_render import render_version_write_events
 from repo_release_tools.config import (
     PinTarget,
@@ -61,8 +62,6 @@ from repo_release_tools.config import (
     VersionGroup,
     VersionTarget,
     find_repo_root,
-    format_missing_tool_rrt_guidance,
-    is_missing_tool_rrt_error,
     iter_config_files,
     load_or_autodetect_config,
 )
@@ -642,26 +641,17 @@ def _load_config_and_group(
     p = VerbosePrinter(verbose=verbose)
     try:
         config = load_or_autodetect_config(root)
-    except FileNotFoundError:
-        p.line(
-            format_missing_tool_rrt_guidance(root, iter_config_files(root)),
-            ok=False,
-            stream=sys.stderr,
-        )
+    except FileNotFoundError as exc:
+        err = describe_config_load_error(exc, root, no_config_file_checked=iter_config_files(root))
+        p.line(err.text, ok=False, stream=sys.stderr)
         return None, None, 1
-    except ValueError as exc:
-        if is_missing_tool_rrt_error(exc):
+    except (ValueError, RuntimeError) as exc:
+        err = describe_config_load_error(exc, root)
+        if err.kind == "missing_tool_rrt":
             p.line("No [tool.rrt] configuration found.", ok=False, stream=sys.stderr)
-            p.line(
-                format_missing_tool_rrt_guidance(root, iter_config_files(root)),
-                ok=False,
-                stream=sys.stderr,
-            )
-            return None, None, 1
-        p.line(str(exc), ok=False, stream=sys.stderr)
-        return None, None, 1
-    except RuntimeError as exc:
-        p.line(str(exc), ok=False, stream=sys.stderr)
+            p.line(err.text, ok=False, stream=sys.stderr)
+        else:
+            p.line(err.text, ok=False, stream=sys.stderr)
         return None, None, 1
 
     requested_group = getattr(args, "group", None)

--- a/src/repo_release_tools/commands/release_repair.py
+++ b/src/repo_release_tools/commands/release_repair.py
@@ -98,9 +98,52 @@ class Drift:
     actual: str
 
 
+@dataclass(frozen=True)
+class ReleaseRepairOptions:
+    """Typed view of ``argparse.Namespace`` for ``rrt release repair``.
+
+    Built once via :meth:`from_args` at the top of :func:`cmd_release_repair`
+    so the top-level flags it reads directly have typed read sites instead
+    of ``getattr(args, ..., default)`` calls. Note that ``cmd_release_repair``
+    still passes the raw ``args`` Namespace through to its helper functions
+    (``_load_config_and_group``, ``_resolve_version_body``, ``_recreate``,
+    ``_verify_and_fix``, ``_commit_message``); those helpers are not
+    ``cmd_*`` entrypoints, and several tests in
+    tests/commands/test_release_repair.py (e.g. test_commit_message_variants,
+    test_resolve_version_body_empty_changelog_returns_none) call them
+    directly with hand-built sparse Namespaces, so their own internal
+    ``getattr`` fallbacks are left untouched by this refactor.
+    """
+
+    verbose: int
+    from_ref: str | None
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> ReleaseRepairOptions:
+        """Build a :class:`ReleaseRepairOptions` from a parsed ``argparse.Namespace``.
+
+        ``from_ref`` is given a real default (None) by release_repair.py's
+        own register_subcommand(), and ``verbose`` is set globally by
+        cli.py's parser. Every test in tests/commands/test_release_repair.py
+        that calls cmd_release_repair goes through the local ``_args()``
+        helper, which always sets both explicitly, so plain ``args.x`` would
+        also be safe here today. The getattr fallbacks are kept regardless,
+        matching the defensive style already used throughout this file's
+        many other ``args`` readers (e.g. ``_resolve_version_body``,
+        ``_load_config_and_group``), since cmd_release_repair is the public
+        entrypoint most likely to be called by future callers with a
+        hand-built Namespace that omits fields.
+        """
+        return cls(
+            verbose=getattr(args, "verbose", 0) or 0,
+            from_ref=getattr(args, "from_ref", None),
+        )
+
+
 def cmd_release_repair(args: argparse.Namespace) -> int:
     """Verify or recreate the release state for the current branch."""
-    verbose: int = getattr(args, "verbose", 0) or 0
+    opts = ReleaseRepairOptions.from_args(args)
+    verbose = opts.verbose
     root = find_repo_root(Path.cwd())
 
     config, group, exit_code = _load_config_and_group(args, root, verbose)
@@ -123,7 +166,7 @@ def cmd_release_repair(args: argparse.Namespace) -> int:
     )
     version_body = _resolve_version_body(args, declared_version, existing_changelog, fmt)
 
-    base_ref: str | None = getattr(args, "from_ref", None)
+    base_ref = opts.from_ref
     if base_ref:
         return _recreate(
             args=args,

--- a/src/repo_release_tools/commands/skill.py
+++ b/src/repo_release_tools/commands/skill.py
@@ -61,6 +61,7 @@ import contextlib
 import shutil
 import sys
 from collections.abc import Iterable
+from dataclasses import dataclass
 from pathlib import Path
 
 from repo_release_tools.integrations.skill_assets import BUNDLED_SKILLS
@@ -144,13 +145,48 @@ def _show_available_install_targets(*, cwd: Path, home: Path) -> None:
     p.footer("pass --target DEST to install (see targets above)")
 
 
+@dataclass(frozen=True)
+class InstallOptions:
+    """Typed view of ``argparse.Namespace`` for ``rrt skill install``.
+
+    Built once via :meth:`from_args` at the top of :func:`cmd_install` so all
+    flags it reads have typed read sites instead of ``getattr(args, ...,
+    default)`` / ``args.x`` calls throughout the function body.
+    """
+
+    targets: list[str] | None
+    dry_run: bool
+    force: bool
+    verbose: int
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> InstallOptions:
+        """Build an :class:`InstallOptions` from a parsed ``argparse.Namespace``.
+
+        ``targets``, ``dry_run``, and ``force`` are given real defaults by
+        skill.py's own register(), and every test in
+        tests/commands/test_skill.py that exercises cmd_install constructs
+        its Namespace with all three set explicitly, so they are read
+        directly. ``verbose`` is set globally by cli.py's parser, but no test
+        Namespace here ever sets it, so the getattr fallback here absorbs
+        that gap.
+        """
+        return cls(
+            targets=args.targets,
+            dry_run=args.dry_run,
+            force=args.force,
+            verbose=getattr(args, "verbose", 0) or 0,
+        )
+
+
 def cmd_install(args: argparse.Namespace) -> int:
     """Install the bundled rrt user skills into one or more agent skill dirs."""
-    verbose: int = getattr(args, "verbose", 0) or 0
+    opts = InstallOptions.from_args(args)
+    verbose = opts.verbose
     cwd = Path.cwd()
     home = Path.home()
-    if not args.targets:
-        if args.dry_run:
+    if not opts.targets:
+        if opts.dry_run:
             _show_available_install_targets(cwd=cwd, home=home)
             return 0
         available = ", ".join(sorted(TARGET_PATHS))
@@ -158,9 +194,9 @@ def cmd_install(args: argparse.Namespace) -> int:
             f"No --target specified. Pass --target DEST (e.g. --target claude-local). Available: {available}.",
         )
 
-    install_plan = _resolve_install_plan(args.targets, cwd=cwd, home=home)
+    install_plan = _resolve_install_plan(opts.targets, cwd=cwd, home=home)
 
-    p = DryRunPrinter(args.dry_run, verbose=verbose)
+    p = DryRunPrinter(opts.dry_run, verbose=verbose)
     p.blank_line()
     p.header(
         "Skill install",
@@ -172,7 +208,7 @@ def cmd_install(args: argparse.Namespace) -> int:
     for target_name, skills_dir in install_plan:
         for skill in BUNDLED_SKILLS:
             destination = skills_dir / skill.name
-            if destination.exists() and not args.force:
+            if destination.exists() and not opts.force:
                 conflicts.append((target_name, skill.name, destination))
 
     if conflicts:
@@ -182,7 +218,7 @@ def cmd_install(args: argparse.Namespace) -> int:
                 f"{target_name} already has {skill_name} at {location}. Use --force to overwrite it.",
             )
 
-    if args.dry_run:
+    if opts.dry_run:
         for target_name, skills_dir in install_plan:
             for skill in BUNDLED_SKILLS:
                 destination = skills_dir / skill.name / "SKILL.md"

--- a/src/repo_release_tools/commands/tag.py
+++ b/src/repo_release_tools/commands/tag.py
@@ -65,10 +65,9 @@ import subprocess
 import sys
 from pathlib import Path
 
+from repo_release_tools.commands._common import describe_config_load_error
 from repo_release_tools.config import (
     find_repo_root,
-    format_missing_tool_rrt_guidance,
-    is_missing_tool_rrt_error,
     iter_config_files,
     load_or_autodetect_config,
 )
@@ -88,25 +87,17 @@ def _load_config_and_version(root: Path, group_name: str | None) -> tuple[object
     """Load config and return (config, version_str), printing errors on failure."""
     try:
         config = load_or_autodetect_config(root)
-    except FileNotFoundError:
-        p = VerbosePrinter()
-        p.line(
-            format_missing_tool_rrt_guidance(root, iter_config_files(root)),
-            ok=False,
-            stream=sys.stderr,
-        )
+    except FileNotFoundError as exc:
+        err = describe_config_load_error(exc, root, no_config_file_checked=iter_config_files(root))
+        VerbosePrinter().line(err.text, ok=False, stream=sys.stderr)
         return None
-    except ValueError as exc:
-        if is_missing_tool_rrt_error(exc):
-            p = VerbosePrinter()
+    except (ValueError, RuntimeError) as exc:
+        err = describe_config_load_error(exc, root)
+        p = VerbosePrinter()
+        if err.kind == "missing_tool_rrt":
             p.line("No [tool.rrt] configuration found.", ok=False, stream=sys.stderr)
-            return None
-        p = VerbosePrinter()
-        p.line(str(exc), ok=False, stream=sys.stderr)
-        return None
-    except RuntimeError as exc:
-        p = VerbosePrinter()
-        p.line(str(exc), ok=False, stream=sys.stderr)
+        else:
+            p.line(err.text, ok=False, stream=sys.stderr)
         return None
 
     try:

--- a/src/repo_release_tools/commands/tag.py
+++ b/src/repo_release_tools/commands/tag.py
@@ -63,6 +63,7 @@ from __future__ import annotations
 import argparse
 import subprocess
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 from repo_release_tools.commands._common import describe_config_load_error
@@ -120,29 +121,66 @@ def _existing_tags(root: Path) -> list[str]:
         return []
 
 
+@dataclass(frozen=True)
+class TagCreateOptions:
+    """Typed view of ``argparse.Namespace`` for ``rrt tag create``.
+
+    Built once via :meth:`from_args` at the top of :func:`cmd_tag_create` so
+    every flag it reads has a typed read site instead of scattered
+    ``getattr(args, ..., default)`` calls throughout the function body.
+    """
+
+    verbose: int
+    dry_run: bool
+    push: bool
+    prefix: str
+    message: str | None
+    group: str | None
+    force: bool
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> TagCreateOptions:
+        """Build a :class:`TagCreateOptions` from a parsed ``argparse.Namespace``.
+
+        Every field here is given a real default by tag.py's own
+        ``register()`` (used by ``rrt tag create``); hooks.py never dispatches
+        to ``cmd_tag_create`` (only ``cmd_tag_check`` has a "tag-check" case),
+        so there is no hooks.py Namespace gap to absorb. The getattr fallbacks
+        remain because several tests in tests/commands/test_tag.py construct
+        sparse ``argparse.Namespace`` objects by hand (via ``_args_create``)
+        that omit some of these attributes.
+        """
+        return cls(
+            verbose=getattr(args, "verbose", 0) or 0,
+            dry_run=getattr(args, "dry_run", False),
+            push=getattr(args, "push", False),
+            prefix=getattr(args, "prefix", "v"),
+            message=getattr(args, "message", None),
+            group=getattr(args, "group", None),
+            force=getattr(args, "force", False),
+        )
+
+
 def cmd_tag_create(args: argparse.Namespace) -> int:
     """Create an annotated git tag matching the current configured version."""
-    verbose: int = getattr(args, "verbose", 0) or 0
+    opts = TagCreateOptions.from_args(args)
+    verbose = opts.verbose
     root = find_repo_root(Path.cwd())
-    dry_run: bool = getattr(args, "dry_run", False)
-    push: bool = getattr(args, "push", False)
-    prefix: str = getattr(args, "prefix", "v")
-    message: str | None = getattr(args, "message", None)
 
-    result = _load_config_and_version(root, getattr(args, "group", None))
+    result = _load_config_and_version(root, opts.group)
     if result is None:
         return 1
     _config, version = result
 
-    tag = _tag_name(version, prefix)
-    msg = message or f"Release {tag}"
+    tag = _tag_name(version, opts.prefix)
+    msg = opts.message or f"Release {tag}"
 
-    p = DryRunPrinter(dry_run, verbose=verbose)
+    p = DryRunPrinter(opts.dry_run, verbose=verbose)
     p.blank_line()
     p.header("Tag create", Tag=tag, Message=msg)
 
     existing = _existing_tags(root)
-    if tag in existing and not getattr(args, "force", False):
+    if tag in existing and not opts.force:
         p2 = VerbosePrinter(verbose=verbose)
         p2.line(
             f"Tag '{tag}' already exists. Use --force to overwrite.",
@@ -151,13 +189,13 @@ def cmd_tag_create(args: argparse.Namespace) -> int:
         )
         return 1
 
-    if dry_run:
+    if opts.dry_run:
         p.line(f"would run: git tag -a {tag} -m {msg!r}")
         p.line("no changes were made")
         return 0
 
     try:
-        if tag in existing and getattr(args, "force", False):
+        if tag in existing and opts.force:
             _git(["git", "tag", "-d", tag], root)
         _git(["git", "tag", "-a", tag, "-m", msg], root)
     except subprocess.CalledProcessError as exc:
@@ -167,7 +205,7 @@ def cmd_tag_create(args: argparse.Namespace) -> int:
 
     p.ok(f"Created tag {tag!r}")
 
-    if push:
+    if opts.push:
         try:
             _git(["git", "push", "origin", tag], root)
             p.ok(f"Pushed {tag!r} to origin")
@@ -179,19 +217,52 @@ def cmd_tag_create(args: argparse.Namespace) -> int:
     return 0
 
 
+@dataclass(frozen=True)
+class TagCheckOptions:
+    """Typed view of ``argparse.Namespace`` for ``rrt tag check``.
+
+    Built once via :meth:`from_args` at the top of :func:`cmd_tag_check` so
+    every flag it reads has a typed read site instead of scattered
+    ``getattr(args, ..., default)`` calls throughout the function body.
+    """
+
+    verbose: int
+    strict: bool
+    prefix: str
+    group: str | None
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> TagCheckOptions:
+        """Build a :class:`TagCheckOptions` from a parsed ``argparse.Namespace``.
+
+        workflow/hooks.py's "tag-check" case hand-builds
+        ``argparse.Namespace(strict=False, prefix="v", group=None,
+        verbose=verbose)`` — exactly these four fields, so no field is
+        missing from that dispatch arm. The getattr fallbacks remain because
+        several tests in tests/commands/test_tag.py construct sparse
+        ``argparse.Namespace`` objects by hand (via ``_args_check``) that
+        never set ``verbose``.
+        """
+        return cls(
+            verbose=getattr(args, "verbose", 0) or 0,
+            strict=getattr(args, "strict", False),
+            prefix=getattr(args, "prefix", "v"),
+            group=getattr(args, "group", None),
+        )
+
+
 def cmd_tag_check(args: argparse.Namespace) -> int:
     """Validate existing tags match the configured naming convention."""
-    verbose: int = getattr(args, "verbose", 0) or 0
+    opts = TagCheckOptions.from_args(args)
+    verbose = opts.verbose
     root = find_repo_root(Path.cwd())
-    strict: bool = getattr(args, "strict", False)
-    prefix: str = getattr(args, "prefix", "v")
 
-    result = _load_config_and_version(root, getattr(args, "group", None))
+    result = _load_config_and_version(root, opts.group)
     if result is None:
         return 1
     _config, version = result
 
-    expected_tag = _tag_name(version, prefix)
+    expected_tag = _tag_name(version, opts.prefix)
     existing_tags = _existing_tags(root)
 
     p = VerbosePrinter(verbose=verbose)
@@ -201,11 +272,11 @@ def cmd_tag_check(args: argparse.Namespace) -> int:
     errors: list[str] = []
 
     for tag in existing_tags:
-        if not tag.startswith(prefix):
-            errors.append(f"Tag '{tag}' does not match prefix '{prefix}'")
+        if not tag.startswith(opts.prefix):
+            errors.append(f"Tag '{tag}' does not match prefix '{opts.prefix}'")
 
     if expected_tag not in existing_tags:
-        if strict:
+        if opts.strict:
             errors.append(f"Expected tag '{expected_tag}' not found (run `rrt tag create`)")
         else:
             p.line(f"  Expected tag '{expected_tag}' not found (run `rrt tag create`)", ok=False)

--- a/src/repo_release_tools/commands/toc.py
+++ b/src/repo_release_tools/commands/toc.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 
 import argparse
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 from repo_release_tools.tools.inject import (
@@ -62,13 +63,53 @@ TOC_EPILOG = (
 )
 
 
+@dataclass(frozen=True)
+class TocOptions:
+    """Typed view of ``argparse.Namespace`` for ``rrt toc``.
+
+    Built once via :meth:`from_args` at the top of :func:`cmd_toc` so all
+    flags it reads have typed read sites instead of ``getattr(args, ...,
+    default)`` / ``args.x`` calls throughout the function body.
+    """
+
+    file: str
+    inject: str | None
+    anchor: str | None
+    min_level: int
+    max_level: int
+    dry_run: bool
+    verbose: int
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> TocOptions:
+        """Build a :class:`TocOptions` from a parsed ``argparse.Namespace``.
+
+        ``file``, ``inject``, ``anchor``, ``min_level``, ``max_level``, and
+        ``dry_run`` are given real values/defaults by toc.py's own
+        register(), and every test in tests/commands/test_toc.py that
+        exercises cmd_toc goes through the local ``_make_args()`` helper
+        which always sets all six, so they are read directly. ``verbose`` is
+        set globally by cli.py's parser, but ``_make_args()`` never sets it,
+        so the getattr fallback here absorbs that gap.
+        """
+        return cls(
+            file=args.file,
+            inject=args.inject,
+            anchor=args.anchor,
+            min_level=args.min_level,
+            max_level=args.max_level,
+            dry_run=args.dry_run,
+            verbose=getattr(args, "verbose", 0) or 0,
+        )
+
+
 def cmd_toc(args: argparse.Namespace) -> int:
     """Generate a Markdown TOC from FILE, optionally injecting it into TARGET."""
-    verbose: int = getattr(args, "verbose", 0) or 0
-    p = DryRunPrinter(getattr(args, "dry_run", False), verbose=verbose)
+    opts = TocOptions.from_args(args)
+    p = DryRunPrinter(opts.dry_run, verbose=opts.verbose)
 
-    inject_file: str | None = getattr(args, "inject", None)
-    anchor_id: str | None = getattr(args, "anchor", None)
+    inject_file = opts.inject
+    anchor_id = opts.anchor
 
     if bool(inject_file) != bool(anchor_id):
         p.line(
@@ -78,14 +119,14 @@ def cmd_toc(args: argparse.Namespace) -> int:
         )
         return 1
 
-    source = Path(args.file)
+    source = Path(opts.file)
     if not source.exists():
         p.line(f"Source file does not exist: {source}", ok=False, stream=sys.stderr)
         return 1
 
     text = source.read_text(encoding="utf-8")
     headings = parse_headings(text)
-    toc = render_toc(headings, min_level=args.min_level, max_level=args.max_level)
+    toc = render_toc(headings, min_level=opts.min_level, max_level=opts.max_level)
 
     if not toc:
         p.line("No headings found in the requested level range.", ok=False, stream=sys.stderr)

--- a/src/repo_release_tools/commands/tree.py
+++ b/src/repo_release_tools/commands/tree.py
@@ -808,13 +808,99 @@ def _inject_rendered_tree(
     return 0
 
 
+@dataclass(frozen=True)
+class Options:
+    """Typed view of ``argparse.Namespace`` for ``rrt tree``.
+
+    Built once via :meth:`from_args` at the top of :func:`cmd_tree` so every
+    flag has a single, typed read site instead of scattered
+    ``getattr(args, ..., default)`` / ``args.x`` calls throughout the
+    function body.
+    """
+
+    verbose: int
+    dry_run: bool
+    inject: str | None
+    anchor: str | None
+    path: str | None
+    root: str
+    max_depth: int | None
+    dirs_only: bool
+    show_hidden: bool
+    fix_empty_dirs: bool
+    yes: bool
+    auto_resolve: str | None
+    format: str
+    absolute: bool
+    strict_empty_dirs: bool
+    snapshot: bool
+    check: bool
+    strict: bool
+    manifest: bool
+    compressed: bool
+    output: str | None
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> Options:
+        """Build an :class:`Options` from a parsed ``argparse.Namespace``.
+
+        Every flag is given a real default by tree.py's own register() (or,
+        for --verbose, by cli.py's global parser), so a Namespace produced by
+        argparse always carries every attribute. ``getattr`` fallbacks here
+        are still required for two independent reasons:
+
+        1. `workflow/hooks.py`'s "tree-check" case hand-builds a sparse
+           Namespace(path=None, root=..., max_depth=..., dirs_only=...,
+           show_hidden=..., inject=None, anchor=None, fix_empty_dirs=False,
+           dry_run=False, strict_empty_dirs=False, snapshot=False,
+           check=True, strict=True, verbose=verbose, format="classic") that
+           omits ``manifest``, ``compressed``, ``yes``, ``auto_resolve``,
+           ``absolute``, and ``output`` entirely. Plain attribute access for
+           those six would raise AttributeError on the `rrt-hooks tree-check`
+           path used by CI/pre-commit.
+        2. Several unit tests in tests/commands/test_tree*.py construct their
+           own sparse argparse.Namespace by hand (helpers like ``_args()``
+           and ``_f2_args()``, plus ad-hoc Namespace(...) calls), routinely
+           omitting ``path``, ``verbose``, ``strict_empty_dirs``,
+           ``fix_empty_dirs``, ``yes``, and ``auto_resolve`` in addition to
+           the six hooks.py never sets.
+
+        This is the single translation point that absorbs both gaps, so the
+        rest of cmd_tree can read opts.x unconditionally.
+        """
+        return cls(
+            verbose=getattr(args, "verbose", 0) or 0,
+            dry_run=getattr(args, "dry_run", False),
+            inject=getattr(args, "inject", None),
+            anchor=getattr(args, "anchor", None),
+            path=getattr(args, "path", None),
+            root=args.root,
+            max_depth=args.max_depth,
+            dirs_only=args.dirs_only,
+            show_hidden=args.show_hidden,
+            fix_empty_dirs=getattr(args, "fix_empty_dirs", False),
+            yes=getattr(args, "yes", False),
+            auto_resolve=getattr(args, "auto_resolve", None),
+            format=args.format,
+            absolute=getattr(args, "absolute", False),
+            strict_empty_dirs=getattr(args, "strict_empty_dirs", False),
+            snapshot=getattr(args, "snapshot", False),
+            check=getattr(args, "check", False),
+            strict=getattr(args, "strict", False),
+            manifest=getattr(args, "manifest", False),
+            compressed=getattr(args, "compressed", False),
+            output=getattr(args, "output", None),
+        )
+
+
 def cmd_tree(args: argparse.Namespace) -> int:
     """Render a project tree from the selected root."""
-    verbose: int = getattr(args, "verbose", 0) or 0
-    p = DryRunPrinter(getattr(args, "dry_run", False), verbose=verbose)
+    opts = Options.from_args(args)
+    verbose: int = opts.verbose
+    p = DryRunPrinter(opts.dry_run, verbose=verbose)
 
-    inject_file: str | None = getattr(args, "inject", None)
-    anchor_id: str | None = getattr(args, "anchor", None)
+    inject_file: str | None = opts.inject
+    anchor_id: str | None = opts.anchor
 
     if bool(inject_file) != bool(anchor_id):
         p.line(
@@ -825,8 +911,8 @@ def cmd_tree(args: argparse.Namespace) -> int:
         return 1
 
     # The positional `path` argument, when given, takes precedence over `--root`.
-    positional_path: str | None = getattr(args, "path", None)
-    root_input = positional_path if positional_path else args.root
+    positional_path: str | None = opts.path
+    root_input = positional_path if positional_path else opts.root
     root = Path(root_input).resolve()
     if not root.exists():
         p.line(f"Root path does not exist: {root}", ok=False, stream=sys.stderr)
@@ -845,9 +931,9 @@ def cmd_tree(args: argparse.Namespace) -> int:
         root=root,
         repo_root=repo_root,
         depth=1,
-        max_depth=args.max_depth,
-        dirs_only=args.dirs_only,
-        show_hidden=args.show_hidden,
+        max_depth=opts.max_depth,
+        dirs_only=opts.dirs_only,
+        show_hidden=opts.show_hidden,
         ignore_cache=ignore_cache,
         warnings=warnings,
     )
@@ -855,7 +941,7 @@ def cmd_tree(args: argparse.Namespace) -> int:
     if repo_root is not None:
         phantom_empty_dirs = _warn_for_empty_directories(entries, warnings, root=root)
 
-    do_fix_empty_dirs: bool = getattr(args, "fix_empty_dirs", False)
+    do_fix_empty_dirs: bool = opts.fix_empty_dirs
     if do_fix_empty_dirs:
         from repo_release_tools.commands._tree_fix import fix_empty_dirs
 
@@ -863,13 +949,13 @@ def cmd_tree(args: argparse.Namespace) -> int:
             root,
             phantom_empty_dirs,
             printer=p,
-            dry_run=getattr(args, "dry_run", False),
-            assume_yes=getattr(args, "yes", False),
-            auto_resolve=getattr(args, "auto_resolve", None),
+            dry_run=opts.dry_run,
+            assume_yes=opts.yes,
+            auto_resolve=opts.auto_resolve,
         )
 
-    fmt = args.format
-    absolute_paths: bool = getattr(args, "absolute", False)
+    fmt = opts.format
+    absolute_paths: bool = opts.absolute
     rendered: str
     match fmt:
         case "ascii":
@@ -899,7 +985,7 @@ def cmd_tree(args: argparse.Namespace) -> int:
         "phantom_empty_dirs": [str(d) for d in phantom_empty_dirs],
     }
 
-    strict_empty: bool = getattr(args, "strict_empty_dirs", False)
+    strict_empty: bool = opts.strict_empty_dirs
     if strict_empty and phantom_empty_dirs:
         for path in phantom_empty_dirs:
             p.line(f"Phantom empty directory (untrackable by git): {path}/", ok=False)
@@ -910,11 +996,11 @@ def cmd_tree(args: argparse.Namespace) -> int:
         )
         return 1
 
-    do_snapshot: bool = getattr(args, "snapshot", False)
-    do_check: bool = getattr(args, "check", False)
-    strict: bool = getattr(args, "strict", False)
-    do_manifest: bool = getattr(args, "manifest", False)
-    do_compressed: bool = getattr(args, "compressed", False)
+    do_snapshot: bool = opts.snapshot
+    do_check: bool = opts.check
+    strict: bool = opts.strict
+    do_manifest: bool = opts.manifest
+    do_compressed: bool = opts.compressed
     # --compressed implies --manifest
     if do_compressed:
         do_manifest = True
@@ -1017,7 +1103,7 @@ def cmd_tree(args: argparse.Namespace) -> int:
         )
 
     # --- default mode: print tree to stdout or write to --output ---
-    output_path: str | None = getattr(args, "output", None)
+    output_path: str | None = opts.output
     if output_path:
         body = (rendered + "\n") if rendered else ""
         Path(output_path).write_text(body, encoding="utf-8")
@@ -1033,8 +1119,8 @@ def cmd_tree(args: argparse.Namespace) -> int:
         p.meta("Git ignore", "enabled")
     else:
         p.meta("Git ignore", "unavailable (non-git directory fallback)")
-    if args.max_depth is not None:
-        p.meta("Max depth", str(args.max_depth))
+    if opts.max_depth is not None:
+        p.meta("Max depth", str(opts.max_depth))
     p.blank_line()
 
     p.section("Tree")

--- a/src/repo_release_tools/commands/workspace.py
+++ b/src/repo_release_tools/commands/workspace.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 
 import argparse
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 from repo_release_tools.changelog import (
@@ -123,14 +124,51 @@ def _update_changelog_for_package(
         p.ok(f"{path} updated (promoted [Unreleased] to [{new}])")
 
 
+@dataclass(frozen=True)
+class WorkspaceBumpOptions:
+    """Typed view of ``argparse.Namespace`` for ``rrt workspace bump``.
+
+    Built once via :meth:`from_args` at the top of :func:`cmd_workspace_bump`
+    so all flags it reads have typed read sites instead of
+    ``getattr(args, ..., default)`` calls throughout the function body.
+    """
+
+    bump: str
+    packages: str
+    dry_run: bool
+    no_changelog: bool
+    verbose: int
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> WorkspaceBumpOptions:
+        """Build a :class:`WorkspaceBumpOptions` from a parsed ``argparse.Namespace``.
+
+        ``bump``, ``packages``, ``dry_run``, and ``no_changelog`` are all
+        positional/required or given real defaults by workspace.py's own
+        register(), and every test in tests/commands/test_workspace.py that
+        exercises cmd_workspace_bump goes through the local ``_args()``
+        helper which always sets all four, so they are read directly.
+        ``verbose`` is set globally by cli.py's parser, but ``_args()``
+        never sets it, so the getattr fallback here absorbs that gap.
+        """
+        return cls(
+            bump=args.bump,
+            packages=args.packages or "",
+            dry_run=args.dry_run,
+            no_changelog=args.no_changelog,
+            verbose=getattr(args, "verbose", 0) or 0,
+        )
+
+
 def cmd_workspace_bump(args: argparse.Namespace) -> int:
     """Apply a unified version bump to all listed packages."""
-    verbose: int = getattr(args, "verbose", 0) or 0
+    opts = WorkspaceBumpOptions.from_args(args)
+    verbose = opts.verbose
     cwd = Path.cwd()
-    dry_run: bool = getattr(args, "dry_run", False)
-    packages_str: str = getattr(args, "packages", "") or ""
-    bump_kind: str = args.bump
-    no_changelog: bool = getattr(args, "no_changelog", False)
+    dry_run = opts.dry_run
+    packages_str = opts.packages
+    bump_kind = opts.bump
+    no_changelog = opts.no_changelog
 
     if not packages_str:
         p = VerbosePrinter(verbose=verbose)

--- a/src/repo_release_tools/commands/workspace.py
+++ b/src/repo_release_tools/commands/workspace.py
@@ -48,11 +48,10 @@ from repo_release_tools.changelog import (
     has_unreleased_section,
     promote_unreleased,
 )
+from repo_release_tools.commands._common import describe_config_load_error
 from repo_release_tools.commands._version_render import render_version_write_events
 from repo_release_tools.config import (
     RrtConfig,
-    format_missing_tool_rrt_guidance,
-    is_missing_tool_rrt_error,
     iter_config_files,
     load_or_autodetect_config,
 )
@@ -154,26 +153,21 @@ def cmd_workspace_bump(args: argparse.Namespace) -> int:
 
         try:
             config = load_or_autodetect_config(pkg_path)
-        except FileNotFoundError:
+        except FileNotFoundError as exc:
+            err = describe_config_load_error(
+                exc, pkg_path, no_config_file_checked=iter_config_files(pkg_path)
+            )
             p = VerbosePrinter(verbose=verbose)
             p.line(f"No rrt config found in {pkg_path}.", ok=False, stream=sys.stderr)
-            p.line(
-                format_missing_tool_rrt_guidance(pkg_path, iter_config_files(pkg_path)),
-                ok=False,
-                stream=sys.stderr,
-            )
+            p.line(err.text, ok=False, stream=sys.stderr)
             return 1
-        except ValueError as exc:
-            if is_missing_tool_rrt_error(exc):
-                p = VerbosePrinter(verbose=verbose)
+        except (ValueError, RuntimeError) as exc:
+            err = describe_config_load_error(exc, pkg_path)
+            p = VerbosePrinter(verbose=verbose)
+            if err.kind == "missing_tool_rrt":
                 p.line(f"No [tool.rrt] config in {pkg_path}.", ok=False, stream=sys.stderr)
-                return 1
-            p = VerbosePrinter(verbose=verbose)
-            p.line(str(exc), ok=False, stream=sys.stderr)
-            return 1
-        except RuntimeError as exc:
-            p = VerbosePrinter(verbose=verbose)
-            p.line(str(exc), ok=False, stream=sys.stderr)
+            else:
+                p.line(err.text, ok=False, stream=sys.stderr)
             return 1
 
         group = config.resolve_group(None)

--- a/src/repo_release_tools/config/core.py
+++ b/src/repo_release_tools/config/core.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import tomllib
+from collections.abc import Callable
+from dataclasses import dataclass
 from glob import has_magic
 from pathlib import Path
 from typing import cast
@@ -1033,6 +1035,73 @@ def _load_primary_remote(value: object) -> str:
     return value.strip()
 
 
+_MISSING = object()
+
+
+@dataclass(frozen=True)
+class FieldSpec:
+    """One key's type/presence/default rule, applied by ``_walk_fields``.
+
+    Construction of domain objects (path resolution, glob expansion,
+    cross-field checks) stays hand-written in the caller — this only
+    validates type/presence.
+    """
+
+    key: str
+    expected_type: type | tuple[type, ...]
+    default: object = _MISSING
+    error: str | Callable[[], str] = ""
+    validator: Callable[[object], object] | None = None
+    allow_none_default: bool = False
+
+
+def _walk_fields(raw: dict[str, object], specs: list[FieldSpec]) -> dict[str, object]:
+    """Validate ``raw`` against ``specs``; return checked values keyed by ``key``."""
+    result: dict[str, object] = {}
+    for spec in specs:
+        value = raw.get(spec.key, spec.default)
+        if spec.allow_none_default and value is None:
+            result[spec.key] = None
+            continue
+        if not isinstance(value, spec.expected_type):
+            raise ValueError(spec.error if isinstance(spec.error, str) else spec.error())
+        result[spec.key] = spec.validator(value) if spec.validator else value
+    return result
+
+
+def _str_field(key: str, message: str, *, default: object = _MISSING) -> FieldSpec:
+    """FieldSpec for a required non-empty string, reusing *message* for both checks."""
+
+    def _non_empty(value: object) -> object:
+        if not value:
+            raise ValueError(message)
+        return value
+
+    return FieldSpec(key, str, default=default, error=message, validator=_non_empty)
+
+
+def _str_list_field(key: str, message: str, *, default: object = _MISSING) -> FieldSpec:
+    """FieldSpec for a list of non-empty strings, reusing *message* for both checks."""
+
+    def _non_empty_items(value: object) -> object:
+        if not all(isinstance(part, str) and part for part in cast("list[object]", value)):
+            raise ValueError(message)
+        return value
+
+    return FieldSpec(key, list, default=default, error=message, validator=_non_empty_items)
+
+
+def _opt_str_field(key: str, message: str) -> FieldSpec:
+    """FieldSpec for an optional string that may be omitted (defaults to ``None``)."""
+    return FieldSpec(key, str, default=None, error=message, allow_none_default=True)
+
+
+_PIN_TARGET_FIELDS = [
+    _str_field("path", "Each pin_targets entry must have a non-empty 'path' string"),
+    _str_field("pattern", "Each pin_targets entry must have a non-empty 'pattern' string"),
+]
+
+
 def _load_pin_targets(root: Path, raw_pins: object) -> list[PinTarget]:
     """Parse a list of pin target tables into ``PinTarget`` objects."""
     if not isinstance(raw_pins, list):
@@ -1049,12 +1118,9 @@ def _load_pin_targets(root: Path, raw_pins: object) -> list[PinTarget]:
         if not isinstance(item, dict):
             raise ValueError("Each pin_targets entry must be a table")
         typed_item = cast("dict[str, object]", item)
-        raw_path = typed_item.get("path")
-        raw_pattern = typed_item.get("pattern")
-        if not isinstance(raw_path, str) or not raw_path:
-            raise ValueError("Each pin_targets entry must have a non-empty 'path' string")
-        if not isinstance(raw_pattern, str) or not raw_pattern:
-            raise ValueError("Each pin_targets entry must have a non-empty 'pattern' string")
+        fields = _walk_fields(typed_item, _PIN_TARGET_FIELDS)
+        raw_path = cast("str", fields["path"])
+        raw_pattern = cast("str", fields["pattern"])
 
         # Reject absolute paths early — pin targets must be repository-local
         # relative paths so downstream code can safely call ``relative_to(root)``.
@@ -1099,6 +1165,15 @@ def _load_pin_targets(root: Path, raw_pins: object) -> list[PinTarget]:
     return pins
 
 
+_GENERATED_ASSET_FIELDS = [
+    _str_field("path", "Each generated_assets entry must have a non-empty 'path' string"),
+    _str_list_field(
+        "command",
+        "Each generated_assets entry must have a non-empty 'command' list of strings",
+    ),
+]
+
+
 def _load_generated_assets(root: Path, raw_assets: object) -> list[GeneratedAsset]:
     """Parse a list of generated asset tables into ``GeneratedAsset`` objects."""
     if not isinstance(raw_assets, list):
@@ -1109,24 +1184,31 @@ def _load_generated_assets(root: Path, raw_assets: object) -> list[GeneratedAsse
         if not isinstance(item, dict):
             raise ValueError("Each generated_assets entry must be a table")
         typed_item = cast("dict[str, object]", item)
-        raw_path = typed_item.get("path")
-        raw_command = typed_item.get("command")
+        fields = _walk_fields(typed_item, _GENERATED_ASSET_FIELDS)
+        raw_path = cast("str", fields["path"])
+        raw_command = cast("list[str]", fields["command"])
 
-        if not isinstance(raw_path, str) or not raw_path:
-            raise ValueError("Each generated_assets entry must have a non-empty 'path' string")
-        if not isinstance(raw_command, list) or not all(
-            isinstance(part, str) and part for part in raw_command
-        ):
-            raise ValueError(
-                "Each generated_assets entry must have a non-empty 'command' list of strings",
-            )
-
-        asset = GeneratedAsset(path=Path(raw_path), command=cast("list[str]", raw_command))
+        asset = GeneratedAsset(path=Path(raw_path), command=raw_command)
         asset.validate()
         assets.append(
             GeneratedAsset(path=root / asset.path, command=asset.command),
         )
     return assets
+
+
+_ARTIFACT_TARGET_FIELDS = [
+    _str_field("path", "Each artifact_targets entry must have a non-empty 'path' string"),
+    _str_list_field(
+        "command",
+        "artifact_targets.command must be a list of non-empty strings",
+        default=[],
+    ),
+    _str_list_field(
+        "inputs",
+        "artifact_targets.inputs must be a list of non-empty strings",
+        default=[],
+    ),
+]
 
 
 def _load_artifact_targets(raw_targets: object) -> list[ArtifactTarget]:
@@ -1138,25 +1220,13 @@ def _load_artifact_targets(raw_targets: object) -> list[ArtifactTarget]:
         if not isinstance(item, dict):
             raise ValueError("Each artifact_targets entry must be a table")
         typed_item = cast("dict[str, object]", item)
-        raw_path = typed_item.get("path")
-        if not isinstance(raw_path, str) or not raw_path:
-            raise ValueError("Each artifact_targets entry must have a non-empty 'path' string")
+        fields = _walk_fields(typed_item, _ARTIFACT_TARGET_FIELDS)
         description = str(typed_item.get("description", ""))
-        raw_command = typed_item.get("command", [])
-        if not isinstance(raw_command, list) or not all(
-            isinstance(p, str) and p for p in raw_command
-        ):
-            raise ValueError("artifact_targets.command must be a list of non-empty strings")
-        raw_inputs = typed_item.get("inputs", [])
-        if not isinstance(raw_inputs, list) or not all(
-            isinstance(s, str) and s for s in raw_inputs
-        ):
-            raise ValueError("artifact_targets.inputs must be a list of non-empty strings")
         target = ArtifactTarget(
-            path=raw_path,
+            path=cast("str", fields["path"]),
             description=description,
-            command=cast("list[str]", raw_command),
-            inputs=cast("list[str]", raw_inputs),
+            command=cast("list[str]", fields["command"]),
+            inputs=cast("list[str]", fields["inputs"]),
         )
         target.validate()
         targets.append(target)
@@ -1172,19 +1242,42 @@ def _load_publish_targets(raw_targets: object) -> dict[str, PublishTarget]:
         if not isinstance(raw_entry, dict):
             raise ValueError(f"publish_targets.{name} must be a table")
         typed_entry = cast("dict[str, object]", raw_entry)
-        remote = typed_entry.get("remote", "")
-        if not isinstance(remote, str) or not remote:
-            raise ValueError(f"publish_targets.{name} must have a non-empty 'remote'")
-        branch = typed_entry.get("branch", "main")
-        if not isinstance(branch, str) or not branch:
-            raise ValueError(f"publish_targets.{name} must have a non-empty 'branch'")
-        message = typed_entry.get("message", "Initial commit")
-        if not isinstance(message, str) or not message:
-            raise ValueError(f"publish_targets.{name} must have a non-empty 'message'")
-        target = PublishTarget(remote=remote, branch=branch, message=message)
+        fields = _walk_fields(
+            typed_entry,
+            [
+                _str_field(
+                    "remote", f"publish_targets.{name} must have a non-empty 'remote'", default=""
+                ),
+                _str_field(
+                    "branch",
+                    f"publish_targets.{name} must have a non-empty 'branch'",
+                    default="main",
+                ),
+                _str_field(
+                    "message",
+                    f"publish_targets.{name} must have a non-empty 'message'",
+                    default="Initial commit",
+                ),
+            ],
+        )
+        target = PublishTarget(
+            remote=cast("str", fields["remote"]),
+            branch=cast("str", fields["branch"]),
+            message=cast("str", fields["message"]),
+        )
         target.validate()
         targets[name] = target
     return targets
+
+
+_VERSION_TARGET_FIELDS = [
+    _str_field("path", "Each version target must have a non-empty 'path' string"),
+    _opt_str_field("kind", "kind must be a string when provided"),
+    _opt_str_field("pattern", "pattern must be a string when provided"),
+    _opt_str_field("section", "section must be a string when provided"),
+    _opt_str_field("field", "field must be a string when provided"),
+    _opt_str_field("ci_format", "ci_format must be a string when provided"),
+]
 
 
 def _load_version_group(
@@ -1205,46 +1298,45 @@ def _load_version_group(
         if not isinstance(item, dict):
             raise ValueError("Each version target must be a table")
         typed_item = cast("dict[str, object]", item)
-        raw_path = typed_item.get("path")
-        if not isinstance(raw_path, str) or not raw_path:
-            raise ValueError("Each version target must have a non-empty 'path' string")
-        raw_kind = typed_item.get("kind")
-        raw_pattern = typed_item.get("pattern")
-        raw_section = typed_item.get("section")
-        raw_field = typed_item.get("field")
-        raw_ci_format = typed_item.get("ci_format")
-        if raw_kind is not None and not isinstance(raw_kind, str):
-            raise ValueError("kind must be a string when provided")
-        if raw_pattern is not None and not isinstance(raw_pattern, str):
-            raise ValueError("pattern must be a string when provided")
-        if raw_section is not None and not isinstance(raw_section, str):
-            raise ValueError("section must be a string when provided")
-        if raw_field is not None and not isinstance(raw_field, str):
-            raise ValueError("field must be a string when provided")
-        if raw_ci_format is not None and not isinstance(raw_ci_format, str):
-            raise ValueError("ci_format must be a string when provided")
+        fields = _walk_fields(typed_item, _VERSION_TARGET_FIELDS)
+        raw_path = cast("str", fields["path"])
         target = VersionTarget(
             path=root / raw_path,
-            kind=raw_kind,
-            pattern=raw_pattern,
-            section=raw_section,
-            field=raw_field,
-            ci_format=raw_ci_format,
+            kind=cast("str | None", fields["kind"]),
+            pattern=cast("str | None", fields["pattern"]),
+            section=cast("str | None", fields["section"]),
+            field=cast("str | None", fields["field"]),
+            ci_format=cast("str | None", fields["ci_format"]),
         )
         target.validate()
         targets.append(target)
 
-    release_branch = raw_group.get("release_branch", defaults["release_branch"])
-    if not isinstance(release_branch, str):
-        raise ValueError("release_branch must be a string")
-
-    changelog_value = raw_group.get("changelog_file", defaults["changelog_file"])
-    if not isinstance(changelog_value, str):
-        raise ValueError("changelog_file must be a string")
-
-    changelog_workflow = raw_group.get("changelog_workflow", defaults["changelog_workflow"])
-    if not isinstance(changelog_workflow, str):
-        raise ValueError("changelog_workflow must be a string")
+    simple_fields = _walk_fields(
+        raw_group,
+        [
+            FieldSpec(
+                "release_branch",
+                str,
+                default=defaults["release_branch"],
+                error="release_branch must be a string",
+            ),
+            FieldSpec(
+                "changelog_file",
+                str,
+                default=defaults["changelog_file"],
+                error="changelog_file must be a string",
+            ),
+            FieldSpec(
+                "changelog_workflow",
+                str,
+                default=defaults["changelog_workflow"],
+                error="changelog_workflow must be a string",
+            ),
+        ],
+    )
+    release_branch = cast("str", simple_fields["release_branch"])
+    changelog_value = cast("str", simple_fields["changelog_file"])
+    changelog_workflow = cast("str", simple_fields["changelog_workflow"])
     if changelog_workflow not in VALID_CHANGELOG_WORKFLOWS:
         allowed = ", ".join(sorted(VALID_CHANGELOG_WORKFLOWS))
         raise ValueError(f"changelog_workflow must be one of {allowed}, got {changelog_workflow!r}")
@@ -1288,20 +1380,27 @@ def _load_version_group(
     upstream_tbl = raw_group.get("upstream", {})
     if not isinstance(upstream_tbl, dict):
         raise ValueError("upstream must be a table when provided")
-    upstream_package = upstream_tbl.get("package")
-    if upstream_package is not None and not isinstance(upstream_package, str):
-        raise ValueError("upstream.package must be a string when provided")
-    upstream_provider = upstream_tbl.get("provider", "pypi")
-    if not isinstance(upstream_provider, str):
-        raise ValueError("upstream.provider must be a string")
+    upstream_fields = _walk_fields(
+        cast("dict[str, object]", upstream_tbl),
+        [
+            _opt_str_field("package", "upstream.package must be a string when provided"),
+            FieldSpec("provider", str, default="pypi", error="upstream.provider must be a string"),
+            FieldSpec(
+                "commit_message",
+                str,
+                default="Mirror: {version}",
+                error="upstream.commit_message must be a string",
+            ),
+        ],
+    )
+    upstream_package = cast("str | None", upstream_fields["package"])
+    upstream_provider = cast("str", upstream_fields["provider"])
     if upstream_provider not in VALID_UPSTREAM_PROVIDERS:
         allowed = ", ".join(sorted(VALID_UPSTREAM_PROVIDERS))
         raise ValueError(
             f"upstream.provider {upstream_provider!r} is not valid; must be one of {allowed}"
         )
-    upstream_commit_message = upstream_tbl.get("commit_message", "Mirror: {version}")
-    if not isinstance(upstream_commit_message, str):
-        raise ValueError("upstream.commit_message must be a string")
+    upstream_commit_message = cast("str", upstream_fields["commit_message"])
 
     return VersionGroup(
         name=group_name,


### PR DESCRIPTION
## Summary

Phase 3 of the approved modernization plan (rebased onto `main` after #152 landed Phase 6a + Phase 2). Six commits:

- **`load_config_or_exit` seam** — `describe_config_load_error()` in `commands/_common.py` centralizes the *classification* of a failed `load_or_autodetect_config` call (four outcomes: no config file, missing `[tool.rrt]`, other ValueError, RuntimeError) without owning printing/exit, since call sites genuinely differ there. 8 files adopted it. `changelog_compare.py`/`changelog_lint.py` use a separate, simpler duplicate pattern that doesn't need this machinery and were correctly left alone.
- **Declarative field-spec walker** in `config/core.py` — a table-driven `FieldSpec`/`_walk_fields` validator replaces the imperative isinstance/raise ladders for `version_group`, `pin_targets`, `generated_assets`, `artifact_targets`, `publish_targets`. Every `ValueError` message stays byte-identical (pinned by the existing config unit suite).
  - **Honest finding:** the file *grew* (1391 → 1490 lines) — the walker's fixed overhead isn't amortized across only 5 ladders. But complexity dropped hard: `_load_version_group` CCN 42 → 23, `_load_pin_targets` 19 → 15, `_load_generated_assets`/`_load_artifact_targets`/`_load_publish_targets` all down 60–70%. The brief's ≥25%-shrink target was the wrong proxy for this technique; complexity reduction is the real, substantial win.
- **Typed `Options` dataclasses** — 18 of ~32 command files converted from scattered `getattr(args, ..., default)` reads to a per-command frozen `Options.from_args(args)` built once at the top of each `cmd_*` handler, including both files the brief named as highest priority: `bump.py` (CCN 62) and `tree.py` (CCN 54). Every `cmd_*` body now reads `opts.xxx` exclusively; remaining `getattr` calls are consolidated into each file's single `from_args()` classmethod (the actual goal — one source of truth per flag).
  - **Remaining scope folded into Phase 4** (command-core extraction touches most of these same files anyway): `docs_cmd.py`, `eol_check.py`, `ci_version.py`, `sync_cmd.py`, `config_cmd.py`, `artifacts_cmd.py`, `folder.py`, `doctor.py`, `git_inspect.py`, `git_sync.py`, and a few smaller files.

## Test plan

- [x] `uv run pytest -q -m "not runtime and not e2e"` — 2,922 passed, coverage 100.00%
- [x] `uv run pytest -m e2e --no-cov` — 71 passed (characterization suite untouched)
- [x] `uvx pre-commit run --all-files` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjTsHn8U7Lmp9Uax8tNBHG