### PR TITLE
fix(ci): grant pull-requests:write so Claude Review can post comments

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 


### PR DESCRIPTION
## Summary

Investigated why the "🤖 Claude Review" job never posts a comment on any PR despite completing successfully.

**Root cause:** the job's `permissions:` block has granted `pull-requests: read` since the workflow was first added (`064e2b0`, unchanged since). The `code-review` plugin's review step posts its result via `gh pr comment`, which needs write access — with read-only, that call 403s *inside Claude's own tool-use loop* rather than as a top-level Actions step failure, so the job still reports `success` (or even hangs at `in_progress` indefinitely) while never actually posting.

**Confirmed via GitHub MCP:** zero Claude comments across PRs #152/#154/#155 despite each job completing; `copilot-pull-request-reviewer[bot]` *did* post successfully on the same PRs, ruling out a repo-wide bot-comment block.

One-line fix: `pull-requests: read` → `pull-requests: write`. `contents` and `issues` stay read-only.

This is likely a generic misconfiguration in the standard Claude Code Review workflow scaffold — worth checking any other repos using the same template.

## Test plan

- [x] Config-only change, no code paths affected
- [ ] Verify on the next PR (including this one, once merged) that Claude Review actually posts a comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjTsHn8U7Lmp9Uax8tNBHG