### PR TITLE
refactor: command-core extraction for doctor/git_inspect/release_cmd + folded Options sweep (modernization phase 4, part 2)

### DIFF
--- a/src/repo_release_tools/commands/artifacts_cmd.py
+++ b/src/repo_release_tools/commands/artifacts_cmd.py
@@ -47,6 +47,7 @@ from __future__ import annotations
 
 import argparse
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -89,15 +90,59 @@ def _target_dicts(config: RrtConfig) -> list[dict[str, Any]]:
     ]
 
 
+@dataclass(frozen=True)
+class Options:
+    """Typed view of ``argparse.Namespace`` for ``rrt artifacts``.
+
+    Built once via :meth:`from_args` at the top of :func:`cmd_artifacts` so
+    every flag has a single, typed read site instead of scattered
+    ``getattr(args, ..., default)`` calls throughout the function body.
+    """
+
+    verbose: int
+    snapshot: bool
+    check: bool
+    list: bool
+    regenerate: bool
+    dry_run: bool
+    strict: bool
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> Options:
+        """Build an :class:`Options` from a parsed ``argparse.Namespace``.
+
+        Every flag is given a real default by artifacts_cmd.py's own
+        register(), so a Namespace produced by artifacts_cmd.py's own
+        argparse subparser always carries all of them. But
+        workflow/hooks.py's three "artifacts-*" dispatch cases
+        (workflow/hooks.py:1467-1487) each build a partial Namespace by
+        hand: "artifacts-check" never sets ``regenerate`` or ``dry_run``,
+        and "artifacts-snapshot" never sets ``dry_run``, so the getattr
+        fallback here absorbs those gaps as well as the sparse
+        ``argparse.Namespace`` objects several unit tests in
+        tests/commands/test_artifacts_cmd.py construct by hand.
+        """
+        return cls(
+            verbose=getattr(args, "verbose", 0) or 0,
+            snapshot=getattr(args, "snapshot", False),
+            check=getattr(args, "check", False),
+            list=getattr(args, "list", False),
+            regenerate=getattr(args, "regenerate", False),
+            dry_run=getattr(args, "dry_run", False),
+            strict=getattr(args, "strict", False),
+        )
+
+
 def cmd_artifacts(args: argparse.Namespace) -> int:
     """Run artifact integrity check, snapshot, or list."""
-    verbose: int = getattr(args, "verbose", 0) or 0
-    do_snapshot: bool = getattr(args, "snapshot", False)
-    do_check: bool = getattr(args, "check", False)
-    do_list: bool = getattr(args, "list", False)
-    do_regenerate: bool = getattr(args, "regenerate", False)
-    dry_run: bool = getattr(args, "dry_run", False)
-    strict: bool = getattr(args, "strict", False)
+    opts = Options.from_args(args)
+    verbose: int = opts.verbose
+    do_snapshot: bool = opts.snapshot
+    do_check: bool = opts.check
+    do_list: bool = opts.list
+    do_regenerate: bool = opts.regenerate
+    dry_run: bool = opts.dry_run
+    strict: bool = opts.strict
 
     p = VerbosePrinter(verbose=verbose)
 

--- a/src/repo_release_tools/commands/ci_version.py
+++ b/src/repo_release_tools/commands/ci_version.py
@@ -152,25 +152,111 @@ def compute_published_version(base_version: str, context: GitHubContext) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Typed options
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ComputeOptions:
+    """Typed view of ``argparse.Namespace`` for ``rrt ci-version compute``.
+
+    Built once via :meth:`from_args` at the top of :func:`cmd_ci_version_compute`
+    (and reused by :func:`cmd_ci_version_sync`, which shares the same flag
+    surface) so every flag has a single, typed read site instead of scattered
+    ``getattr(args, ..., default)`` calls throughout the function bodies.
+    """
+
+    verbose: int
+    base: str | None
+    group: str | None
+    ref: str | None
+    ref_name: str | None
+    run_id: str | None
+    run_attempt: str | None
+    dry_run: bool
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> ComputeOptions:
+        """Build a :class:`ComputeOptions` from a parsed ``argparse.Namespace``.
+
+        Every flag below is given a real default by ``_add_compute_args``
+        (or, for ``--verbose``, by cli.py's global parser), so a Namespace
+        produced by argparse always carries every attribute. The getattr
+        fallbacks here exist only because some unit tests in
+        tests/commands/test_ci_version.py construct sparse
+        ``argparse.Namespace`` objects by hand instead of going through
+        ``register()``; this is the single translation point that absorbs
+        that, so the rest of the command can read ``opts.x`` unconditionally.
+        ``dry_run`` is absent on ``compute`` (no ``--dry-run`` flag there) so
+        it defaults to ``False``; ``sync`` always sets it via argparse.
+        """
+        return cls(
+            verbose=getattr(args, "verbose", 0) or 0,
+            base=getattr(args, "base", None),
+            group=getattr(args, "group", None),
+            ref=getattr(args, "ref", None),
+            ref_name=getattr(args, "ref_name", None),
+            run_id=getattr(args, "run_id", None),
+            run_attempt=getattr(args, "run_attempt", None),
+            dry_run=getattr(args, "dry_run", False),
+        )
+
+
+@dataclass(frozen=True)
+class ApplyOptions:
+    """Typed view of ``argparse.Namespace`` for ``rrt ci-version apply``.
+
+    Built once via :meth:`from_args` at the top of :func:`cmd_ci_version_apply`
+    so every flag has a single, typed read site instead of scattered
+    ``getattr(args, ..., default)`` / ``args.x`` calls throughout the
+    function body.
+    """
+
+    verbose: int
+    version: str
+    dry_run: bool
+    group: str | None
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> ApplyOptions:
+        """Build an :class:`ApplyOptions` from a parsed ``argparse.Namespace``.
+
+        ``version`` and ``dry_run`` are given real defaults by ``register()``
+        (``version`` is a required positional, ``dry_run`` defaults to
+        ``False`` via ``store_true``), so a Namespace produced by argparse
+        always carries both. The getattr fallbacks here exist only because
+        some unit tests construct sparse ``argparse.Namespace`` objects by
+        hand (e.g. without ``group`` or ``verbose``); this is the single
+        translation point that absorbs that.
+        """
+        return cls(
+            verbose=getattr(args, "verbose", 0) or 0,
+            version=getattr(args, "version", ""),
+            dry_run=getattr(args, "dry_run", False),
+            group=getattr(args, "group", None),
+        )
+
+
+# ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
 
 
-def _context_from_args(args: argparse.Namespace) -> GitHubContext:
+def _context_from_opts(opts: ComputeOptions) -> GitHubContext:
     """Build a :class:`GitHubContext` merging CLI flags over env variables."""
     env = GitHubContext.from_env()
     return GitHubContext(
-        ref=getattr(args, "ref", None) or env.ref,
-        ref_name=getattr(args, "ref_name", None) or env.ref_name,
-        run_id=getattr(args, "run_id", None) or env.run_id,
-        run_attempt=getattr(args, "run_attempt", None) or env.run_attempt,
+        ref=opts.ref or env.ref,
+        ref_name=opts.ref_name or env.ref_name,
+        run_id=opts.run_id or env.run_id,
+        run_attempt=opts.run_attempt or env.run_attempt,
     )
 
 
-def _resolve_base(args: argparse.Namespace, root: Path) -> str | None:
+def _resolve_base(opts: ComputeOptions, root: Path) -> str | None:
     """Return the base version string from ``--base`` or the first version target."""
-    if args.base:
-        return args.base
+    if opts.base:
+        return opts.base
     try:
         config = load_or_autodetect_config(root)
         if config.autodetected:
@@ -179,7 +265,7 @@ def _resolve_base(args: argparse.Namespace, root: Path) -> str | None:
             if mismatch := check_autodetected_version_consistency(config):
                 p.line(mismatch, ok=False, stream=sys.stderr)
                 return None
-        group = config.resolve_group(getattr(args, "group", None))
+        group = config.resolve_group(opts.group)
         return str(read_group_current_version(group))
     except (FileNotFoundError, ValueError, RuntimeError) as exc:
         err = describe_config_load_error(exc, root)
@@ -208,18 +294,18 @@ def cmd_ci_version_compute(args: argparse.Namespace) -> int:
 
         VERSION=$(rrt ci-version compute)
     """
-    verbose: int = getattr(args, "verbose", 0) or 0
+    opts = ComputeOptions.from_args(args)
 
     root = find_repo_root(Path.cwd())
-    base = _resolve_base(args, root)
+    base = _resolve_base(opts, root)
     if base is None:
         return 1
 
-    context = _context_from_args(args)
+    context = _context_from_opts(opts)
     try:
         version = compute_published_version(base, context)
     except ValueError as exc:
-        p = VerbosePrinter(verbose=verbose)
+        p = VerbosePrinter(verbose=opts.verbose)
         p.line(str(exc), ok=False, stream=sys.stderr)
         return 1
     # Machine-readable output: keep raw version on stdout
@@ -234,18 +320,18 @@ def cmd_ci_version_apply(args: argparse.Namespace) -> int:
     Cargo / TOML targets (``ci_format = "semver_pre"``) receive the version
     after conversion via :func:`to_semver`.
     """
-    verbose: int = getattr(args, "verbose", 0) or 0
+    opts = ApplyOptions.from_args(args)
     root = find_repo_root(Path.cwd())
 
     try:
         config = load_or_autodetect_config(root)
         if config.autodetected:
-            p = VerbosePrinter(verbose=verbose)
+            p = VerbosePrinter(verbose=opts.verbose)
             p.line(format_autodetected_config_notice(config), ok=False, stream=sys.stderr)
-        group = config.resolve_group(getattr(args, "group", None))
+        group = config.resolve_group(opts.group)
     except (FileNotFoundError, ValueError, RuntimeError) as exc:
         err = describe_config_load_error(exc, root)
-        p = VerbosePrinter(verbose=verbose)
+        p = VerbosePrinter(verbose=opts.verbose)
         if err.kind == "no_config_file":
             p.line("No supported rrt config file found.", ok=False, stream=sys.stderr)
             p.action(err.text, stream=sys.stderr)
@@ -258,7 +344,7 @@ def cmd_ci_version_apply(args: argparse.Namespace) -> int:
 
     ci_targets = [t for t in group.version_targets if t.ci_format in VALID_CI_FORMATS]
     if not ci_targets:
-        p = VerbosePrinter(verbose=verbose)
+        p = VerbosePrinter(verbose=opts.verbose)
         p.line(
             "No version targets with ci_format configured. "
             'Add ci_format = "pep440" or ci_format = "semver_pre" to the selected version group.',
@@ -267,10 +353,10 @@ def cmd_ci_version_apply(args: argparse.Namespace) -> int:
         )
         return 1
 
-    version: str = args.version
+    version: str = opts.version
 
     progress = ProgressLine(file=sys.stdout)
-    p = DryRunPrinter(args.dry_run, verbose=verbose)
+    p = DryRunPrinter(opts.dry_run, verbose=opts.verbose)
     p.line(rule("Applying CI versions", width=terminal_width()))
     total = len(ci_targets)
     for i, target in enumerate(ci_targets, 1):
@@ -281,7 +367,7 @@ def cmd_ci_version_apply(args: argparse.Namespace) -> int:
             # rather than writing an invalid Cargo SemVer string.
             if version_str == version and ".dev" in version:
                 progress.clear()
-                p_err = VerbosePrinter(verbose=verbose)
+                p_err = VerbosePrinter(verbose=opts.verbose)
                 p_err.line(
                     f"Cannot convert {version!r} to a Cargo-compatible SemVer prerelease. "
                     "Only versions ending in '.dev<digits>' are supported (e.g. 0.2.0.dev42).",
@@ -294,11 +380,11 @@ def cmd_ci_version_apply(args: argparse.Namespace) -> int:
         if total > 1 and i > 1:
             progress.clear()
         try:
-            event = replace_version_in_file(target, version_str, dry_run=args.dry_run)
+            event = replace_version_in_file(target, version_str, dry_run=opts.dry_run)
             render_version_write_events([event])
         except (FileNotFoundError, RuntimeError) as exc:
             progress.clear()
-            p = VerbosePrinter(verbose=verbose)
+            p = VerbosePrinter(verbose=opts.verbose)
             p.line(str(exc), ok=False, stream=sys.stderr)
             return 1
         if total > 1:
@@ -306,7 +392,7 @@ def cmd_ci_version_apply(args: argparse.Namespace) -> int:
 
     progress.clear()
     p.blank_line()
-    if args.dry_run:
+    if opts.dry_run:
         p.line(
             subtle(
                 f"{GLYPHS.bullet.skip} [dry-run] complete {GLYPHS.typography.mdash} no files were modified",
@@ -322,27 +408,27 @@ def cmd_ci_version_sync(args: argparse.Namespace) -> int:
 
     Equivalent to running ``compute`` followed by ``apply`` with the result.
     """
-    verbose: int = getattr(args, "verbose", 0) or 0
+    opts = ComputeOptions.from_args(args)
 
     root = find_repo_root(Path.cwd())
-    base = _resolve_base(args, root)
+    base = _resolve_base(opts, root)
     if base is None:
         return 1
 
-    context = _context_from_args(args)
+    context = _context_from_opts(opts)
     try:
         version = compute_published_version(base, context)
     except ValueError as exc:
-        p = VerbosePrinter(verbose=verbose)
+        p = VerbosePrinter(verbose=opts.verbose)
         p.line(str(exc), ok=False, stream=sys.stderr)
         return 1
-    p = VerbosePrinter(verbose=verbose)
+    p = VerbosePrinter(verbose=opts.verbose)
     p.action(f"Applying published version: {version}")
 
     apply_args = argparse.Namespace(
         version=version,
-        dry_run=args.dry_run,
-        group=getattr(args, "group", None),
+        dry_run=opts.dry_run,
+        group=opts.group,
     )
     return cmd_ci_version_apply(apply_args)
 

--- a/src/repo_release_tools/commands/config_cmd.py
+++ b/src/repo_release_tools/commands/config_cmd.py
@@ -86,6 +86,7 @@ import difflib
 import importlib.resources
 import json
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 from repo_release_tools import config as cfg
@@ -271,12 +272,58 @@ def _cmd_reference(*, check: bool, dry_run: bool) -> int:
     return 0
 
 
+@dataclass(frozen=True)
+class Options:
+    """Typed view of ``argparse.Namespace`` for ``rrt config``.
+
+    Built once via :meth:`from_args` at the top of :func:`cmd_config` so
+    every flag has a single, typed read site instead of scattered
+    ``getattr(args, ..., default)`` calls throughout the function body.
+    """
+
+    verbose: int
+    schema: bool
+    reference: bool
+    check: bool
+    dry_run: bool
+    validate: bool
+    raw: bool
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> Options:
+        """Build an :class:`Options` from a parsed ``argparse.Namespace``.
+
+        Every flag other than ``verbose`` is given a real default by
+        config_cmd.py's own register(), and workflow/hooks.py's
+        "config-validate" and "config-reference-check" dispatch cases
+        (workflow/hooks.py:1379-1401) each build a fully populated
+        ``argparse.Namespace`` with every one of these fields set
+        explicitly, so a Namespace from either caller always carries them.
+        The getattr fallbacks here exist only because some unit tests in
+        tests/commands/test_config_cmd.py construct sparse
+        ``argparse.Namespace`` objects by hand instead of going through
+        register(). ``verbose`` is set globally by cli.py's parser (and
+        explicitly by hooks.py's dispatch cases), but tests may omit it, so
+        the fallback here absorbs that gap too.
+        """
+        return cls(
+            verbose=getattr(args, "verbose", 0) or 0,
+            schema=getattr(args, "schema", False),
+            reference=getattr(args, "reference", False),
+            check=getattr(args, "check", False),
+            dry_run=getattr(args, "dry_run", False),
+            validate=getattr(args, "validate", False),
+            raw=getattr(args, "raw", False),
+        )
+
+
 def cmd_config(args: argparse.Namespace) -> int:
     """Print the resolved rrt config as a tree."""
-    verbose: int = getattr(args, "verbose", 0) or 0
+    opts = Options.from_args(args)
+    verbose: int = opts.verbose
     root = cfg.find_repo_root(Path.cwd())
 
-    if getattr(args, "schema", False):
+    if opts.schema:
         schema = _load_schema()
         if not schema:
             p = VerbosePrinter(verbose=verbose)
@@ -289,13 +336,13 @@ def cmd_config(args: argparse.Namespace) -> int:
         sys.stdout.write(json.dumps(schema, indent=2) + "\n")
         return 0
 
-    if getattr(args, "reference", False):
+    if opts.reference:
         return _cmd_reference(
-            check=getattr(args, "check", False),
-            dry_run=getattr(args, "dry_run", False),
+            check=opts.check,
+            dry_run=opts.dry_run,
         )
 
-    if getattr(args, "validate", False):
+    if opts.validate:
         return _cmd_validate(root)
 
     try:
@@ -311,7 +358,7 @@ def cmd_config(args: argparse.Namespace) -> int:
         return 1
 
     # --raw: syntax-highlighted view of the raw config file
-    if getattr(args, "raw", False):
+    if opts.raw:
         config_path = conf.config_file
         try:
             raw_text = config_path.read_text(encoding="utf-8")

--- a/src/repo_release_tools/commands/docs_cmd.py
+++ b/src/repo_release_tools/commands/docs_cmd.py
@@ -84,6 +84,7 @@ from __future__ import annotations
 
 import argparse
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 from repo_release_tools.commands.docs_suggest import cmd_docs_suggest
@@ -160,17 +161,56 @@ def _build_docs_lock_sources(entries: list[DocEntry]) -> list[dict[str, object]]
 # ---------------------------------------------------------------------------
 
 
+@dataclass(frozen=True)
+class GenerateOptions:
+    """Typed view of ``argparse.Namespace`` for ``rrt docs generate``.
+
+    Built once via :meth:`from_args` at the top of :func:`_cmd_generate` so
+    every flag has a single, typed read site instead of scattered
+    ``getattr(args, ..., default)`` / ``args.x`` calls throughout the
+    function body.
+    """
+
+    verbose: int
+    root: str
+    dry_run: bool
+    lang: str | None
+    format: str | None
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> GenerateOptions:
+        """Build a :class:`GenerateOptions` from a parsed ``argparse.Namespace``.
+
+        Every flag below is given a real default by ``register()`` (or, for
+        ``--verbose``, by cli.py's global parser), so a Namespace produced by
+        argparse's own ``rrt docs generate`` parser always carries every
+        attribute. The getattr fallbacks here absorb two other real callers:
+        unit tests in tests/commands/test_docs_cmd.py that construct sparse
+        ``argparse.Namespace`` objects by hand, and workflow/hooks.py's
+        ``docs-generate`` dispatch case, which always sets ``root``,
+        ``dry_run``, ``format``, and ``lang`` explicitly but relies on this
+        fallback for ``verbose`` timing.
+        """
+        return cls(
+            verbose=getattr(args, "verbose", 0) or 0,
+            root=getattr(args, "root", "."),
+            dry_run=getattr(args, "dry_run", False),
+            lang=getattr(args, "lang", None),
+            format=getattr(args, "format", None),
+        )
+
+
 def _cmd_generate(args: argparse.Namespace) -> int:
-    verbose: int = getattr(args, "verbose", 0) or 0
-    cwd = Path(args.root)
-    p = DryRunPrinter(dry_run=args.dry_run, verbose=verbose)
+    opts = GenerateOptions.from_args(args)
+    cwd = Path(opts.root)
+    p = DryRunPrinter(dry_run=opts.dry_run, verbose=opts.verbose)
     p.header("rrt docs generate")
 
     config = _config_for_cwd(cwd)
 
     # Override languages / formats from CLI if provided
-    if getattr(args, "lang", None):
-        raw_langs = [l.strip().lower() for l in args.lang.split(",") if l.strip()]  # noqa: E741
+    if opts.lang:
+        raw_langs = [l.strip().lower() for l in opts.lang.split(",") if l.strip()]  # noqa: E741
         from repo_release_tools.config import _VALID_LANGUAGES
 
         if invalid := [ln for ln in raw_langs if ln not in _VALID_LANGUAGES]:
@@ -184,7 +224,7 @@ def _cmd_generate(args: argparse.Namespace) -> int:
 
         config = dc_replace(config, languages=tuple(raw_langs))
 
-    fmt = getattr(args, "format", None) or config.formats[0]
+    fmt = opts.format or config.formats[0]
 
     p.section("Scanning sources")
     entries = extract_docs_from_dir(cwd, config)
@@ -196,7 +236,7 @@ def _cmd_generate(args: argparse.Namespace) -> int:
 
     p.section(f"Rendering ({fmt})")
 
-    if args.dry_run and fmt == "toml":
+    if opts.dry_run and fmt == "toml":
         # In dry-run mode: build lock but don't write
         sources = _build_docs_lock_sources(entries)
         build_lock(sources)  # validate structure; don't write
@@ -227,13 +267,45 @@ def _cmd_generate(args: argparse.Namespace) -> int:
 # ---------------------------------------------------------------------------
 
 
+@dataclass(frozen=True)
+class CheckOptions:
+    """Typed view of ``argparse.Namespace`` for ``rrt docs check``.
+
+    Built once via :meth:`from_args` at the top of :func:`_cmd_check` so
+    every flag has a single, typed read site instead of ``getattr(args,
+    ..., default)`` / ``args.x`` calls throughout the function body.
+    """
+
+    verbose: int
+    root: str
+    lock_file: str | None
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> CheckOptions:
+        """Build a :class:`CheckOptions` from a parsed ``argparse.Namespace``.
+
+        ``root`` and ``lock_file`` are given real defaults by ``register()``
+        (or, for ``--verbose``, by cli.py's global parser), so a Namespace
+        produced by argparse's own ``rrt docs check`` parser always carries
+        every attribute. The getattr fallbacks here absorb unit tests in
+        tests/commands/test_docs_cmd.py that construct sparse
+        ``argparse.Namespace`` objects by hand; ``check-docs`` is not
+        currently dispatched from workflow/hooks.py.
+        """
+        return cls(
+            verbose=getattr(args, "verbose", 0) or 0,
+            root=getattr(args, "root", "."),
+            lock_file=getattr(args, "lock_file", None),
+        )
+
+
 def _cmd_check(args: argparse.Namespace) -> int:
-    verbose: int = getattr(args, "verbose", 0) or 0
-    cwd = Path(args.root)
-    p = VerbosePrinter(verbose=verbose)
+    opts = CheckOptions.from_args(args)
+    cwd = Path(opts.root)
+    p = VerbosePrinter(verbose=opts.verbose)
     config = _config_for_cwd(cwd)
 
-    lock_file = getattr(args, "lock_file", None) or config.lock_file
+    lock_file = opts.lock_file or config.lock_file
     lock_path = docs_lock_path(cwd, lock_file)
 
     entries = extract_docs_from_dir(cwd, config)
@@ -261,15 +333,53 @@ def _cmd_check(args: argparse.Namespace) -> int:
 # ---------------------------------------------------------------------------
 
 
+@dataclass(frozen=True)
+class PublishOptions:
+    """Typed view of ``argparse.Namespace`` for ``rrt docs publish``.
+
+    Built once via :meth:`from_args` at the top of :func:`_cmd_publish` so
+    every flag has a single, typed read site instead of scattered
+    ``getattr(args, ..., default)`` calls throughout the function body.
+    """
+
+    verbose: int
+    root: str
+    check: bool
+    dry_run: bool
+    fail_on_change: bool
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> PublishOptions:
+        """Build a :class:`PublishOptions` from a parsed ``argparse.Namespace``.
+
+        Every flag below is given a real default by ``register()`` (or, for
+        ``--verbose``, by cli.py's global parser), so a Namespace produced by
+        argparse's own ``rrt docs publish`` parser always carries every
+        attribute. The getattr fallbacks here absorb two other real callers:
+        unit tests in tests/commands/test_docs_cmd.py that construct sparse
+        ``argparse.Namespace`` objects by hand, and workflow/hooks.py's
+        ``docs-publish`` dispatch case, which always sets ``root``, ``check``,
+        ``dry_run``, and ``fail_on_change`` explicitly but relies on this
+        fallback for ``verbose`` timing.
+        """
+        return cls(
+            verbose=getattr(args, "verbose", 0) or 0,
+            root=getattr(args, "root", "."),
+            check=getattr(args, "check", False),
+            dry_run=getattr(args, "dry_run", False),
+            fail_on_change=getattr(args, "fail_on_change", False),
+        )
+
+
 def _cmd_publish(args: argparse.Namespace) -> int:
     """Write all generated CLI-reference doc files to disk (or check for staleness)."""
-    verbose: int = getattr(args, "verbose", 0) or 0
+    opts = PublishOptions.from_args(args)
     from repo_release_tools.docs import publisher as docs_publisher  # noqa: PLC0415
 
-    check: bool = getattr(args, "check", False)
-    dry_run: bool = getattr(args, "dry_run", False)
-    fail_on_change: bool = getattr(args, "fail_on_change", False)
-    root = Path(getattr(args, "root", ".")).resolve()
+    check: bool = opts.check
+    dry_run: bool = opts.dry_run
+    fail_on_change: bool = opts.fail_on_change
+    root = Path(opts.root).resolve()
 
     cfg = None
     try:
@@ -290,7 +400,7 @@ def _cmd_publish(args: argparse.Namespace) -> int:
         return 1
 
     if dry_run:
-        p = DryRunPrinter(dry_run=True, verbose=verbose)
+        p = DryRunPrinter(dry_run=True, verbose=opts.verbose)
         for target, _rendered in rendered_targets:
             p.would_write(str(target.output_path))
         return 0
@@ -432,15 +542,53 @@ def _expand_platform_vars(content: str, docs: DocsConfig) -> str:
     return content
 
 
+@dataclass(frozen=True)
+class InjectOptions:
+    """Typed view of ``argparse.Namespace`` for ``rrt docs inject``.
+
+    Built once via :meth:`from_args` at the top of :func:`_cmd_inject` so
+    every flag has a single, typed read site instead of scattered
+    ``getattr(args, ..., default)`` calls throughout the function body.
+    """
+
+    verbose: int
+    root: str
+    check: bool
+    dry_run: bool
+    add_anchors: bool
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> InjectOptions:
+        """Build an :class:`InjectOptions` from a parsed ``argparse.Namespace``.
+
+        Every flag below is given a real default by ``register()`` (or, for
+        ``--verbose``, by cli.py's global parser), so a Namespace produced by
+        argparse's own ``rrt docs inject`` parser always carries every
+        attribute. The getattr fallbacks here absorb two other real callers:
+        unit tests in tests/commands/test_docs_cmd.py that construct sparse
+        ``argparse.Namespace`` objects by hand, and workflow/hooks.py's
+        ``docs-inject`` dispatch case, which always sets ``root``, ``check``,
+        ``dry_run``, and ``add_anchors`` explicitly but relies on this
+        fallback for ``verbose`` timing.
+        """
+        return cls(
+            verbose=getattr(args, "verbose", 0) or 0,
+            root=getattr(args, "root", "."),
+            check=getattr(args, "check", False),
+            dry_run=getattr(args, "dry_run", False),
+            add_anchors=getattr(args, "add_anchors", False),
+        )
+
+
 def _cmd_inject(args: argparse.Namespace) -> int:
     """Inject or verify all shared anchor blocks from [tool.rrt.docs.shared_blocks]."""
-    verbose: int = getattr(args, "verbose", 0) or 0
+    opts = InjectOptions.from_args(args)
     from repo_release_tools import __version__ as rrt_version  # noqa: PLC0415
 
-    check: bool = getattr(args, "check", False)
-    dry_run: bool = getattr(args, "dry_run", False)
-    add_anchors: bool = getattr(args, "add_anchors", False)
-    root = Path(getattr(args, "root", ".")).resolve()
+    check: bool = opts.check
+    dry_run: bool = opts.dry_run
+    add_anchors: bool = opts.add_anchors
+    root = Path(opts.root).resolve()
 
     cfg = None
     try:
@@ -452,19 +600,19 @@ def _cmd_inject(args: argparse.Namespace) -> int:
             raise
 
     if cfg is None:
-        p = VerbosePrinter(verbose=verbose)
+        p = VerbosePrinter(verbose=opts.verbose)
         p.action("No rrt config found; skipping shared_blocks injection.")
         return 0
 
     if cfg.docs is not None and cfg.docs.shared_blocks:
         if dry_run:
-            p = DryRunPrinter(dry_run=True, verbose=verbose)
+            p = DryRunPrinter(dry_run=True, verbose=opts.verbose)
             for block in cfg.docs.shared_blocks:
                 p.would_write(", ".join(block.targets), detail=f"anchor: {block.anchor_id!r}")
             return 0
 
         repo_url = (cfg.docs.source_repo_url or "") if cfg.docs else ""
-        p = VerbosePrinter(verbose=verbose)
+        p = VerbosePrinter(verbose=opts.verbose)
 
         exit_code = 0
         for block in cfg.docs.shared_blocks:
@@ -633,18 +781,60 @@ def _prepend_anchor_if_missing(
 # ---------------------------------------------------------------------------
 
 
+@dataclass(frozen=True)
+class BadgesOptions:
+    """Typed view of ``argparse.Namespace`` for ``rrt docs badges``.
+
+    Built once via :meth:`from_args` at the top of :func:`_cmd_badges` so
+    every flag has a single, typed read site instead of scattered
+    ``getattr(args, ..., default)`` calls throughout the function body.
+    """
+
+    verbose: int
+    root: str
+    check: bool
+    dry_run: bool
+    output_dir: str | None
+    all_platforms: bool
+    platform: str | None
+    variant: str | None
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> BadgesOptions:
+        """Build a :class:`BadgesOptions` from a parsed ``argparse.Namespace``.
+
+        Every flag below is given a real default by ``register()`` (or, for
+        ``--verbose``, by cli.py's global parser), so a Namespace produced by
+        argparse's own ``rrt docs badges`` parser always carries every
+        attribute. The getattr fallbacks here exist only because some unit
+        tests in tests/commands/test_docs_cmd.py / test_docs_api.py construct
+        sparse ``argparse.Namespace`` objects by hand; ``rrt docs badges`` is
+        not currently dispatched from workflow/hooks.py.
+        """
+        return cls(
+            verbose=getattr(args, "verbose", 0) or 0,
+            root=getattr(args, "root", "."),
+            check=getattr(args, "check", False),
+            dry_run=getattr(args, "dry_run", False),
+            output_dir=getattr(args, "output_dir", None),
+            all_platforms=getattr(args, "all_platforms", False),
+            platform=getattr(args, "platform", None),
+            variant=getattr(args, "variant", None),
+        )
+
+
 def _cmd_badges(args: argparse.Namespace) -> int:
     """Generate platform SVG badge files into docs/public/assets/badges/."""
-    verbose: int = getattr(args, "verbose", 0) or 0
+    opts = BadgesOptions.from_args(args)
     from repo_release_tools.tools.platform import KNOWN_LABEL_KEYS, get_badge_svg  # noqa: PLC0415
 
-    check: bool = getattr(args, "check", False)
-    dry_run: bool = getattr(args, "dry_run", False)
-    root = Path(getattr(args, "root", ".")).resolve()
-    output_dir_arg: str | None = getattr(args, "output_dir", None)
-    all_platforms: bool = getattr(args, "all_platforms", False)
-    platform_arg: str | None = getattr(args, "platform", None)
-    variant_arg: str | None = getattr(args, "variant", None)
+    check: bool = opts.check
+    dry_run: bool = opts.dry_run
+    root = Path(opts.root).resolve()
+    output_dir_arg: str | None = opts.output_dir
+    all_platforms: bool = opts.all_platforms
+    platform_arg: str | None = opts.platform
+    variant_arg: str | None = opts.variant
 
     cfg = None
     try:
@@ -667,7 +857,7 @@ def _cmd_badges(args: argparse.Namespace) -> int:
         else [variant_arg]
     )
 
-    p = DryRunPrinter(dry_run=dry_run, verbose=verbose)
+    p = DryRunPrinter(dry_run=dry_run, verbose=opts.verbose)
     p.header("rrt docs badges")
 
     exit_code = 0
@@ -701,9 +891,45 @@ def _cmd_badges(args: argparse.Namespace) -> int:
 # ---------------------------------------------------------------------------
 
 
+@dataclass(frozen=True)
+class ApiOptions:
+    """Typed view of ``argparse.Namespace`` for ``rrt docs api``.
+
+    Built once via :meth:`from_args` at the top of :func:`_cmd_api` so every
+    flag has a single, typed read site instead of scattered ``getattr(args,
+    ..., default)`` calls throughout the function body.
+    """
+
+    verbose: int
+    root: str
+    format: str
+    output: str | None
+    dry_run: bool
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> ApiOptions:
+        """Build an :class:`ApiOptions` from a parsed ``argparse.Namespace``.
+
+        Every flag below is given a real default by ``register()`` (or, for
+        ``--verbose``, by cli.py's global parser), so a Namespace produced by
+        argparse's own ``rrt docs api`` parser always carries every
+        attribute. The getattr fallbacks here exist only because some unit
+        tests in tests/commands/test_docs_api*.py construct sparse
+        ``argparse.Namespace`` objects by hand; ``rrt docs api`` is not
+        currently dispatched from workflow/hooks.py.
+        """
+        return cls(
+            verbose=getattr(args, "verbose", 0) or 0,
+            root=getattr(args, "root", "."),
+            format=getattr(args, "format", None) or "md",
+            output=getattr(args, "output", None),
+            dry_run=getattr(args, "dry_run", False),
+        )
+
+
 def _cmd_api(args: argparse.Namespace) -> int:
     """Emit a structured index of all rrt CLI commands and arguments."""
-    verbose: int = getattr(args, "verbose", 0) or 0
+    opts = ApiOptions.from_args(args)
     from repo_release_tools.cli import build_parser  # noqa: PLC0415
     from repo_release_tools.docs.api_index import (  # noqa: PLC0415
         build_api_index,
@@ -713,12 +939,12 @@ def _cmd_api(args: argparse.Namespace) -> int:
         render_api_txt,
     )
 
-    fmt: str = getattr(args, "format", None) or "md"
-    output_arg: str | None = getattr(args, "output", None)
-    dry_run: bool = getattr(args, "dry_run", False)
-    root = Path(getattr(args, "root", ".")).resolve()
+    fmt: str = opts.format
+    output_arg: str | None = opts.output
+    dry_run: bool = opts.dry_run
+    root = Path(opts.root).resolve()
 
-    p = DryRunPrinter(dry_run=dry_run, verbose=verbose)
+    p = DryRunPrinter(dry_run=dry_run, verbose=opts.verbose)
 
     # When the rendered payload goes directly to stdout, suppress the status
     # header/footer so callers can safely pipe output (e.g. to `jq`).
@@ -781,6 +1007,42 @@ def _cmd_suggest(args: argparse.Namespace) -> int:
 # ---------------------------------------------------------------------------
 
 
+@dataclass(frozen=True)
+class MapOptions:
+    """Typed view of ``argparse.Namespace`` for ``rrt docs map``.
+
+    Built once via :meth:`from_args` at the top of :func:`_cmd_map` so every
+    flag has a single, typed read site instead of scattered ``getattr(args,
+    ..., default)`` / ``args.x`` calls throughout the function body.
+    """
+
+    verbose: int
+    root: str
+    dry_run: bool
+    check: bool
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> MapOptions:
+        """Build a :class:`MapOptions` from a parsed ``argparse.Namespace``.
+
+        Every flag below is given a real default by ``register()`` (or, for
+        ``--verbose``, by cli.py's global parser), so a Namespace produced by
+        argparse's own ``rrt docs map`` parser always carries every
+        attribute. The getattr fallbacks here absorb two other real callers:
+        unit tests in tests/commands/test_docs_map_cli.py that construct
+        sparse ``argparse.Namespace`` objects by hand, and
+        workflow/hooks.py's ``docs-map-update``/``docs-map-check`` dispatch
+        cases, which always set ``root``, ``check``, and ``dry_run``
+        explicitly but rely on this fallback for ``verbose`` timing.
+        """
+        return cls(
+            verbose=getattr(args, "verbose", 0) or 0,
+            root=getattr(args, "root", "."),
+            dry_run=getattr(args, "dry_run", False),
+            check=getattr(args, "check", False),
+        )
+
+
 def _cmd_map(args: argparse.Namespace) -> int:
     """Generate or check per-directory purpose docs via `rrt docs map`."""
     from repo_release_tools.commands.docs_map import generate  # noqa: PLC0415
@@ -789,10 +1051,10 @@ def _cmd_map(args: argparse.Namespace) -> int:
         refresh_lockfile,
     )
 
-    verbose: int = getattr(args, "verbose", 0) or 0
-    cwd = Path(args.root)
+    opts = MapOptions.from_args(args)
+    cwd = Path(opts.root)
     docs_cfg = _config_for_cwd(cwd)
-    p = DryRunPrinter(dry_run=getattr(args, "dry_run", False), verbose=verbose)
+    p = DryRunPrinter(dry_run=opts.dry_run, verbose=opts.verbose)
 
     if docs_cfg.map is None:
         p.line(
@@ -803,7 +1065,7 @@ def _cmd_map(args: argparse.Namespace) -> int:
         return 1
 
     map_cfg = docs_cfg.map
-    check: bool = getattr(args, "check", False)
+    check: bool = opts.check
 
     if check:
         drift = detect_drift(map_cfg, cwd)
@@ -860,10 +1122,39 @@ def _cmd_map(args: argparse.Namespace) -> int:
 # ---------------------------------------------------------------------------
 
 
+@dataclass(frozen=True)
+class DispatchOptions:
+    """Typed view of ``argparse.Namespace`` for the ``rrt docs`` dispatcher.
+
+    Built once via :meth:`from_args` at the top of :func:`cmd_docs` so both
+    flags it reads directly have typed read sites instead of
+    ``getattr(args, ..., default)`` calls; each sub-action re-reads the full
+    Namespace via its own Options class.
+    """
+
+    verbose: int
+    docs_action: str
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> DispatchOptions:
+        """Build a :class:`DispatchOptions` from a parsed ``argparse.Namespace``.
+
+        ``docs_action`` is set by every dispatch path (register()'s
+        subparsers default to ``None``, but the top-level ``rrt docs``
+        parser and every workflow/hooks.py case set it explicitly), so the
+        getattr fallback here exists only for unit tests that construct a
+        bare ``argparse.Namespace()`` without it.
+        """
+        return cls(
+            verbose=getattr(args, "verbose", 0) or 0,
+            docs_action=getattr(args, "docs_action", "generate"),
+        )
+
+
 def cmd_docs(args: argparse.Namespace) -> int:
     """Dispatch rrt docs sub-actions."""
-    verbose: int = getattr(args, "verbose", 0) or 0
-    sub = getattr(args, "docs_action", "generate")
+    opts = DispatchOptions.from_args(args)
+    sub = opts.docs_action
     match sub:
         case "generate":
             return _cmd_generate(args)
@@ -881,7 +1172,7 @@ def cmd_docs(args: argparse.Namespace) -> int:
             return _cmd_api(args)
         case "map":
             return _cmd_map(args)
-    p = VerbosePrinter(verbose=verbose)
+    p = VerbosePrinter(verbose=opts.verbose)
     p.line(f"Unknown docs action: {sub!r}", ok=False, stream=sys.stderr)
     return 1
 

--- a/src/repo_release_tools/commands/doctor.py
+++ b/src/repo_release_tools/commands/doctor.py
@@ -83,6 +83,7 @@ from repo_release_tools.changelog import (
 )
 from repo_release_tools.commands._common import describe_config_load_error
 from repo_release_tools.config import (
+    RrtConfig,
     find_repo_root,
     format_autodetected_config_notice,
     iter_config_files,
@@ -320,6 +321,53 @@ class Options:
         )
 
 
+def _render_doctor_report(
+    p: VerbosePrinter,
+    named_checks: list[tuple[str, tuple[str, bool, str]]],
+    config: RrtConfig,
+) -> bool:
+    """Render the core automation report and feature-specific-checks guidance.
+
+    Returns ``True`` when every check in ``named_checks`` passed (``all_ok``).
+    """
+    all_ok = True
+    p.section("Core automation checks")
+    for _name, (message, ok, severity) in named_checks:
+        p.verbose_line(f"  {_name}: {severity}", level=1)
+        match severity:
+            case "ok":
+                p.line(f"  {message}", ok=True)
+            case "obsolete":
+                p.obsolete(f"  {message}")
+            case "warning":
+                p.warn(f"  {message}")
+            case _:
+                p.line(f"  {message}", ok=False)
+        if not ok:
+            all_ok = False
+
+    p.blank_line()
+    if all_ok:
+        p.ok("Core automation checks passed.")
+    else:
+        p.line("One or more core automation checks failed.", ok=False)
+
+    p.blank_line()
+    p.warn(
+        "Compatibility note: release-target validation lives in 'rrt release check'. "
+        "Use both checks for historical doctor coverage.",
+    )
+    p.blank_line()
+    p.section("Feature-specific checks")
+    p.action("Run 'rrt release check' for version targets, pin targets, and changelog files.")
+    if config.docs is not None:
+        p.action("Run 'rrt docs check' for source-owned docs lockfile and marker health.")
+    if config.eol is not None:
+        p.action("Run 'rrt eol' for runtime support and end-of-life policy checks.")
+
+    return all_ok
+
+
 def cmd_doctor(args: argparse.Namespace) -> int:
     """Check the health of the rrt configuration."""
     opts = Options.from_args(args)
@@ -395,40 +443,7 @@ def cmd_doctor(args: argparse.Namespace) -> int:
         p.warn("Health regressions detected (advisory). Use --strict to block.")
         return 0
 
-    all_ok = True
-    p.section("Core automation checks")
-    for _name, (message, ok, severity) in named_checks:
-        p.verbose_line(f"  {_name}: {severity}", level=1)
-        match severity:
-            case "ok":
-                p.line(f"  {message}", ok=True)
-            case "obsolete":
-                p.obsolete(f"  {message}")
-            case "warning":
-                p.warn(f"  {message}")
-            case _:
-                p.line(f"  {message}", ok=False)
-        if not ok:
-            all_ok = False
-
-    p.blank_line()
-    if all_ok:
-        p.ok("Core automation checks passed.")
-    else:
-        p.line("One or more core automation checks failed.", ok=False)
-
-    p.blank_line()
-    p.warn(
-        "Compatibility note: release-target validation lives in 'rrt release check'. "
-        "Use both checks for historical doctor coverage.",
-    )
-    p.blank_line()
-    p.section("Feature-specific checks")
-    p.action("Run 'rrt release check' for version targets, pin targets, and changelog files.")
-    if config.docs is not None:
-        p.action("Run 'rrt docs check' for source-owned docs lockfile and marker health.")
-    if config.eol is not None:
-        p.action("Run 'rrt eol' for runtime support and end-of-life policy checks.")
+    all_ok = _render_doctor_report(p, named_checks, config)
 
     if opts.fix or opts.fix_dry_run:
         fixes = _fix_missing_unreleased(root, config, dry_run=opts.fix_dry_run)

--- a/src/repo_release_tools/commands/doctor.py
+++ b/src/repo_release_tools/commands/doctor.py
@@ -71,6 +71,7 @@ from __future__ import annotations
 
 import argparse
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 from repo_release_tools.changelog import (
@@ -282,15 +283,48 @@ def _fix_missing_unreleased(root: Path, config: object, *, dry_run: bool) -> lis
     return changes
 
 
+@dataclass(frozen=True)
+class Options:
+    """Typed view of ``argparse.Namespace`` for ``rrt doctor``.
+
+    Built once via :meth:`from_args` at the top of :func:`cmd_doctor` so every
+    flag has a single, typed read site instead of scattered
+    ``getattr(args, ..., default)`` calls throughout the function body.
+    """
+
+    fix: bool
+    fix_dry_run: bool
+    snapshot: bool
+    check: bool
+    strict: bool
+    verbose: int
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> Options:
+        """Build an :class:`Options` from a parsed ``argparse.Namespace``."""
+        # NOTE: every flag below is given a real default by doctor.py's own
+        # register() (or, for --verbose, by cli.py's global parser), so a
+        # Namespace produced by argparse always carries every attribute.
+        # The getattr fallbacks here exist only because some unit tests in
+        # tests/commands/test_doctor.py construct sparse argparse.Namespace
+        # objects by hand instead of going through register(); this is the
+        # single translation point that absorbs that, so the rest of
+        # cmd_doctor can read opts.x unconditionally.
+        return cls(
+            fix=getattr(args, "fix", False),
+            fix_dry_run=getattr(args, "fix_dry_run", False),
+            snapshot=getattr(args, "snapshot", False),
+            check=getattr(args, "check", False),
+            strict=getattr(args, "strict", False),
+            verbose=getattr(args, "verbose", 0) or 0,
+        )
+
+
 def cmd_doctor(args: argparse.Namespace) -> int:
     """Check the health of the rrt configuration."""
+    opts = Options.from_args(args)
     root = find_repo_root(Path.cwd())
-    fix: bool = getattr(args, "fix", False)
-    fix_dry_run: bool = getattr(args, "fix_dry_run", False)
-    do_snapshot: bool = getattr(args, "snapshot", False)
-    do_check: bool = getattr(args, "check", False)
-    strict: bool = getattr(args, "strict", False)
-    verbose: int = getattr(args, "verbose", 0) or 0
+    verbose = opts.verbose
 
     try:
         config = load_or_autodetect_config(root)
@@ -337,20 +371,20 @@ def cmd_doctor(args: argparse.Namespace) -> int:
         for name, (message, _ok, severity) in named_checks
     ]
 
-    if do_snapshot:
+    if opts.snapshot:
         lock_data = build_health_lock(check_results)
         write_lock(health_lock_path(root), lock_data)
         p.ok("Health snapshot written to .rrt/health.lock.toml")
         return 0
 
-    if do_check:
+    if opts.check:
         current, regressions = health_lock_is_current(health_lock_path(root), check_results)
         if current:
             p.ok("No health regressions detected.")
             return 0
         for msg in regressions:
             p.warn(f"  {msg}")
-        if strict:
+        if opts.strict:
             p.line("Health regressions detected (--strict mode).", ok=False, stream=sys.stderr)
             p.line(
                 "Run `rrt doctor --snapshot` to update the health snapshot.",
@@ -396,8 +430,8 @@ def cmd_doctor(args: argparse.Namespace) -> int:
     if config.eol is not None:
         p.action("Run 'rrt eol' for runtime support and end-of-life policy checks.")
 
-    if fix or fix_dry_run:
-        fixes = _fix_missing_unreleased(root, config, dry_run=fix_dry_run)
+    if opts.fix or opts.fix_dry_run:
+        fixes = _fix_missing_unreleased(root, config, dry_run=opts.fix_dry_run)
         if fixes:
             p.blank_line()
             p.section("Auto-fix results")

--- a/src/repo_release_tools/commands/eol_check.py
+++ b/src/repo_release_tools/commands/eol_check.py
@@ -72,6 +72,7 @@ rrt eol --warn-days 90 --error-days 30
 from __future__ import annotations
 
 import argparse
+from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
 
@@ -316,11 +317,59 @@ def run_eol_checks(
     return all_ok, check_entries
 
 
+@dataclass(frozen=True)
+class Options:
+    """Typed view of ``argparse.Namespace`` for ``rrt eol``.
+
+    Built once via :meth:`from_args` at the top of :func:`cmd_eol` so every
+    flag has a single, typed read site instead of scattered
+    ``getattr(args, ..., default)`` calls throughout the function body.
+    """
+
+    verbose: int
+    language: str | None
+    fetch_live: bool
+    warn_days: int | None
+    error_days: int | None
+    allow_eol: bool
+    host_only: bool
+    project_only: bool
+    snapshot: bool
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> Options:
+        """Build an :class:`Options` from a parsed ``argparse.Namespace``.
+
+        Every flag below is given a real default by ``_attach_eol_args`` /
+        ``register()`` (or, for ``--verbose``, by cli.py's global parser), so
+        a Namespace produced by argparse's own ``rrt eol`` parser always
+        carries every attribute. The getattr fallbacks here absorb two other
+        real callers: unit tests in tests/commands/test_eol_check.py that
+        construct sparse ``argparse.Namespace`` objects by hand, and
+        workflow/hooks.py's ``check-eol`` dispatch case, which registers a
+        bare ``subparsers.add_parser("check-eol")`` with none of these flags
+        and only sets ``parsed.verbose`` before calling ``cmd_eol_check`` —
+        every other field must default exactly as it does today (``None`` /
+        ``False``) for that hook invocation to behave unchanged.
+        """
+        return cls(
+            verbose=getattr(args, "verbose", 0) or 0,
+            language=getattr(args, "language", None),
+            fetch_live=getattr(args, "fetch_live", False),
+            warn_days=getattr(args, "warn_days", None),
+            error_days=getattr(args, "error_days", None),
+            allow_eol=getattr(args, "allow_eol", False),
+            host_only=getattr(args, "host_only", False),
+            project_only=getattr(args, "project_only", False),
+            snapshot=getattr(args, "snapshot", False),
+        )
+
+
 def cmd_eol(args: argparse.Namespace) -> int:
     """Check host runtimes and project minimums against EOL dates."""
+    opts = Options.from_args(args)
     root = find_repo_root(Path.cwd())
-    verbose: int = getattr(args, "verbose", 0) or 0
-    p = VerbosePrinter(verbose=verbose)
+    p = VerbosePrinter(verbose=opts.verbose)
 
     # Determine effective config: CLI flags override config-file values
     eol_cfg: EolConfig | None = None
@@ -332,21 +381,19 @@ def cmd_eol(args: argparse.Namespace) -> int:
 
     if eol_cfg is not None:
         # Merge: CLI flags take priority over config-file values
-        warn_days = _int_override(getattr(args, "warn_days", None), eol_cfg.warn_days)
-        error_days = _int_override(getattr(args, "error_days", None), eol_cfg.error_days)
-        fetch_live: bool = getattr(args, "fetch_live", False) or eol_cfg.fetch_live
-        allow_eol: bool = getattr(args, "allow_eol", False) or eol_cfg.allow_eol
+        warn_days = _int_override(opts.warn_days, eol_cfg.warn_days)
+        error_days = _int_override(opts.error_days, eol_cfg.error_days)
+        fetch_live: bool = opts.fetch_live or eol_cfg.fetch_live
+        allow_eol: bool = opts.allow_eol or eol_cfg.allow_eol
         overrides = eol_cfg.overrides
-        lang_arg: str | None = getattr(args, "language", None)
-        languages: tuple[str, ...] = (lang_arg,) if lang_arg else eol_cfg.languages
+        languages: tuple[str, ...] = (opts.language,) if opts.language else eol_cfg.languages
     else:
-        warn_days = _int_override(getattr(args, "warn_days", None), 180)
-        error_days = _int_override(getattr(args, "error_days", None), 0)
-        fetch_live = getattr(args, "fetch_live", False)
-        allow_eol = getattr(args, "allow_eol", False)
+        warn_days = _int_override(opts.warn_days, 180)
+        error_days = _int_override(opts.error_days, 0)
+        fetch_live = opts.fetch_live
+        allow_eol = opts.allow_eol
         overrides = ()
-        lang_arg = getattr(args, "language", None)
-        languages = (lang_arg,) if lang_arg else ("python",)
+        languages = (opts.language,) if opts.language else ("python",)
 
     p.ok("rrt eol")
     p.action(f"Languages: {', '.join(languages)}")
@@ -358,9 +405,6 @@ def cmd_eol(args: argparse.Namespace) -> int:
     p.verbose_line(f"  warn_days={warn_days} error_days={error_days}", level=2)
     p.blank_line()
 
-    host_only = getattr(args, "host_only", False)
-    project_only = getattr(args, "project_only", False)
-
     all_ok, check_entries = run_eol_checks(
         languages=languages,
         root=root,
@@ -370,11 +414,11 @@ def cmd_eol(args: argparse.Namespace) -> int:
         allow_eol=allow_eol,
         overrides=overrides,
         p=p,
-        host_only=host_only,
-        project_only=project_only,
+        host_only=opts.host_only,
+        project_only=opts.project_only,
     )
 
-    if getattr(args, "snapshot", False):
+    if opts.snapshot:
         upsert_health_lock_checks(health_lock_path(root), check_entries)
         p.ok(f"EOL results merged into .rrt/health.lock.toml ({len(check_entries)} checks)")
 

--- a/src/repo_release_tools/commands/folder.py
+++ b/src/repo_release_tools/commands/folder.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 from repo_release_tools.config import (
@@ -64,19 +65,69 @@ def _load_folder_policy_config(root: Path) -> RrtConfig | None:
         raise
 
 
+@dataclass(frozen=True)
+class CheckOptions:
+    """Typed view of ``argparse.Namespace`` for ``rrt folder check``.
+
+    Built once via :meth:`from_args` at the top of :func:`cmd_folder_check`
+    so every flag has a single, typed read site instead of scattered
+    ``getattr(args, ..., default)`` calls throughout the function body.
+    """
+
+    verbose: int
+    root: str
+    template: tuple[str, ...]
+    report_only: bool
+    snapshot: bool
+    format: str
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> CheckOptions:
+        """Build a :class:`CheckOptions` from a parsed ``argparse.Namespace``.
+
+        ``root``, ``template``, and ``report_only`` are given real
+        defaults by folder.py's own register() and by
+        workflow/hooks.py's "folder-check" subparser
+        (workflow/hooks.py:1237-1260), so a Namespace from either caller
+        always carries them and they are read directly. ``snapshot`` is
+        only registered by folder.py's own register() -- hooks.py's
+        "folder-check" subparser also defines its own ``--snapshot``
+        (line 1256), so both callers carry it, but several unit tests in
+        tests/commands/test_folder.py construct sparse
+        ``argparse.Namespace`` objects that omit it, so the getattr
+        fallback absorbs that gap. ``format`` is never set by
+        folder.py's own register() (there is no ``--format`` flag on
+        this subcommand); hooks.py's "folder-check" dispatch case sets
+        ``parsed.format = "text"`` explicitly, so the fallback here
+        covers direct callers/tests that never set it. ``verbose`` is
+        set globally by cli.py's parser (and explicitly by hooks.py's
+        dispatch case), but tests may omit it, so the fallback absorbs
+        that too.
+        """
+        return cls(
+            verbose=getattr(args, "verbose", 0) or 0,
+            root=args.root,
+            template=tuple(args.template or ()),
+            report_only=args.report_only,
+            snapshot=getattr(args, "snapshot", False),
+            format=getattr(args, "format", "text"),
+        )
+
+
 def cmd_folder_check(args: argparse.Namespace) -> int:
     """Run folder supervision checks."""
-    verbose: int = getattr(args, "verbose", 0) or 0
-    root = Path(args.root).resolve()
+    opts = CheckOptions.from_args(args)
+    verbose = opts.verbose
+    root = Path(opts.root).resolve()
     config = _load_folder_policy_config(root)
     report = check_folders(
         root=root,
         policy=None if config is None else config.folders,
-        template_names=tuple(args.template or ()),
-        mode_override="warn" if args.report_only else None,
+        template_names=opts.template,
+        mode_override="warn" if opts.report_only else None,
     )
 
-    if getattr(args, "snapshot", False):
+    if opts.snapshot:
         check_entries = [
             {
                 "name": f"folder.{target.rule_name}",
@@ -94,9 +145,9 @@ def cmd_folder_check(args: argparse.Namespace) -> int:
         p_snap = VerbosePrinter(verbose=verbose)
         p_snap.ok(f"Folder results merged into .rrt/health.lock.toml ({len(check_entries)} checks)")
 
-    if getattr(args, "format", "text") == "json":
+    if opts.format == "json":
         sys.stdout.write(json.dumps(report.to_dict(), indent=2) + "\n")
-        return 0 if report.ok or args.report_only else 1
+        return 0 if report.ok or opts.report_only else 1
 
     p = VerbosePrinter(verbose=verbose)
     p.blank_line()
@@ -115,27 +166,70 @@ def cmd_folder_check(args: argparse.Namespace) -> int:
                 case _:
                     p.line(f"{violation.path}: {violation.message}", ok=False, stream=sys.stderr)
 
-    return 0 if report.ok or args.report_only else 1
+    return 0 if report.ok or opts.report_only else 1
+
+
+@dataclass(frozen=True)
+class ScaffoldOptions:
+    """Typed view of ``argparse.Namespace`` for ``rrt folder scaffold``.
+
+    Built once via :meth:`from_args` at the top of :func:`cmd_folder_scaffold`
+    so every flag has a single, typed read site instead of scattered
+    ``getattr(args, ..., default)`` calls throughout the function body.
+    """
+
+    verbose: int
+    root: str
+    template: tuple[str, ...]
+    force: bool
+    dry_run: bool
+    format: str
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> ScaffoldOptions:
+        """Build a :class:`ScaffoldOptions` from a parsed ``argparse.Namespace``.
+
+        ``root``, ``template``, ``force``, and ``dry_run`` are all given
+        real defaults by folder.py's own register(), the only caller of
+        ``cmd_folder_scaffold`` (workflow/hooks.py has no
+        "folder-scaffold" dispatch case), so a Namespace produced by
+        argparse always carries them and they are read directly.
+        ``format`` has no corresponding ``--format`` flag on this
+        subcommand at all, so the getattr fallback is the only source of
+        its default. ``verbose`` is set globally by cli.py's parser, but
+        several unit tests in tests/commands/test_folder.py construct
+        sparse ``argparse.Namespace`` objects that omit it, so the
+        fallback absorbs that gap.
+        """
+        return cls(
+            verbose=getattr(args, "verbose", 0) or 0,
+            root=args.root,
+            template=tuple(args.template or ()),
+            force=args.force,
+            dry_run=args.dry_run,
+            format=getattr(args, "format", "text"),
+        )
 
 
 def cmd_folder_scaffold(args: argparse.Namespace) -> int:
     """Scaffold folder structure from templates or config."""
-    verbose: int = getattr(args, "verbose", 0) or 0
-    root = Path(args.root).resolve()
+    opts = ScaffoldOptions.from_args(args)
+    verbose = opts.verbose
+    root = Path(opts.root).resolve()
     config = _load_folder_policy_config(root)
     report = scaffold_folders(
         root=root,
         policy=None if config is None else config.folders,
-        template_names=tuple(args.template or ()),
-        force=args.force,
-        dry_run=args.dry_run,
+        template_names=opts.template,
+        force=opts.force,
+        dry_run=opts.dry_run,
     )
 
-    if getattr(args, "format", "text") == "json":
+    if opts.format == "json":
         sys.stdout.write(json.dumps(report.to_dict(), indent=2) + "\n")
         return 0
 
-    p = DryRunPrinter(args.dry_run, verbose=verbose)
+    p = DryRunPrinter(opts.dry_run, verbose=verbose)
     p.blank_line()
     p.header("Folder scaffold", Root=str(root))
     for action in report.actions:
@@ -147,17 +241,56 @@ def cmd_folder_scaffold(args: argparse.Namespace) -> int:
     return 0
 
 
+@dataclass(frozen=True)
+class DesignOptions:
+    """Typed view of ``argparse.Namespace`` for ``rrt folder design``.
+
+    Built once via :meth:`from_args` at the top of :func:`cmd_folder_design`
+    so every flag has a single, typed read site instead of scattered
+    ``getattr(args, ..., default)`` calls throughout the function body.
+    """
+
+    verbose: int
+    root: str
+    name: str
+    loose: bool
+    selector: str
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> DesignOptions:
+        """Build a :class:`DesignOptions` from a parsed ``argparse.Namespace``.
+
+        ``root``, ``name``, ``loose``, and ``selector`` are all given real
+        defaults by folder.py's own register(), the only caller of
+        ``cmd_folder_design`` (workflow/hooks.py has no "folder-design"
+        dispatch case), so a Namespace produced by argparse always
+        carries them and they are read directly. ``verbose`` is set
+        globally by cli.py's parser, but several unit tests in
+        tests/commands/test_folder.py construct sparse
+        ``argparse.Namespace`` objects that omit it, so the getattr
+        fallback absorbs that gap.
+        """
+        return cls(
+            verbose=getattr(args, "verbose", 0) or 0,
+            root=args.root,
+            name=args.name,
+            loose=args.loose,
+            selector=args.selector,
+        )
+
+
 def cmd_folder_design(args: argparse.Namespace) -> int:
     """Infer a folder template from an existing directory tree."""
-    verbose: int = getattr(args, "verbose", 0) or 0
-    root = Path(args.root).resolve()
+    opts = DesignOptions.from_args(args)
+    verbose = opts.verbose
+    root = Path(opts.root).resolve()
     if not root.exists() or not root.is_dir():
         p = VerbosePrinter(verbose=verbose)
         p.line(f"Design root must be an existing directory: {root}", ok=False, stream=sys.stderr)
         return 1
 
-    template = capture_template(name=args.name, root=root, loose=args.loose)
-    snippet = render_captured_template_toml(template, selector=args.selector)
+    template = capture_template(name=opts.name, root=root, loose=opts.loose)
+    snippet = render_captured_template_toml(template, selector=opts.selector)
     sys.stdout.write(snippet)
     return 0
 

--- a/src/repo_release_tools/commands/git_inspect.py
+++ b/src/repo_release_tools/commands/git_inspect.py
@@ -445,6 +445,53 @@ class SyncStatusOptions:
         return cls(verbose=getattr(args, "verbose", 0) or 0, base_ref=args.base_ref)
 
 
+def _render_sync_analysis(
+    p: VerbosePrinter,
+    *,
+    branch_name: str,
+    base_ref: str | None,
+    operation: str | None,
+    conflicts: list[str],
+    ahead: int,
+    behind: int,
+) -> int:
+    """Render the "Analysis" section for `rrt git sync-status` and return failure count.
+
+    Checks, in order: in-progress merge/rebase, unresolved conflicts, and
+    ahead/behind drift against *base_ref*. Matches the original inline body
+    of :func:`cmd_sync_status` exactly, including message wording.
+    """
+    p.section("Analysis")
+    failures = 0
+
+    if operation is None:
+        p.ok("No merge or rebase is in progress.")
+    else:
+        failures += 1
+        p.warn(f"{operation.capitalize()} is in progress. Resolve or abort it first.")
+
+    if not conflicts:
+        p.ok("No unresolved conflicts detected.")
+    else:
+        failures += 1
+        p.warn(f"Found {len(conflicts)} conflicted path(s).")
+
+    if base_ref is None:
+        failures += 1
+        p.warn("No upstream branch is configured. Use --base-ref to analyze sync drift.")
+    elif ahead == 0 and behind == 0:
+        p.ok(f"{branch_name} matches {base_ref}.")
+    elif ahead > 0 and behind == 0:
+        p.ok(f"{branch_name} is ahead of {base_ref} by {ahead} commit(s).")
+    else:
+        failures += 1
+        problem = sync_problem(branch_name, base_ref=base_ref, ahead=ahead, behind=behind)
+        if problem is not None:
+            p.warn(problem)
+
+    return failures
+
+
 def cmd_sync_status(args: argparse.Namespace) -> int:
     """Analyze merge/rebase blockers and divergence against a sync base."""
     opts = SyncStatusOptions.from_args(args)
@@ -484,33 +531,15 @@ def cmd_sync_status(args: argparse.Namespace) -> int:
         Status=summarize_status(branch_name, status_lines, upstream=base_ref, root=root),
     )
 
-    p.section("Analysis")
-    failures = 0
-
-    if operation is None:
-        p.ok("No merge or rebase is in progress.")
-    else:
-        failures += 1
-        p.warn(f"{operation.capitalize()} is in progress. Resolve or abort it first.")
-
-    if not conflicts:
-        p.ok("No unresolved conflicts detected.")
-    else:
-        failures += 1
-        p.warn(f"Found {len(conflicts)} conflicted path(s).")
-
-    if base_ref is None:
-        failures += 1
-        p.warn("No upstream branch is configured. Use --base-ref to analyze sync drift.")
-    elif ahead == 0 and behind == 0:
-        p.ok(f"{branch_name} matches {base_ref}.")
-    elif ahead > 0 and behind == 0:
-        p.ok(f"{branch_name} is ahead of {base_ref} by {ahead} commit(s).")
-    else:
-        failures += 1
-        problem = sync_problem(branch_name, base_ref=base_ref, ahead=ahead, behind=behind)
-        if problem is not None:
-            p.warn(problem)
+    failures = _render_sync_analysis(
+        p,
+        branch_name=branch_name,
+        base_ref=base_ref,
+        operation=operation,
+        conflicts=conflicts,
+        ahead=ahead,
+        behind=behind,
+    )
 
     if conflicts:
         p.blank_line()

--- a/src/repo_release_tools/commands/git_inspect.py
+++ b/src/repo_release_tools/commands/git_inspect.py
@@ -228,6 +228,91 @@ class DoctorOptions:
         )
 
 
+def _compute_changelog_problem(
+    *,
+    latest_subject: str,
+    branch_name: str,
+    changelog_file: str,
+    root: Path,
+) -> str | None:
+    """Return a changelog problem message, or ``None`` when no changelog work is required.
+
+    Mirrors the original inline body of :func:`cmd_doctor`: only inspects
+    HEAD's changed files (via ``git diff-tree``) when *latest_subject*
+    indicates changelog work is expected for this commit type.
+    """
+    if not latest_subject or not commit_subject_requires_changelog(latest_subject):
+        return None
+    changed_files = git.capture(
+        ["git", "diff-tree", "--no-commit-id", "--name-only", "--root", "-r", "HEAD"],
+        root,
+    )
+    changed = [line for line in changed_files.splitlines() if line.strip()]
+    if changelog_is_updated(changed, changelog_file=changelog_file, cwd=root):
+        return None
+    return (
+        f"Branch {branch_name!r} suggests changelog work, but {changelog_file} is not part of HEAD."
+    )
+
+
+def _build_doctor_checks(
+    *,
+    branch_problem: str | None,
+    upstream: str | None,
+    dirty_problem: str | None,
+    operation_problem: str | None,
+    conflict_problem: str | None,
+    subject_problem: str | None,
+    changelog_problem: str | None,
+    changelog_file: str,
+    branch_name: str,
+    relation_problem: str | None,
+) -> list[tuple[bool, str, str]]:
+    """Build the ordered (ok, ok_message, problem_message) tuples for `rrt git doctor`.
+
+    One tuple per health check; the sync-relation check is appended only when
+    an upstream branch is configured, matching the original inline logic.
+    """
+    checks: list[tuple[bool, str, str]] = [
+        (branch_problem is None, "Branch naming matches rrt policy.", branch_problem or ""),
+        (
+            upstream is not None,
+            "Upstream branch is configured.",
+            "No upstream branch configured." if upstream is None else "",
+        ),
+        (dirty_problem is None, "Working tree is clean.", dirty_problem or ""),
+        (
+            operation_problem is None,
+            "No merge or rebase is in progress.",
+            operation_problem or "",
+        ),
+        (
+            conflict_problem is None,
+            "No unresolved conflicts detected.",
+            conflict_problem or "",
+        ),
+        (
+            subject_problem is None,
+            "Latest commit subject is conventional.",
+            subject_problem or "",
+        ),
+        (
+            changelog_problem is None,
+            f"Changelog state is valid for {changelog_file}.",
+            changelog_problem or "",
+        ),
+    ]
+    if upstream is not None:
+        checks.append(
+            (
+                relation_problem is None,
+                f"{branch_name} does not need sync from {upstream}.",
+                relation_problem or "",
+            ),
+        )
+    return checks
+
+
 def cmd_doctor(args: argparse.Namespace) -> int:
     """Run a compact repository health report for rrt workflows."""
     opts = DoctorOptions.from_args(args)
@@ -265,19 +350,12 @@ def cmd_doctor(args: argparse.Namespace) -> int:
         f"Found {len(conflicts)} conflicted path(s). Resolve them first." if conflicts else None
     )
     relation_problem = sync_problem(branch_name, base_ref=upstream, ahead=ahead, behind=behind)
-
-    changelog_problem: str | None = None
-    if latest_subject and commit_subject_requires_changelog(latest_subject):
-        changed_files = git.capture(
-            ["git", "diff-tree", "--no-commit-id", "--name-only", "--root", "-r", "HEAD"],
-            root,
-        )
-        changed = [line for line in changed_files.splitlines() if line.strip()]
-        if not changelog_is_updated(changed, changelog_file=opts.changelog_file, cwd=root):
-            changelog_problem = (
-                f"Branch {branch_name!r} suggests changelog work, but {opts.changelog_file} "
-                "is not part of HEAD."
-            )
+    changelog_problem = _compute_changelog_problem(
+        latest_subject=latest_subject,
+        branch_name=branch_name,
+        changelog_file=opts.changelog_file,
+        root=root,
+    )
 
     summary = summarize_status(branch_name, status_lines, upstream=upstream, root=root)
     p = VerbosePrinter(verbose=verbose)
@@ -294,43 +372,18 @@ def cmd_doctor(args: argparse.Namespace) -> int:
     p.section("Checks")
     failures = 0
 
-    checks: list[tuple[bool, str, str]] = [
-        (branch_problem is None, "Branch naming matches rrt policy.", branch_problem or ""),
-        (
-            upstream is not None,
-            "Upstream branch is configured.",
-            "No upstream branch configured." if upstream is None else "",
-        ),
-        (dirty_problem is None, "Working tree is clean.", dirty_problem or ""),
-        (
-            operation_problem is None,
-            "No merge or rebase is in progress.",
-            operation_problem or "",
-        ),
-        (
-            conflict_problem is None,
-            "No unresolved conflicts detected.",
-            conflict_problem or "",
-        ),
-        (
-            subject_problem is None,
-            "Latest commit subject is conventional.",
-            subject_problem or "",
-        ),
-        (
-            changelog_problem is None,
-            f"Changelog state is valid for {opts.changelog_file}.",
-            changelog_problem or "",
-        ),
-    ]
-    if upstream is not None:
-        checks.append(
-            (
-                relation_problem is None,
-                f"{branch_name} does not need sync from {upstream}.",
-                relation_problem or "",
-            ),
-        )
+    checks = _build_doctor_checks(
+        branch_problem=branch_problem,
+        upstream=upstream,
+        dirty_problem=dirty_problem,
+        operation_problem=operation_problem,
+        conflict_problem=conflict_problem,
+        subject_problem=subject_problem,
+        changelog_problem=changelog_problem,
+        changelog_file=opts.changelog_file,
+        branch_name=branch_name,
+        relation_problem=relation_problem,
+    )
 
     for ok, ok_msg, problem in checks:
         if ok:

--- a/src/repo_release_tools/commands/git_inspect.py
+++ b/src/repo_release_tools/commands/git_inspect.py
@@ -672,33 +672,15 @@ class DiffOptions:
         )
 
 
-def cmd_diff(args: argparse.Namespace) -> int:
-    """Show a compact git diff using DiffGlyphs."""
-    opts = DiffOptions.from_args(args)
-    verbose = opts.verbose
-    root = Path.cwd()
-    if not git.is_git_repository(root):
-        p = VerbosePrinter(verbose=verbose)
-        p.line(f"{root} is not inside a Git work tree.", ok=False, stream=sys.stderr)
-        return 1
+def _render_diff_body(raw: str, *, verbose: int) -> None:
+    """Render the file/hunk/line body of a unified diff using rrt glyphs.
 
-    cmd = ["git", "diff", "--unified=3"]
-    if opts.staged:
-        cmd.append("--staged")
-    if opts.against:
-        cmd.append(opts.against)
-
-    try:
-        raw = git.capture_checked(cmd, root)
-    except RuntimeError as exc:
-        p = VerbosePrinter(verbose=verbose)
-        p.line(str(exc), ok=False, stream=sys.stderr)
-        return 1
-    if not raw.strip():
-        p = VerbosePrinter(verbose=verbose)
-        p.ok("No diff to show.")
-        return 0
-
+    Single stateful pass over *raw*'s lines: tracks the current file name and
+    old/new line counters as hunks and +/-/context lines are consumed.
+    Matches the original inline loop body of :func:`cmd_diff` exactly,
+    including its practice of constructing a fresh :class:`VerbosePrinter`
+    per emitted line/section.
+    """
     current_file: str = ""
     old_lineno: int | None = None
     new_lineno: int | None = None
@@ -776,6 +758,36 @@ def cmd_diff(args: argparse.Namespace) -> int:
         p.line(f"  {rendered}")
 
     p.blank_line()
+
+
+def cmd_diff(args: argparse.Namespace) -> int:
+    """Show a compact git diff using DiffGlyphs."""
+    opts = DiffOptions.from_args(args)
+    verbose = opts.verbose
+    root = Path.cwd()
+    if not git.is_git_repository(root):
+        p = VerbosePrinter(verbose=verbose)
+        p.line(f"{root} is not inside a Git work tree.", ok=False, stream=sys.stderr)
+        return 1
+
+    cmd = ["git", "diff", "--unified=3"]
+    if opts.staged:
+        cmd.append("--staged")
+    if opts.against:
+        cmd.append(opts.against)
+
+    try:
+        raw = git.capture_checked(cmd, root)
+    except RuntimeError as exc:
+        p = VerbosePrinter(verbose=verbose)
+        p.line(str(exc), ok=False, stream=sys.stderr)
+        return 1
+    if not raw.strip():
+        p = VerbosePrinter(verbose=verbose)
+        p.ok("No diff to show.")
+        return 0
+
+    _render_diff_body(raw, verbose=verbose)
     return 0
 
 

--- a/src/repo_release_tools/commands/release_cmd.py
+++ b/src/repo_release_tools/commands/release_cmd.py
@@ -65,6 +65,7 @@ from __future__ import annotations
 import argparse
 import re
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 from repo_release_tools.commands._common import describe_config_load_error
@@ -72,6 +73,8 @@ from repo_release_tools.commands.release_notes import register_subcommand as _re
 from repo_release_tools.commands.release_repair import register_subcommand as _register_repair
 from repo_release_tools.config import (
     PinTarget,
+    RrtConfig,
+    VersionGroup,
     VersionTarget,
     _describe_version_target,
     find_repo_root,
@@ -169,9 +172,98 @@ def _check_pin_target(pin: PinTarget, root: Path) -> tuple[str, bool, str]:
     return f"{relative} match", True, "ok"
 
 
-def cmd_release_check(args: argparse.Namespace) -> int:  # noqa: ARG001
+@dataclass(frozen=True)
+class ReleaseCheckOptions:
+    """Typed view of ``argparse.Namespace`` for ``rrt release check``.
+
+    Built once via :meth:`from_args` at the top of :func:`cmd_release_check`
+    so the single flag it reads has a typed read site instead of a bare
+    ``getattr(args, ..., default)`` call.
+    """
+
+    verbose: int
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> ReleaseCheckOptions:
+        """Build a :class:`ReleaseCheckOptions` from a parsed ``argparse.Namespace``.
+
+        ``verbose`` is set globally by cli.py's parser, so a Namespace produced
+        by argparse always carries it. The getattr fallback exists only because
+        several tests in tests/commands/test_release_cmd.py call
+        cmd_release_check with a bare ``argparse.Namespace()`` that never sets
+        ``verbose``.
+        """
+        return cls(verbose=getattr(args, "verbose", 0) or 0)
+
+
+def _check_release_group(
+    group: VersionGroup,
+    config: RrtConfig,
+    root: Path,
+    p: VerbosePrinter,
+) -> bool:
+    """Check one version group's targets, render its report, and return overall status.
+
+    Aggregates version-target, pin-target, and changelog-file checks for
+    *group* into a single `[group.name]` report block, matching the original
+    inline loop body of :func:`cmd_release_check`. Returns ``True`` when every
+    check in the group passed.
+    """
+    group_ok = True
+    statuses: list[tuple[str, str]] = []
+
+    for target in group.version_targets:
+        message, ok, severity = _check_version_target(target, root)
+        statuses.append((message, severity))
+        if not ok:
+            group_ok = False
+
+    all_pins = group.pin_targets + config.global_pin_targets
+    if all_pins:
+        seen: set[tuple[object, str]] = set()
+        unique_pins = []
+        for pin in all_pins:
+            key = (pin.path, pin.pattern)
+            if key not in seen:
+                seen.add(key)
+                unique_pins.append(pin)
+
+        for pin in unique_pins:
+            message, ok, severity = _check_pin_target(pin, root)
+            statuses.append((message, severity))
+            if not ok:
+                group_ok = False
+
+    changelog = group.changelog_file
+    if changelog.exists():
+        statuses.append((f"{changelog.relative_to(root)} exists", "ok"))
+    else:
+        statuses.append((f"{changelog.relative_to(root)} not found", "error"))
+        group_ok = False
+
+    if group_ok:
+        p.ok(f"[{group.name}]")
+    else:
+        p.line(f"[{group.name}]", ok=False)
+    for msg, severity in statuses:
+        match severity:
+            case "ok":
+                p.line(f"  {msg}", ok=True)
+            case "obsolete":
+                p.obsolete(f"  {msg}")
+            case "warning":
+                p.warn(f"  {msg}")
+            case _:
+                p.line(f"  {msg}", ok=False)
+    p.blank_line()
+
+    return group_ok
+
+
+def cmd_release_check(args: argparse.Namespace) -> int:
     """Check release-oriented version, pin, and changelog targets."""
-    verbose: int = getattr(args, "verbose", 0) or 0
+    opts = ReleaseCheckOptions.from_args(args)
+    verbose = opts.verbose
     root = find_repo_root(Path.cwd())
 
     try:
@@ -206,55 +298,7 @@ def cmd_release_check(args: argparse.Namespace) -> int:  # noqa: ARG001
     p.section("Release checks")
 
     for group in config.version_groups:
-        group_ok = True
-        statuses: list[tuple[str, str]] = []
-
-        for target in group.version_targets:
-            message, ok, severity = _check_version_target(target, root)
-            statuses.append((message, severity))
-            if not ok:
-                group_ok = False
-
-        all_pins = group.pin_targets + config.global_pin_targets
-        if all_pins:
-            seen: set[tuple[object, str]] = set()
-            unique_pins = []
-            for pin in all_pins:
-                key = (pin.path, pin.pattern)
-                if key not in seen:
-                    seen.add(key)
-                    unique_pins.append(pin)
-
-            for pin in unique_pins:
-                message, ok, severity = _check_pin_target(pin, root)
-                statuses.append((message, severity))
-                if not ok:
-                    group_ok = False
-
-        changelog = group.changelog_file
-        if changelog.exists():
-            statuses.append((f"{changelog.relative_to(root)} exists", "ok"))
-        else:
-            statuses.append((f"{changelog.relative_to(root)} not found", "error"))
-            group_ok = False
-
-        if group_ok:
-            p.ok(f"[{group.name}]")
-        else:
-            p.line(f"[{group.name}]", ok=False)
-        for msg, severity in statuses:
-            match severity:
-                case "ok":
-                    p.line(f"  {msg}", ok=True)
-                case "obsolete":
-                    p.obsolete(f"  {msg}")
-                case "warning":
-                    p.warn(f"  {msg}")
-                case _:
-                    p.line(f"  {msg}", ok=False)
-        p.blank_line()
-
-        if not group_ok:
+        if not _check_release_group(group, config, root, p):
             all_ok = False
 
     if all_ok:

--- a/src/repo_release_tools/commands/sync_cmd.py
+++ b/src/repo_release_tools/commands/sync_cmd.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 from repo_release_tools.commands.bump import apply_version
@@ -87,19 +88,68 @@ def _stage_and_commit(
 # ---------------------------------------------------------------------------
 
 
+@dataclass(frozen=True)
+class Options:
+    """Typed view of ``argparse.Namespace`` for ``rrt sync``.
+
+    Built once via :meth:`from_args` at the top of :func:`cmd_sync` so every
+    flag has a single, typed read site instead of scattered
+    ``getattr(args, ..., default)`` calls throughout the function body.
+    """
+
+    dry_run: bool
+    verbose: int
+    group: str | None
+    json: bool
+    bump: bool
+    commit: bool
+    tag: bool
+    commit_message: str | None
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> Options:
+        """Build an :class:`Options` from a parsed ``argparse.Namespace``.
+
+        ``dry_run``, ``group``, and ``json`` are given real defaults by both
+        sync_cmd.py's own register() and workflow/hooks.py's "sync" dispatch
+        case's subparser, so a Namespace produced by either always carries
+        them. ``bump``, ``commit``, ``tag``, and ``commit_message`` are only
+        registered by sync_cmd.py's own register() -- hooks.py's "sync"
+        subparser (workflow/hooks.py:1160-1178) only exposes --group, --json,
+        and --dry-run for the read-only listing use case -- so a Namespace
+        built by hooks.py's dispatch lacks all four and needs the getattr
+        fallback. ``verbose`` is set globally by cli.py's parser (and
+        explicitly by hooks.py before calling cmd_sync), but several tests in
+        tests/commands/test_sync_cmd.py construct sparse
+        ``argparse.Namespace`` objects that omit it, so the fallback here
+        absorbs that gap too.
+        """
+        return cls(
+            dry_run=getattr(args, "dry_run", False),
+            verbose=getattr(args, "verbose", 0),
+            group=getattr(args, "group", None),
+            json=getattr(args, "json", False),
+            bump=getattr(args, "bump", False),
+            commit=getattr(args, "commit", False),
+            tag=getattr(args, "tag", False),
+            commit_message=getattr(args, "commit_message", None),
+        )
+
+
 def cmd_sync(args: argparse.Namespace) -> int:
     """Print upstream versions newer than the current project version.
 
     With ``--bump``: apply each newer version to the configured targets in
     ascending order, then optionally commit and tag.
     """
-    dry_run: bool = getattr(args, "dry_run", False)
-    p = DryRunPrinter(dry_run, verbose=getattr(args, "verbose", 0))
+    opts = Options.from_args(args)
+    dry_run: bool = opts.dry_run
+    p = DryRunPrinter(dry_run, verbose=opts.verbose)
     cfg = load_or_autodetect_config(Path.cwd())
     try:
-        group = cfg.resolve_group(getattr(args, "group", None))
+        group = cfg.resolve_group(opts.group)
     except ValueError as exc:
-        p = VerbosePrinter(verbose=getattr(args, "verbose", 0))
+        p = VerbosePrinter(verbose=opts.verbose)
         p.line(str(exc), ok=False, stream=sys.stderr)
         return 1
 
@@ -119,14 +169,14 @@ def cmd_sync(args: argparse.Namespace) -> int:
 
     fresh = newer_versions(current, parsed)
 
-    do_bump: bool = getattr(args, "bump", False)
-    do_commit: bool = getattr(args, "commit", False)
-    do_tag: bool = getattr(args, "tag", False)
-    commit_message_tmpl: str | None = getattr(args, "commit_message", None)
+    do_bump: bool = opts.bump
+    do_commit: bool = opts.commit
+    do_tag: bool = opts.tag
+    commit_message_tmpl: str | None = opts.commit_message
 
     # ── List-only mode (no --bump) ──────────────────────────────────────────
     if not do_bump:
-        if getattr(args, "json", False):
+        if opts.json:
             sys.stdout.write(json.dumps([str(v) for v in fresh]) + "\n")
         else:
             for v in fresh:
@@ -190,8 +240,8 @@ def cmd_sync(args: argparse.Namespace) -> int:
                 prefix="v",
                 message=None,
                 force=False,
-                group=getattr(args, "group", None),
-                verbose=getattr(args, "verbose", 0),
+                group=opts.group,
+                verbose=opts.verbose,
             )
             rc = cmd_tag_create(tag_ns)
             if rc != 0:

--- a/tests/commands/test_ci_version.py
+++ b/tests/commands/test_ci_version.py
@@ -10,8 +10,9 @@ from typing import cast
 import pytest
 
 from repo_release_tools.commands.ci_version import (
+    ComputeOptions,
     GitHubContext,
-    _context_from_args,
+    _context_from_opts,
     cmd_ci_version_apply,
     cmd_ci_version_compute,
     cmd_ci_version_sync,
@@ -88,7 +89,10 @@ def test_context_from_args_prefers_cli_values_over_env(monkeypatch: pytest.Monke
     monkeypatch.setenv("GITHUB_RUN_ID", "99")
     monkeypatch.setenv("GITHUB_RUN_ATTEMPT", "3")
 
-    ctx = _context_from_args(_ns(ref="refs/heads/cli", ref_name="", run_id=None, run_attempt="7"))
+    opts = ComputeOptions.from_args(
+        _ns(ref="refs/heads/cli", ref_name="", run_id=None, run_attempt="7"),
+    )
+    ctx = _context_from_opts(opts)
 
     assert ctx == GitHubContext(
         ref="refs/heads/cli",

--- a/tests/commands/test_doctor.py
+++ b/tests/commands/test_doctor.py
@@ -15,6 +15,7 @@ from repo_release_tools.config import (
     VersionGroup,
     VersionTarget,
 )
+from repo_release_tools.ui import VerbosePrinter
 
 _ARGS = argparse.Namespace()
 
@@ -842,3 +843,86 @@ def test_doctor_verbose_emits_level1_output(
     err = capsys.readouterr().err
     assert "doctor:" in err
     assert "pre_commit:" in err
+
+
+# ---------------------------------------------------------------------------
+# Direct extraction tests: Options.from_args / _render_doctor_report
+# ---------------------------------------------------------------------------
+
+
+def test_options_from_args_sparse_namespace_uses_defaults() -> None:
+    """A Namespace missing every attribute falls back to Options' documented defaults."""
+    opts = doctor.Options.from_args(argparse.Namespace())
+
+    assert opts == doctor.Options(
+        fix=False,
+        fix_dry_run=False,
+        snapshot=False,
+        check=False,
+        strict=False,
+        verbose=0,
+    )
+
+
+def test_options_from_args_reads_explicit_values() -> None:
+    """Every flag on a fully-populated Namespace is read through, unchanged."""
+    args = argparse.Namespace(
+        fix=True,
+        fix_dry_run=True,
+        snapshot=True,
+        check=True,
+        strict=True,
+        verbose=2,
+    )
+
+    opts = doctor.Options.from_args(args)
+
+    assert opts == doctor.Options(
+        fix=True,
+        fix_dry_run=True,
+        snapshot=True,
+        check=True,
+        strict=True,
+        verbose=2,
+    )
+
+
+def test_render_doctor_report_all_ok_returns_true(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """All-ok checks render as passed and the helper returns True."""
+    p = VerbosePrinter()
+    conf = _make_config(tmp_path)
+    named_checks = [
+        ("pre_commit", (".pre-commit-config.yaml includes repo-release-tools hooks", True, "ok")),
+        ("lefthook", ("lefthook.yml not configured", True, "warning")),
+    ]
+
+    all_ok = doctor._render_doctor_report(p, named_checks, conf)
+
+    assert all_ok is True
+    out = capsys.readouterr().out
+    assert "Core automation checks passed." in out
+    assert "rrt release check" in out
+
+
+def test_render_doctor_report_failure_returns_false_and_gates_feature_hints(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A non-ok/obsolete/warning severity flips all_ok False; docs/eol hints follow config."""
+    p = VerbosePrinter()
+    conf = _make_config(tmp_path, docs=None, eol=None)
+    named_checks = [
+        ("workflows", ("workflow.yml unreadable: boom", False, "error")),
+        ("husky", (".husky includes repo-release-tools hooks (pre-commit)", True, "obsolete")),
+    ]
+
+    all_ok = doctor._render_doctor_report(p, named_checks, conf)
+
+    assert all_ok is False
+    out = capsys.readouterr().out
+    assert "One or more core automation checks failed." in out
+    assert "rrt docs check" not in out
+    assert "rrt eol" not in out

--- a/tests/commands/test_git_inspect.py
+++ b/tests/commands/test_git_inspect.py
@@ -544,6 +544,49 @@ def test_cmd_diff_renders_added_and_removed(
     assert "foo.py" in captured
 
 
+def test_render_diff_body_renders_added_and_removed(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Direct call renders the file section and added/removed/unchanged lines."""
+    diff_output = (
+        "diff --git a/foo.py b/foo.py\n"
+        "index abc..def 100644\n"
+        "--- a/foo.py\n"
+        "+++ b/foo.py\n"
+        "@@ -1,2 +1,3 @@\n"
+        " unchanged\n"
+        "-removed line\n"
+        "+added line\n"
+    )
+
+    git_inspect._render_diff_body(diff_output, verbose=0)
+
+    out = capsys.readouterr().out
+    assert "foo.py" in out
+    assert "removed line" in out
+    assert "added line" in out
+    assert "unchanged" in out
+
+
+def test_render_diff_body_handles_deleted_file(capsys: pytest.CaptureFixture[str]) -> None:
+    """A deleted file (``+++ /dev/null``) still gets a section header from the old path."""
+    diff_output = (
+        "diff --git a/gone.py b/gone.py\n"
+        "deleted file mode 100644\n"
+        "index abc..000 100644\n"
+        "--- a/gone.py\n"
+        "+++ /dev/null\n"
+        "@@ -1 +0,0 @@\n"
+        "-old content\n"
+    )
+
+    git_inspect._render_diff_body(diff_output, verbose=0)
+
+    out = capsys.readouterr().out
+    assert "gone.py" in out
+    assert "old content" in out
+
+
 def test_cmd_diff_staged_flag(monkeypatch: pytest.MonkeyPatch) -> None:
     captured_cmd = {}
     monkeypatch.setattr(git_inspect.git, "is_git_repository", lambda _: True)

--- a/tests/commands/test_git_inspect.py
+++ b/tests/commands/test_git_inspect.py
@@ -295,6 +295,48 @@ def test_cmd_sync_status_rejects_missing_base_ref(
     assert "does not exist" in captured.err
 
 
+def test_render_sync_analysis_reports_all_clear(capsys: pytest.CaptureFixture[str]) -> None:
+    """No operation, no conflicts, and a matching base ref yields zero failures."""
+    p = git_inspect.VerbosePrinter(verbose=0)
+
+    failures = git_inspect._render_sync_analysis(
+        p,
+        branch_name="main",
+        base_ref="origin/main",
+        operation=None,
+        conflicts=[],
+        ahead=0,
+        behind=0,
+    )
+
+    out = capsys.readouterr().out
+    assert failures == 0
+    assert "No merge or rebase is in progress." in out
+    assert "No unresolved conflicts detected." in out
+    assert "main matches origin/main." in out
+
+
+def test_render_sync_analysis_counts_each_failure(capsys: pytest.CaptureFixture[str]) -> None:
+    """An in-progress rebase, conflicts, and divergence each count as a failure."""
+    p = git_inspect.VerbosePrinter(verbose=0)
+
+    failures = git_inspect._render_sync_analysis(
+        p,
+        branch_name="feat/x",
+        base_ref="origin/feat/x",
+        operation="rebase",
+        conflicts=["UU src/conflicted.py"],
+        ahead=2,
+        behind=3,
+    )
+
+    out = capsys.readouterr().out
+    assert failures == 3
+    assert "Rebase is in progress" in out
+    assert "Found 1 conflicted path(s)." in out
+    assert "diverged" in out.lower() or "Rebase or merge is needed" in out
+
+
 def test_cmd_check_dirty_tree_reports_status_lines(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],

--- a/tests/commands/test_git_inspect.py
+++ b/tests/commands/test_git_inspect.py
@@ -215,6 +215,84 @@ def test_cmd_doctor_reports_conflicts_and_sync_need(
     assert "src/conflicted.py" in captured.out
 
 
+def test_compute_changelog_problem_skips_non_changelog_commit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No changelog problem is computed (and no diff-tree call made) for chore commits."""
+
+    def fake_capture(cmd: list[str], cwd: pathlib.Path) -> str:
+        raise AssertionError("diff-tree should not be queried for chore commits")
+
+    monkeypatch.setattr(git_inspect.git, "capture", fake_capture)
+
+    result = git_inspect._compute_changelog_problem(
+        latest_subject="chore: update docs tooling",
+        branch_name="chore/update-docs",
+        changelog_file="CHANGELOG.md",
+        root=pathlib.Path("/repo"),
+    )
+
+    assert result is None
+
+
+def test_compute_changelog_problem_flags_missing_changelog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A feat commit whose HEAD diff doesn't touch the changelog file is flagged."""
+    monkeypatch.setattr(
+        git_inspect.git,
+        "capture",
+        lambda cmd, cwd: "src/repo_release_tools/cli.py",
+    )
+
+    result = git_inspect._compute_changelog_problem(
+        latest_subject="feat: add parser",
+        branch_name="feat/add-parser",
+        changelog_file="CHANGELOG.md",
+        root=pathlib.Path("/repo"),
+    )
+
+    assert result is not None
+    assert "feat/add-parser" in result
+    assert "CHANGELOG.md" in result
+
+
+def test_build_doctor_checks_appends_relation_check_only_with_upstream() -> None:
+    """The sync-relation check is appended only when an upstream branch is configured."""
+    without_upstream = git_inspect._build_doctor_checks(
+        branch_problem=None,
+        upstream=None,
+        dirty_problem=None,
+        operation_problem=None,
+        conflict_problem=None,
+        subject_problem=None,
+        changelog_problem=None,
+        changelog_file="CHANGELOG.md",
+        branch_name="main",
+        relation_problem=None,
+    )
+    with_upstream = git_inspect._build_doctor_checks(
+        branch_problem=None,
+        upstream="origin/main",
+        dirty_problem=None,
+        operation_problem=None,
+        conflict_problem=None,
+        subject_problem=None,
+        changelog_problem=None,
+        changelog_file="CHANGELOG.md",
+        branch_name="main",
+        relation_problem="Branch 'main' is behind origin/main by 1 commit(s). Sync is needed.",
+    )
+
+    assert len(without_upstream) == 7
+    assert len(with_upstream) == 8
+    assert with_upstream[-1] == (
+        False,
+        "main does not need sync from origin/main.",
+        "Branch 'main' is behind origin/main by 1 commit(s). Sync is needed.",
+    )
+
+
 def test_cmd_sync_status_reports_diverged_rebase_conflicts(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],

--- a/tests/commands/test_release_cmd.py
+++ b/tests/commands/test_release_cmd.py
@@ -14,6 +14,7 @@ from repo_release_tools.commands.release_notes import (
     cmd_release_notes,
 )
 from repo_release_tools.config import PinTarget, RrtConfig, VersionGroup, VersionTarget
+from repo_release_tools.ui import VerbosePrinter
 
 _ARGS = argparse.Namespace()
 
@@ -362,6 +363,45 @@ def test_release_check_pin_target_obsolete_status(
     out = capsys.readouterr().out
     assert rc == 0
     assert "obsolete: deprecated" in out
+
+
+# ---------------------------------------------------------------------------
+# _check_release_group (extracted per-group check/render block)
+# ---------------------------------------------------------------------------
+
+
+def test_check_release_group_all_healthy_returns_true(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A group with a readable version target and an existing changelog passes."""
+    conf = _make_config(tmp_path)
+    _write_version_file(conf.version_groups[0].version_targets[0].path)
+    (tmp_path / "CHANGELOG.md").write_text("# Changelog\n", encoding="utf-8")
+    p = VerbosePrinter(verbose=0)
+
+    group_ok = release_cmd._check_release_group(conf.version_groups[0], conf, tmp_path, p)
+
+    out = capsys.readouterr().out
+    assert group_ok is True
+    assert "[default]" in out
+    assert "1.2.3" in out
+
+
+def test_check_release_group_missing_changelog_returns_false(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A missing changelog file fails the group even when the version target is fine."""
+    conf = _make_config(tmp_path)
+    _write_version_file(conf.version_groups[0].version_targets[0].path)
+    p = VerbosePrinter(verbose=0)
+
+    group_ok = release_cmd._check_release_group(conf.version_groups[0], conf, tmp_path, p)
+
+    out = capsys.readouterr().out
+    assert group_ok is False
+    assert "CHANGELOG.md not found" in out
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Second part of Phase 4 (command-core extraction), scoped in `analysis/the/PHASE4_SCOPE.md`. Four independent worktree agents ran in parallel on disjoint files, then were integrated onto this branch (14 commits, zero conflicts across all four groups).

**CCN reductions (all four brief-named "next-worst" functions now under the CCN-25 exit target):**

| Function | Before | After | Extracted |
|---|---|---|---|
| `doctor.cmd_doctor` | 28 | **18** | `_render_doctor_report` |
| `git_inspect.cmd_doctor` | 31 | **17** | `_compute_changelog_problem`, `_build_doctor_checks` |
| `git_inspect.cmd_sync_status` | 22 | **14** | `_render_sync_analysis` |
| `git_inspect.cmd_diff` | 28 | **6** | `_render_diff_body` |
| `release_cmd.cmd_release_check` | 25 | **10** | `_check_release_group` |

Every extraction has direct unit tests. `doctor.py` also gained a typed `Options` dataclass (6 raw `getattr` reads consolidated).

**Folded-in Phase 3 `Options`-dataclass sweep** (per the 2026-07-10 decision to fold the remaining files into Phase 4, since this phase touches most of them anyway):
- `docs_cmd.py` (8 command classes), `eol_check.py`, `ci_version.py` — genuine debt, fully converted
- `sync_cmd.py`, `config_cmd.py`, `artifacts_cmd.py`, `folder.py` — genuine debt, fully converted
- `git_inspect.py`, `git_sync.py` — **already fully converted** before this pass (confirmed via real-getattr-count verification, excluding docstring false-positives — a lesson learned earlier in this phase when a naive `grep -c` overstated debt)

Every `Options.from_args()` was cross-checked against `workflow/hooks.py`'s dispatch cases to confirm which `getattr` fallbacks are load-bearing for the hooks/Action surface vs. test-only — documented in each docstring.

## Test plan

- [x] `uv run pytest -q -m "not runtime and not e2e"` — 2,953 passed, coverage 100.00%
- [x] `uv run pytest -m e2e --no-cov` — 71 passed (characterization suite untouched; output byte-identical, including `git_sync.py`'s destructive-gate contract items)
- [x] `uvx pre-commit run --all-files` — clean (including `ty check`)
- [x] Hook latency vs `analysis/the/P1_LATENCY_BASELINE.md` — 141/132/149 ms, all within the +10% budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjTsHn8U7Lmp9Uax8tNBHG