### PR TITLE
refactor: surface unification — MCP/CLI parity fixes + hooks.py parser-spec sharing (modernization phase 5)

### DIFF
--- a/src/repo_release_tools/commands/folder.py
+++ b/src/repo_release_tools/commands/folder.py
@@ -295,6 +295,38 @@ def cmd_folder_design(args: argparse.Namespace) -> int:
     return 0
 
 
+def _add_folder_check_arguments(parser: argparse.ArgumentParser) -> None:
+    """Register the ``folder check`` flag set on ``parser``.
+
+    Single source of truth for this command's flags. Consumed by both the
+    real ``rrt folder check`` subparser built in :func:`register` and by
+    ``workflow/hooks.py``'s ``folder-check`` subparser, so the two surfaces
+    can no longer drift out of sync.
+    """
+    parser.add_argument("--root", default=".", metavar="PATH", help="Root to validate.")
+    parser.add_argument(
+        "--template",
+        action="append",
+        default=[],
+        help=(
+            "Built-in or custom template name to apply at the root. "
+            f"Available built-ins: {', '.join(sorted(resolve_template_catalog()))}."
+        ),
+    )
+    parser.add_argument(
+        "--report-only",
+        action="store_true",
+        default=False,
+        help="Downgrade violations to warnings for this invocation.",
+    )
+    parser.add_argument(
+        "--snapshot",
+        action="store_true",
+        default=False,
+        help="Merge folder check results into .rrt/health.lock.toml after running.",
+    )
+
+
 def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
     """Register the folder command family."""
     parser = subparsers.add_parser(
@@ -312,28 +344,7 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
         "check",
         help="Validate folder structure against templates or configured rules.",
     )
-    check_parser.add_argument("--root", default=".", metavar="PATH", help="Root to validate.")
-    check_parser.add_argument(
-        "--template",
-        action="append",
-        default=[],
-        help=(
-            "Built-in or custom template name to apply at the root. "
-            f"Available built-ins: {', '.join(sorted(resolve_template_catalog()))}."
-        ),
-    )
-    check_parser.add_argument(
-        "--report-only",
-        action="store_true",
-        default=False,
-        help="Downgrade violations to warnings for this invocation.",
-    )
-    check_parser.add_argument(
-        "--snapshot",
-        action="store_true",
-        default=False,
-        help="Merge folder check results into .rrt/health.lock.toml after running.",
-    )
+    _add_folder_check_arguments(check_parser)
     check_parser.set_defaults(handler=cmd_folder_check)
 
     scaffold_parser = folder_sub.add_parser(

--- a/src/repo_release_tools/commands/git_sync.py
+++ b/src/repo_release_tools/commands/git_sync.py
@@ -782,6 +782,44 @@ GIT_PUBLISH_SNAPSHOT_EXAMPLES = (
 )
 
 
+def _add_publish_snapshot_arguments(parser: argparse.ArgumentParser) -> None:
+    """Register the ``publish-snapshot`` flag set on ``parser``.
+
+    Single source of truth for this command's flags. Consumed by both the
+    real ``rrt git publish-snapshot`` parser built in :func:`register_sync`
+    and by ``workflow/hooks.py``'s ``publish-snapshot`` subparser, so the two
+    surfaces can no longer drift out of sync (previously a copy-pasted
+    ``add_argument`` block lived in each file — see
+    ``PublishSnapshotOptions.from_args`` for the historical note on that
+    duplication).
+    """
+    parser.add_argument(
+        "target",
+        nargs="?",
+        default=None,
+        help="Named [tool.rrt.publish_targets.<name>] entry to resolve remote/branch/message from.",
+    )
+    parser.add_argument("--remote", default=None, help="Remote name or URL to force-push to.")
+    parser.add_argument(
+        "--branch", default=None, help="Remote branch to force-push to. Defaults to main."
+    )
+    parser.add_argument("--message", default=None, help="Commit message for the snapshot commit.")
+    parser.add_argument(
+        "--exclude",
+        action="append",
+        default=None,
+        metavar="PATTERN",
+        help="Glob (fnmatch, repo-relative) to exclude from the snapshot. Repeatable; extends "
+        "the resolved target's [tool.rrt.publish_targets.<name>].exclude list.",
+    )
+    parser.add_argument(
+        "--yes-i-know-this-overwrites-remote-history",
+        action="store_true",
+        help="Required confirmation to actually force-push. Without it, behaves as --dry-run.",
+    )
+    add_dry_run_flag(parser)
+
+
 def register_sync(git_sub: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
     """Register the branch maintenance and synchronization subcommands."""
     sync_parser = git_sub.add_parser(
@@ -905,33 +943,5 @@ def register_sync(git_sub: argparse._SubParsersAction[argparse.ArgumentParser]) 
         ),
         epilog=GIT_PUBLISH_SNAPSHOT_EXAMPLES,
     )
-    publish_snapshot_parser.add_argument(
-        "target",
-        nargs="?",
-        default=None,
-        help="Named [tool.rrt.publish_targets.<name>] entry to resolve remote/branch/message from.",
-    )
-    publish_snapshot_parser.add_argument(
-        "--remote", default=None, help="Remote name or URL to force-push to."
-    )
-    publish_snapshot_parser.add_argument(
-        "--branch", default=None, help="Remote branch to force-push to. Defaults to main."
-    )
-    publish_snapshot_parser.add_argument(
-        "--message", default=None, help="Commit message for the snapshot commit."
-    )
-    publish_snapshot_parser.add_argument(
-        "--exclude",
-        action="append",
-        default=None,
-        metavar="PATTERN",
-        help="Glob (fnmatch, repo-relative) to exclude from the snapshot. Repeatable; extends "
-        "the resolved target's [tool.rrt.publish_targets.<name>].exclude list.",
-    )
-    publish_snapshot_parser.add_argument(
-        "--yes-i-know-this-overwrites-remote-history",
-        action="store_true",
-        help="Required confirmation to actually force-push. Without it, behaves as --dry-run.",
-    )
-    add_dry_run_flag(publish_snapshot_parser)
+    _add_publish_snapshot_arguments(publish_snapshot_parser)
     publish_snapshot_parser.set_defaults(handler=cmd_publish_snapshot)

--- a/src/repo_release_tools/mcp/tools/publish_tools.py
+++ b/src/repo_release_tools/mcp/tools/publish_tools.py
@@ -31,9 +31,19 @@ def register(mcp: FastMCP) -> None:
         message: str = "Initial commit",
         exclude: list[str] | None = None,
         dry_run: bool = True,
+        confirm: bool = False,
     ) -> PublishSnapshotResult:
-        """Force-push a single-commit snapshot of tracked content to a secondary remote. dry_run=True by default; force-push additionally requires dry_run=False (no separate confirmation flag on this surface — treat dry_run=False as the explicit confirmation)."""
+        """Force-push a single-commit snapshot of tracked content to a secondary remote.
+
+        dry_run=True by default. The force-push requires BOTH ``dry_run=False`` AND
+        ``confirm=True`` -- mirroring the CLI's ``rrt git publish-snapshot``, which
+        requires an explicit ``--yes-i-know-this-overwrites-remote-history`` flag in
+        addition to not passing ``--dry-run`` (two independent signals for one
+        destructive, history-rewriting operation). If ``confirm`` is omitted or False,
+        the call is always treated as a dry-run preview, regardless of ``dry_run``.
+        """
         root: Path = ctx.lifespan_context.get("root", Path.cwd())
+        dry_run = dry_run or not confirm
 
         if not git.is_git_repository(root):
             return PublishSnapshotResult(

--- a/src/repo_release_tools/mcp/tools/version_tools.py
+++ b/src/repo_release_tools/mcp/tools/version_tools.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 from fastmcp import Context, FastMCP
@@ -52,8 +53,22 @@ def register(mcp: FastMCP) -> None:
         ctx: Context,
         level: str,
         dry_run: bool = True,
+        group: str | None = None,
     ) -> list[BumpGroupResult] | dict[str, Any]:
-        """Preview or apply a version bump. level: major | minor | patch | alpha | beta | rc. dry_run=True by default."""
+        """Preview or apply a version bump.
+
+        level: major | minor | patch | alpha | beta | rc. dry_run=True by default.
+        group: restrict the bump to one ``[tool.rrt]`` version group; omit to bump every
+        configured group (one :class:`BumpGroupResult` per group either way).
+
+        Runs the SAME pipeline as the ``rrt bump`` CLI command (preflight, version
+        targets, pin targets, changelog promotion/generation, lockfile and generated-asset
+        refresh, then release-branch checkout + commit) via
+        :mod:`repo_release_tools.commands.bump`'s shared stage functions, so an MCP bump
+        and a CLI bump of the same repo produce identical results (fixes defect D9: the
+        previous MCP bump only rewrote version-target files and skipped pins, changelog,
+        lockfiles, generated assets, and git branch/commit entirely).
+        """
         valid_levels = ("major", "minor", "patch", "alpha", "beta", "rc")
         if level not in valid_levels:
             return {"error": f"level must be one of: {', '.join(valid_levels)}"}
@@ -65,38 +80,114 @@ def register(mcp: FastMCP) -> None:
         if config is None:
             return {"error": "No rrt configuration found."}
 
-        from repo_release_tools.version.semver import Version
-        from repo_release_tools.version.targets import read_version_string
+        from repo_release_tools.commands import bump as bump_cmd
+        from repo_release_tools.preflight import PreflightError, run_preflight
+        from repo_release_tools.workflow import git
 
-        groups = config.version_groups
+        root: Path = ctx.lifespan_context.get("root", Path.cwd())
+
+        try:
+            groups = [config.resolve_group(group)] if group is not None else config.version_groups
+        except ValueError as exc:
+            return {"error": str(exc)}
         total = float(len(groups))
         results: list[BumpGroupResult] = []
-        for i, group in enumerate(groups):
+        for i, target_group in enumerate(groups):
+            group_opts = bump_cmd.Options(
+                bump=level,
+                group=target_group.name,
+                dry_run=dry_run,
+                force=False,
+                no_commit=False,
+                no_verify=False,
+                no_changelog=False,
+                no_pin_sync=False,
+                no_update=False,
+                include_maintenance=False,
+                changelog_mode=None,
+                base_branch=None,
+                calver_scheme="YYYY.MM.DD",
+                verbose=0,
+            )
             try:
-                current = read_version_string(group.primary_target())
-                new_ver = str(Version.parse(current).bump(level))
-                await ctx.info(
-                    f"{'Would bump' if dry_run else 'Bumping'} {group.name}: {current} → {new_ver}"
-                )
-                applied = False
-                if not dry_run:
-                    from repo_release_tools.version.targets import replace_version_in_file
+                resolved = bump_cmd.resolve_bump_target(config, group_opts)
+            except (bump_cmd.BumpResolutionError, RuntimeError, OSError, ValueError) as exc:
+                results.append(BumpGroupResult(group=target_group.name, error=str(exc)))
+                if total > 0:
+                    await ctx.report_progress(float(i + 1), total)
+                continue
 
-                    for target in group.version_targets:
-                        replace_version_in_file(target, new_ver, dry_run=False)
-                        await ctx.info(f"Updated {target.path}")
-                    applied = True
-                results.append(
-                    BumpGroupResult(
-                        group=group.name,
-                        current=current,
-                        new=new_ver,
-                        dry_run=dry_run,
-                        applied=applied,
+            current, new = resolved.current, resolved.new
+            new_ver = str(new)
+            await ctx.info(
+                f"{'Would bump' if dry_run else 'Bumping'} {target_group.name}: "
+                f"{current} → {new_ver}"
+            )
+            try:
+                run_preflight(config, dry_run=dry_run, group=target_group)
+
+                branch_name = target_group.release_branch.format(version=new)
+                base = "<current>" if dry_run else git.current_branch(root)
+
+                if not dry_run and git.branch_exists(root, branch_name):
+                    raise RuntimeError(
+                        f"Branch '{branch_name}' already exists. Delete it first or "
+                        "choose a different version."
                     )
+
+                changed_paths = bump_cmd.apply_bump_files(
+                    target_group, new, config, dry_run=dry_run
                 )
-            except (RuntimeError, OSError, ValueError) as exc:
-                results.append(BumpGroupResult(group=group.name, error=str(exc)))
+
+                effective_changelog_mode = bump_cmd.resolve_changelog_mode(config, None)
+                bump_cmd.update_changelog(
+                    bump_cmd.RrtConfig(
+                        root=config.root,
+                        config_file=config.config_file,
+                        version_groups=[target_group],
+                        default_group_name=target_group.name,
+                    ),
+                    new_ver,
+                    include_maintenance=False,
+                    dry_run=dry_run,
+                    changelog_mode=effective_changelog_mode,
+                )
+
+                if target_group.lock_command:
+                    bump_cmd.refresh_bump_lockfile(target_group, root, dry_run=dry_run)
+
+                if target_group.generated_assets and not bump_cmd.refresh_bump_generated_assets(
+                    target_group, root, dry_run=dry_run
+                ):
+                    raise RuntimeError(
+                        f"Generated asset refresh failed for group {target_group.name!r}."
+                    )
+
+                bump_cmd.finalize_bump_git(
+                    target_group,
+                    new,
+                    changed_paths,
+                    root,
+                    branch_name=branch_name,
+                    base=base,
+                    force=False,
+                    opts=group_opts,
+                )
+            except (bump_cmd.BumpResolutionError, PreflightError, RuntimeError, OSError) as exc:
+                results.append(BumpGroupResult(group=target_group.name, error=str(exc)))
+                if total > 0:
+                    await ctx.report_progress(float(i + 1), total)
+                continue
+
+            results.append(
+                BumpGroupResult(
+                    group=target_group.name,
+                    current=str(current),
+                    new=new_ver,
+                    dry_run=dry_run,
+                    applied=not dry_run,
+                )
+            )
             if total > 0:
                 await ctx.report_progress(float(i + 1), total)
         if total > 0:

--- a/src/repo_release_tools/workflow/hooks.py
+++ b/src/repo_release_tools/workflow/hooks.py
@@ -28,6 +28,7 @@ from repo_release_tools.commands.config_cmd import cmd_config
 from repo_release_tools.commands.docs_cmd import cmd_docs
 from repo_release_tools.commands.docs_suggest import cmd_docs_suggest
 from repo_release_tools.commands.doctor import cmd_doctor
+from repo_release_tools.commands.drift_cmd import _add_drift_lock_arguments
 from repo_release_tools.commands.drift_cmd import cmd_check as cmd_drift_check
 from repo_release_tools.commands.eol_check import cmd_eol as cmd_eol_check
 from repo_release_tools.commands.folder import cmd_folder_check
@@ -1156,10 +1157,17 @@ def main(argv: list[str] | None = None) -> int:
         "tree-check",
         help="Validate project tree structure against .rrt/tree.lock.toml (strict).",
     )
-    subparsers.add_parser(
+    drift_check_parser = subparsers.add_parser(
         "drift-check",
         help="Verify agent-surface drift lockfile is current (rrt drift check).",
     )
+    # Flags are the single source of truth in commands/drift_cmd.py, shared
+    # with `rrt drift check`'s own register(). hooks.py previously hand-built
+    # a partial argparse.Namespace(root=".", lock_file="drift.lock.toml",
+    # verbose=verbose) here instead of parsing real flags — this now parses a
+    # real, complete Namespace so --root/--lock-file overrides are possible
+    # from the hooks surface too (previously silently ignored/unsupported).
+    _add_drift_lock_arguments(drift_check_parser)
 
     sync_parser = subparsers.add_parser(
         "sync",
@@ -1339,12 +1347,8 @@ def main(argv: list[str] | None = None) -> int:
             )
             return cmd_tree(tree_args)
         case "drift-check":
-            drift_args = argparse.Namespace(
-                root=".",
-                lock_file="drift.lock.toml",
-                verbose=verbose,
-            )
-            return cmd_drift_check(drift_args)
+            parsed.verbose = verbose
+            return cmd_drift_check(parsed)
         case "sync":
             parsed.verbose = verbose
             return cmd_sync(parsed)

--- a/src/repo_release_tools/workflow/hooks.py
+++ b/src/repo_release_tools/workflow/hooks.py
@@ -31,7 +31,10 @@ from repo_release_tools.commands.doctor import cmd_doctor
 from repo_release_tools.commands.drift_cmd import cmd_check as cmd_drift_check
 from repo_release_tools.commands.eol_check import cmd_eol as cmd_eol_check
 from repo_release_tools.commands.folder import cmd_folder_check
-from repo_release_tools.commands.git_sync import cmd_publish_snapshot
+from repo_release_tools.commands.git_sync import (
+    _add_publish_snapshot_arguments,
+    cmd_publish_snapshot,
+)
 from repo_release_tools.commands.release_cmd import cmd_release_check
 from repo_release_tools.commands.sync_cmd import cmd_sync
 from repo_release_tools.commands.tag import cmd_tag_check
@@ -1183,39 +1186,11 @@ def main(argv: list[str] | None = None) -> int:
         "publish-snapshot",
         help="Force-push a single-commit snapshot of tracked content to a secondary remote.",
     )
-    publish_snapshot_parser.add_argument(
-        "target",
-        nargs="?",
-        default=None,
-        help="Named [tool.rrt.publish_targets.<name>] entry to resolve remote/branch/message from.",
-    )
-    publish_snapshot_parser.add_argument(
-        "--remote", default=None, help="Remote name or URL to force-push to."
-    )
-    publish_snapshot_parser.add_argument(
-        "--branch", default=None, help="Remote branch to force-push to. Defaults to main."
-    )
-    publish_snapshot_parser.add_argument(
-        "--message", default=None, help="Commit message for the snapshot commit."
-    )
-    publish_snapshot_parser.add_argument(
-        "--exclude",
-        action="append",
-        default=None,
-        metavar="PATTERN",
-        help="Glob (fnmatch, repo-relative) to exclude from the snapshot. Repeatable; extends "
-        "the resolved target's [tool.rrt.publish_targets.<name>].exclude list.",
-    )
-    publish_snapshot_parser.add_argument(
-        "--yes-i-know-this-overwrites-remote-history",
-        action="store_true",
-        help="Required confirmation to actually force-push. Without it, behaves as --dry-run.",
-    )
-    publish_snapshot_parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Preview without changing git.",
-    )
+    # Flags are the single source of truth in commands/git_sync.py, shared with
+    # `rrt git publish-snapshot`'s own register_sync() — see
+    # _add_publish_snapshot_arguments's docstring for why this used to be a
+    # copy-pasted block here (pylint R0801) that could silently drift.
+    _add_publish_snapshot_arguments(publish_snapshot_parser)
 
     subparsers.add_parser(
         "config-validate",

--- a/src/repo_release_tools/workflow/hooks.py
+++ b/src/repo_release_tools/workflow/hooks.py
@@ -31,7 +31,7 @@ from repo_release_tools.commands.doctor import cmd_doctor
 from repo_release_tools.commands.drift_cmd import _add_drift_lock_arguments
 from repo_release_tools.commands.drift_cmd import cmd_check as cmd_drift_check
 from repo_release_tools.commands.eol_check import cmd_eol as cmd_eol_check
-from repo_release_tools.commands.folder import cmd_folder_check
+from repo_release_tools.commands.folder import _add_folder_check_arguments, cmd_folder_check
 from repo_release_tools.commands.git_sync import (
     _add_publish_snapshot_arguments,
     cmd_publish_snapshot,
@@ -1221,27 +1221,10 @@ def main(argv: list[str] | None = None) -> int:
         "folder-check",
         help="Validate repository folder structure against configured rules or templates.",
     )
-    folder_check_parser.add_argument(
-        "--root", default=".", metavar="PATH", help="Root to validate."
-    )
-    folder_check_parser.add_argument(
-        "--template",
-        action="append",
-        default=[],
-        help="Built-in or custom template name to apply at the root.",
-    )
-    folder_check_parser.add_argument(
-        "--report-only",
-        action="store_true",
-        default=False,
-        help="Downgrade violations to warnings.",
-    )
-    folder_check_parser.add_argument(
-        "--snapshot",
-        action="store_true",
-        default=False,
-        help="Merge results into .rrt/health.lock.toml.",
-    )
+    # Flags are the single source of truth in commands/folder.py, shared with
+    # `rrt folder check`'s own register(). This also unifies previously
+    # slightly-different help text between the two copy-pasted specs.
+    _add_folder_check_arguments(folder_check_parser)
 
     artifacts_check_parser = subparsers.add_parser(
         "artifacts-check",

--- a/tests/e2e/test_mcp_parity_and_ordering.py
+++ b/tests/e2e/test_mcp_parity_and_ordering.py
@@ -7,15 +7,20 @@ Pins the behavior contract from ``analysis/the/MODERNIZATION_BRIEF.md`` §5:
   4th/5th sort-key elements order pre-release labels *lexically*, which is not SemVer 2.0
   precedence (``rc.10`` sorts before ``rc.2``) — pinned as-is per the brief's SME
   recommendation to pin D1 initially (§7-Q2).
-- **D9** (``mcp/tools/version_tools.py:68-105`` vs. ``commands/bump.py``'s full pipeline):
-  the MCP ``rrt_bump`` tool only rewrites ``group.version_targets`` — it never touches pin
-  targets, never promotes ``[Unreleased]``, and performs no git branch/commit. This is a
-  known, non-atomic partial pipeline; Phase 5 unifies it onto ``perform_bump`` and MUST flip
-  these assertions (brief §5, defect D9; Phase 5 exit criteria).
-- **D4/D6** (``mcp/tools/publish_tools.py:27-142``): ``rrt_publish_snapshot`` defaults
-  ``dry_run=True`` and treats ``dry_run=False`` alone as the destructive confirmation — there
-  is no separate ``confirm`` flag on this surface, unlike the CLI's explicit
-  ``publish-snapshot`` confirmation flag (C3). Pinned as-is; Phase 5 adds parity.
+- **D9 (FIXED in Phase 5)** (``mcp/tools/version_tools.py`` vs. ``commands/bump.py``'s full
+  pipeline): the MCP ``rrt_bump`` tool now calls the SAME stage functions the CLI's
+  ``cmd_bump`` uses (``resolve_bump_target`` → ``apply_bump_files`` → ``update_changelog`` →
+  ``refresh_bump_lockfile``/``refresh_bump_generated_assets`` → ``finalize_bump_git``), so an
+  MCP bump and a CLI bump of the same repo produce identical results: pin targets are
+  updated, ``[Unreleased]`` is promoted, and a release branch + commit are created. The
+  assertions below were flipped from "pinned as-is partial pipeline" to "matches the CLI's
+  full pipeline" per brief §5 defect D9 / Phase 5 exit criteria.
+- **D4/D6 (FIXED in Phase 5)** (``mcp/tools/publish_tools.py``): ``rrt_publish_snapshot`` now
+  requires a separate ``confirm: bool = False`` parameter in addition to ``dry_run=False``
+  before it will force-push — mirroring the CLI's explicit
+  ``--yes-i-know-this-overwrites-remote-history`` confirmation flag (C3). ``dry_run=False``
+  alone (without ``confirm=True``) is downgraded to a safe dry-run preview, matching the
+  CLI's two-signal requirement.
 - **MCP/CLI parity seed**: today's overlap/divergence of reported target files between
   ``rrt bump --dry-run`` (CLI) and the MCP dry-run ``rrt_bump`` tool on the same fixture repo,
   which becomes the Phase 5 parity gate.
@@ -161,7 +166,7 @@ def test_d1_newer_versions_lexical_ordering_propagates() -> None:
 
 
 # ---------------------------------------------------------------------------
-# D9 — MCP partial bump divergence (in-process MCP tool call, non-dry-run)
+# D9 (fixed) — MCP bump now runs the full CLI pipeline (in-process, non-dry-run)
 # ---------------------------------------------------------------------------
 
 _PIN_PYPROJECT = """\
@@ -197,13 +202,15 @@ def _make_pin_repo(factory: RepoFactory) -> Path:
 
 
 @pytest.mark.mcp
-def test_d9_mcp_bump_updates_version_targets_only(
+def test_d9_mcp_bump_updates_version_targets_and_pins_and_changelog(
     e2e_repo_factory: RepoFactory, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """MCP ``rrt_bump`` (non-dry-run) writes version targets but leaves pins/changelog/git alone.
+    """MCP ``rrt_bump`` (non-dry-run) now updates version targets, pins, AND the changelog.
 
-    # D9: MCP bump is a partial pipeline — pinned as-is; Phase 5 unifies it onto
-    # perform_bump and MUST flip these assertions.
+    # D9 (fixed): MCP bump now shares commands/bump.py's stage functions
+    # (resolve_bump_target -> apply_bump_files -> update_changelog -> ... ->
+    # finalize_bump_git), matching the CLI's full pipeline. Phase 5 flipped this
+    # assertion from "partial pipeline, pinned as-is" to "full parity with the CLI".
     """
     pytest.importorskip("fastmcp")
     from fastmcp import Client
@@ -214,9 +221,6 @@ def test_d9_mcp_bump_updates_version_targets_only(
     pin_doc = repo / "docs" / "action.md"
     changelog = repo / "CHANGELOG.md"
     pyproject = repo / "pyproject.toml"
-
-    original_changelog = changelog.read_text(encoding="utf-8")
-    original_pin_doc = pin_doc.read_text(encoding="utf-8")
 
     monkeypatch.chdir(repo)
 
@@ -235,45 +239,43 @@ def test_d9_mcp_bump_updates_version_targets_only(
     assert bump_result.applied is True, f"expected applied=True for dry_run=False: {output}"
     assert bump_result.new == "0.1.1", f"expected new version 0.1.1: {output}"
 
-    # Version target WAS updated (this is the part D9 gets "right").
+    # Version target updated.
     pyproject_text = pyproject.read_text(encoding="utf-8")
     assert "0.1.1" in pyproject_text, (
-        f"D9: expected pyproject.toml version target to be updated to 0.1.1; "
+        f"expected pyproject.toml version target to be updated to 0.1.1; "
         f"content:\n{pyproject_text}\nMCP result: {output}"
     )
 
-    # D9: pin targets are NOT updated by the MCP bump tool (unlike commands/bump.py's
-    # apply_version, which applies group.pin_targets + config.global_pin_targets).
+    # D9 (fixed): pin targets ARE now updated by the MCP bump tool, matching
+    # commands/bump.py's apply_version (group.pin_targets + config.global_pin_targets).
     pin_doc_text = pin_doc.read_text(encoding="utf-8")
-    assert pin_doc_text == original_pin_doc, (
-        f"D9: MCP bump is a partial pipeline — pinned as-is; Phase 5 unifies it onto "
-        f"perform_bump and MUST flip this assertion. Expected docs/action.md to be "
-        f"UNCHANGED (still v0.1.0) after MCP rrt_bump; got:\n{pin_doc_text}"
+    assert "v0.1.1" in pin_doc_text, (
+        f"D9 fix: expected docs/action.md pin target to be updated to v0.1.1 after "
+        f"MCP rrt_bump; got:\n{pin_doc_text}"
     )
 
-    # D9: [Unreleased] is NOT promoted by the MCP bump tool.
+    # D9 (fixed): [Unreleased] IS now promoted by the MCP bump tool.
     changelog_text = changelog.read_text(encoding="utf-8")
-    assert changelog_text == original_changelog, (
-        f"D9: MCP bump is a partial pipeline — pinned as-is; Phase 5 unifies it onto "
-        f"perform_bump and MUST flip this assertion. Expected CHANGELOG.md to be "
-        f"UNCHANGED (still [Unreleased]) after MCP rrt_bump; got:\n{changelog_text}"
-    )
     assert "[Unreleased]" in changelog_text, (
-        f"D9: [Unreleased] heading must survive untouched; got:\n{changelog_text}"
+        f"D9 fix: promoted changelog must still carry a fresh empty [Unreleased] "
+        f"placeholder above the new section; got:\n{changelog_text}"
     )
-    assert "[0.1.1]" not in changelog_text, (
-        f"D9: no [0.1.1] section should have been created by MCP bump; got:\n{changelog_text}"
+    assert "[0.1.1]" in changelog_text, (
+        f"D9 fix: expected [Unreleased] to be promoted to a [0.1.1] section by MCP "
+        f"rrt_bump; got:\n{changelog_text}"
     )
 
 
 @pytest.mark.mcp
-def test_d9_mcp_bump_creates_no_git_branch_or_commit(
+def test_d9_mcp_bump_creates_release_branch_and_commit(
     e2e_repo_factory: RepoFactory, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """MCP ``rrt_bump`` (non-dry-run) never branches or commits, unlike the CLI's full pipeline.
+    """MCP ``rrt_bump`` (non-dry-run) now branches and commits, matching the CLI's pipeline.
 
-    # D9: MCP bump is a partial pipeline — pinned as-is; Phase 5 unifies it onto
-    # perform_bump and MUST flip these assertions.
+    # D9 (fixed): MCP bump now calls finalize_bump_git (the same stage function
+    # commands/bump.py's cmd_bump uses), so it checks out the release branch, stages
+    # the changed files, and commits -- exactly like the CLI. Phase 5 flipped this
+    # assertion from "no branch/commit" to "branch + commit created".
     """
     pytest.importorskip("fastmcp")
     from fastmcp import Client
@@ -300,27 +302,27 @@ def test_d9_mcp_bump_creates_no_git_branch_or_commit(
     branch_list = git("branch", "--list", cwd=repo).stdout
     status = git("status", "--short", cwd=repo).stdout
 
-    assert after_branch == before_branch == "main", (
-        f"D9: MCP bump is a partial pipeline — pinned as-is; Phase 5 unifies it onto "
-        f"perform_bump and MUST flip this assertion. Expected to remain on 'main'; "
-        f"was {before_branch!r}, now {after_branch!r}. MCP result: {data!r}"
+    assert before_branch == "main", f"fixture should start on 'main'; was {before_branch!r}"
+    assert after_branch == "release/v0.1.1", (
+        f"D9 fix: expected MCP rrt_bump to check out the release branch "
+        f"'release/v0.1.1', matching the CLI's finalize_bump_git; was on "
+        f"{after_branch!r}. MCP result: {data!r}"
     )
-    assert "release/v0.1.1" not in branch_list, (
-        f"D9: no release branch should be created by MCP bump; branches:\n{branch_list}"
+    assert "release/v0.1.1" in branch_list, (
+        f"D9 fix: expected a release branch to be created by MCP bump; branches:\n{branch_list}"
     )
-    assert after_log == before_log, (
-        f"D9: MCP bump is a partial pipeline — pinned as-is; Phase 5 unifies it onto "
-        f"perform_bump and MUST flip this assertion. Expected no new commit; "
+    assert after_log != before_log, (
+        f"D9 fix: expected a new commit on the release branch; "
         f"before:\n{before_log}\nafter:\n{after_log}"
     )
-    assert "pyproject.toml" in status, (
-        f"D9: the version-target write should be left as an uncommitted, unstaged change "
-        f"(no git add/commit happens); git status --short:\n{status}"
+    assert status.strip() == "", (
+        f"D9 fix: MCP bump should commit the changed files (nothing left uncommitted), "
+        f"matching the CLI's git add + git commit; git status --short:\n{status}"
     )
 
 
 # ---------------------------------------------------------------------------
-# D4/D6 — MCP publish-snapshot confirmation shape
+# D4/D6 (fixed) — MCP publish-snapshot confirmation parity with the CLI
 # ---------------------------------------------------------------------------
 
 
@@ -338,7 +340,8 @@ def test_d4_publish_snapshot_dry_run_defaults_true(
 ) -> None:
     """``rrt_publish_snapshot`` defaults to ``dry_run=True`` when the argument is omitted.
 
-    # D4/D6: weaker than CLI's explicit confirm flag — pinned as-is; Phase 5 adds parity.
+    # D4/D6: the safe default (dry_run=True) is unchanged by the Phase 5 fix — only the
+    # *destructive* path gained a second required signal (see test_d6 below).
     """
     pytest.importorskip("fastmcp")
     from fastmcp import Client
@@ -379,7 +382,8 @@ def test_d4_publish_snapshot_dry_run_true_pushes_nothing(
 ) -> None:
     """``dry_run=True`` (explicit) previews the publish but pushes nothing to the remote.
 
-    # D4/D6: weaker than CLI's explicit confirm flag — pinned as-is; Phase 5 adds parity.
+    # D4/D6: unaffected by the Phase 5 fix — dry_run=True always previews, regardless
+    # of confirm.
     """
     pytest.importorskip("fastmcp")
     from fastmcp import Client
@@ -413,14 +417,18 @@ def test_d4_publish_snapshot_dry_run_true_pushes_nothing(
 
 
 @pytest.mark.mcp
-def test_d6_publish_snapshot_dry_run_false_alone_is_the_confirmation(
+def test_d6_publish_snapshot_dry_run_false_alone_no_longer_confirms(
     e2e_repo: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """``dry_run=False`` alone force-pushes — there is no separate ``confirm`` parameter.
+    """``dry_run=False`` alone (no ``confirm=True``) is now downgraded to a safe preview.
 
     Exercised against a local bare repo only, never a real remote.
 
-    # D4/D6: weaker than CLI's explicit confirm flag — pinned as-is; Phase 5 adds parity.
+    # D6 (fixed): the tool gained a ``confirm: bool = False`` parameter. Passing
+    # dry_run=False without confirm=True no longer force-pushes -- it fails safe and
+    # behaves exactly like a dry-run, mirroring the CLI's requirement for BOTH
+    # not-dry-run AND --yes-i-know-this-overwrites-remote-history. Phase 5 flipped
+    # this assertion from "force-pushes" to "fails safe / does not publish".
     """
     pytest.importorskip("fastmcp")
     from fastmcp import Client
@@ -428,7 +436,7 @@ def test_d6_publish_snapshot_dry_run_false_alone_is_the_confirmation(
     from repo_release_tools.mcp.server import create_server
     from repo_release_tools.mcp.tools import publish_tools
 
-    # NOTE(P1) D4/D6: confirm there is no separate confirmation parameter on this tool by
+    # D6 (fixed): confirm the new 'confirm' parameter now exists on this tool by
     # inspecting the registered function's signature directly (belt-and-braces alongside
     # the behavioral proof below).
     class _Capture:
@@ -447,9 +455,10 @@ def test_d6_publish_snapshot_dry_run_false_alone_is_the_confirmation(
     publish_tools.register(cast("Any", capture))  # duck-typed FastMCP stand-in
     assert capture.fn is not None
     param_names = set(inspect.signature(capture.fn).parameters)
-    assert "confirm" not in param_names, (
-        f"D4/D6: expected no separate 'confirm' parameter on rrt_publish_snapshot "
-        f"(dry_run=False alone is the destructive confirmation); got params {param_names}"
+    assert "confirm" in param_names, (
+        f"D6 fix: expected a separate 'confirm' parameter on rrt_publish_snapshot "
+        f"(dry_run=False alone must no longer be sufficient to force-push); "
+        f"got params {param_names}"
     )
 
     bare = _init_bare_remote(tmp_path)
@@ -460,7 +469,7 @@ def test_d6_publish_snapshot_dry_run_false_alone_is_the_confirmation(
     async def _call() -> Any:
         server = create_server()
         async with Client(server) as client:
-            # No 'confirm' kwarg exists on this surface — dry_run=False is the only gate.
+            # confirm intentionally omitted: dry_run=False alone must no longer be enough.
             result = await client.call_tool(
                 "rrt_publish_snapshot",
                 {"remote": "snapshot", "branch": "main", "dry_run": False},
@@ -469,14 +478,67 @@ def test_d6_publish_snapshot_dry_run_false_alone_is_the_confirmation(
 
     data = asyncio.run(_call())
 
+    assert data.published is False, (
+        f"D6 fix: dry_run=False without confirm=True must fail safe (no publish); got {data!r}"
+    )
+    assert data.dry_run is True, (
+        f"D6 fix: expected the call to be downgraded to dry_run=True when confirm is "
+        f"omitted; got {data!r}"
+    )
+    assert data.error is None, f"expected a clean fail-safe preview, not an error; got {data!r}"
+
+    branches = git("branch", "-a", "--list", cwd=bare).stdout
+    assert branches.strip() == "", (
+        f"D6 fix: dry_run=False without confirm=True must push nothing to the remote; "
+        f"bare repo branches:\n{branches!r}"
+    )
+
+
+@pytest.mark.mcp
+def test_d6_publish_snapshot_dry_run_false_and_confirm_true_force_pushes(
+    e2e_repo: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``dry_run=False`` AND ``confirm=True`` together force-push -- the new two-signal gate.
+
+    Exercised against a local bare repo only, never a real remote.
+
+    # D4/D6 (fixed): this is the new positive case added by Phase 5 -- the destructive
+    # path now requires both signals, matching the CLI's two-flag requirement (C3).
+    """
+    pytest.importorskip("fastmcp")
+    from fastmcp import Client
+
+    from repo_release_tools.mcp.server import create_server
+
+    bare = _init_bare_remote(tmp_path)
+    git("remote", "add", "snapshot", str(bare), cwd=e2e_repo)
+
+    monkeypatch.chdir(e2e_repo)
+
+    async def _call() -> Any:
+        server = create_server()
+        async with Client(server) as client:
+            result = await client.call_tool(
+                "rrt_publish_snapshot",
+                {
+                    "remote": "snapshot",
+                    "branch": "main",
+                    "dry_run": False,
+                    "confirm": True,
+                },
+            )
+            return result.data
+
+    data = asyncio.run(_call())
+
     assert data.published is True, (
-        f"D4/D6: dry_run=False alone (no separate confirm flag) must force-push; got {data!r}"
+        f"D4/D6 fix: dry_run=False AND confirm=True together must force-push; got {data!r}"
     )
     assert data.error is None, f"expected a clean publish; got {data!r}"
 
     branches = run_ok(["git", "branch", "--list", "main"], cwd=bare).stdout
     assert "main" in branches, (
-        f"D4/D6: expected the snapshot to land on {bare}'s main branch; branches:\n{branches!r}"
+        f"D4/D6 fix: expected the snapshot to land on {bare}'s main branch; branches:\n{branches!r}"
     )
 
 

--- a/tests/mcp/test_tools.py
+++ b/tests/mcp/test_tools.py
@@ -12,6 +12,7 @@ import pytest
 
 pytest.importorskip("fastmcp", reason="[mcp] extra not installed")
 
+from repo_release_tools.config import RrtConfig, VersionGroup, VersionTarget
 from repo_release_tools.mcp.models import (
     BranchResult,
     BranchValidationResult,
@@ -346,45 +347,258 @@ def test_rrt_bump_empty_groups_skips_progress(tmp_path: Path) -> None:
     ctx.report_progress.assert_not_called()
 
 
+def _real_group_config(tmp_path: Path, *, name: str = "default") -> tuple[VersionGroup, RrtConfig]:
+    """Build a real (non-mock) VersionGroup + RrtConfig backed by a pyproject.toml on disk.
+
+    Used by the rrt_bump tests below to exercise the actual Phase-5 pipeline
+    (resolve_bump_target -> apply_bump_files -> update_changelog -> ... ->
+    finalize_bump_git) end-to-end, matching how tests/commands/test_bump.py fixtures
+    the same functions for the CLI side.
+    """
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "fixture"\nversion = "1.0.0"\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "CHANGELOG.md").write_text(
+        "# Changelog\n\n## [Unreleased]\n### Added\n- something\n",
+        encoding="utf-8",
+    )
+    target = VersionTarget(path=tmp_path / "pyproject.toml", kind="pep621")
+    group = VersionGroup(
+        name=name,
+        release_branch="release/v{version}",
+        changelog_file=tmp_path / "CHANGELOG.md",
+        lock_command=[],
+        generated_files=[],
+        version_targets=[target],
+        changelog_workflow="incremental",
+    )
+    config = RrtConfig(
+        root=tmp_path,
+        config_file=tmp_path / ".rrt.toml",
+        version_groups=[group],
+        default_group_name=name,
+    )
+    return group, config
+
+
 def test_rrt_bump_dry_run(tmp_path: Path) -> None:
     tools = _ver_tools(tmp_path)
-    mock_group = MagicMock()
-    mock_group.name = "main"
-    mock_group.primary_target.return_value = MagicMock()
-    mock_config = MagicMock()
-    mock_config.version_groups = [mock_group]
-    ctx = _ctx(tmp_path, config=mock_config)
+    _, config = _real_group_config(tmp_path)
+    ctx = _ctx(tmp_path, config=config)
 
     async def _run() -> Any:
-        with patch("repo_release_tools.version.targets.read_version_string", return_value="1.0.0"):
-            return await tools["rrt_bump"](ctx, level="patch", dry_run=True)
+        return await tools["rrt_bump"](ctx, level="patch", dry_run=True)
 
     result = asyncio.run(_run())
     assert isinstance(result, list)
+    assert result[0].current == "1.0.0"
+    assert result[0].new == "1.0.1"
     assert result[0].dry_run is True
     assert result[0].applied is False
     assert ctx.report_progress.await_count >= 1
 
+    # dry-run must not touch disk at all (D9 fix: preflight + apply_bump_files both
+    # honour dry_run just like the CLI).
+    assert "1.0.0" in (tmp_path / "pyproject.toml").read_text(encoding="utf-8")
+    assert "[Unreleased]" in (tmp_path / "CHANGELOG.md").read_text(encoding="utf-8")
+
 
 def test_rrt_bump_applied(tmp_path: Path) -> None:
+    """D9 fix: a non-dry-run MCP bump runs the SAME pipeline as the CLI's cmd_bump.
+
+    Version target, changelog promotion, and git branch/commit all happen -- unlike
+    the pre-Phase-5 MCP tool, which only wrote version targets.
+    """
     tools = _ver_tools(tmp_path)
-    mock_group = MagicMock()
-    mock_group.name = "main"
-    mock_group.primary_target.return_value = MagicMock()
-    mock_group.version_targets = [MagicMock()]
-    mock_config = MagicMock()
-    mock_config.version_groups = [mock_group]
-    ctx = _ctx(tmp_path, config=mock_config)
+    _, config = _real_group_config(tmp_path)
+    ctx = _ctx(tmp_path, config=config)
+
+    monkeypatch_calls: list[list[str]] = []
+
+    def fake_run(
+        cmd: list[str],
+        root: Path,
+        *,
+        dry_run: bool,
+        label: str,
+        suppress_announce: bool = False,
+    ) -> str:
+        monkeypatch_calls.append(cmd)
+        return ""
 
     async def _run() -> Any:
         with (
-            patch("repo_release_tools.version.targets.read_version_string", return_value="1.0.0"),
-            patch("repo_release_tools.version.targets.replace_version_in_file"),
+            patch("repo_release_tools.commands.bump.git.working_tree_clean", return_value=True),
+            patch("repo_release_tools.commands.bump.git.branch_exists", return_value=False),
+            patch("repo_release_tools.commands.bump.git.current_branch", return_value="main"),
+            patch("repo_release_tools.commands.bump.git.run", side_effect=fake_run),
         ):
             return await tools["rrt_bump"](ctx, level="patch", dry_run=False)
 
     result = asyncio.run(_run())
+    assert result[0].error is None, result[0]
     assert result[0].applied is True
+    assert result[0].new == "1.0.1"
+
+    # Version target updated on disk.
+    assert "1.0.1" in (tmp_path / "pyproject.toml").read_text(encoding="utf-8")
+    # Changelog promoted -- the D9 fix: this file was never touched by the old tool.
+    changelog_text = (tmp_path / "CHANGELOG.md").read_text(encoding="utf-8")
+    assert "[1.0.1]" in changelog_text
+
+    # Git branch + commit stage happened via finalize_bump_git -- the D9 fix.
+    assert ["git", "checkout", "-b", "release/v1.0.1"] in monkeypatch_calls
+    assert any(cmd[:2] == ["git", "commit"] for cmd in monkeypatch_calls)
+
+
+def test_rrt_bump_existing_release_branch_returns_error(tmp_path: Path) -> None:
+    """A non-dry-run bump refuses to proceed when the release branch already exists."""
+    tools = _ver_tools(tmp_path)
+    _, config = _real_group_config(tmp_path)
+    ctx = _ctx(tmp_path, config=config)
+
+    async def _run() -> Any:
+        with (
+            patch("repo_release_tools.commands.bump.git.working_tree_clean", return_value=True),
+            patch("repo_release_tools.commands.bump.git.branch_exists", return_value=True),
+            patch("repo_release_tools.commands.bump.git.current_branch", return_value="main"),
+        ):
+            return await tools["rrt_bump"](ctx, level="patch", dry_run=False)
+
+    result = asyncio.run(_run())
+    assert result[0].error is not None
+    assert "already exists" in result[0].error
+    # No files should have been touched -- the error is raised before apply_bump_files.
+    assert "1.0.0" in (tmp_path / "pyproject.toml").read_text(encoding="utf-8")
+
+
+def test_rrt_bump_runs_lock_command_when_configured(tmp_path: Path) -> None:
+    """When a group configures ``lock_command``, the MCP bump refreshes it like the CLI."""
+    tools = _ver_tools(tmp_path)
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "fixture"\nversion = "1.0.0"\n', encoding="utf-8"
+    )
+    (tmp_path / "CHANGELOG.md").write_text("# Changelog\n\n## [Unreleased]\n", encoding="utf-8")
+    group = VersionGroup(
+        name="default",
+        release_branch="release/v{version}",
+        changelog_file=tmp_path / "CHANGELOG.md",
+        lock_command=["echo", "locking"],
+        generated_files=[],
+        version_targets=[VersionTarget(path=tmp_path / "pyproject.toml", kind="pep621")],
+        changelog_workflow="incremental",
+    )
+    config = RrtConfig(
+        root=tmp_path,
+        config_file=tmp_path / ".rrt.toml",
+        version_groups=[group],
+        default_group_name="default",
+    )
+    ctx = _ctx(tmp_path, config=config)
+
+    async def _run() -> Any:
+        with patch("repo_release_tools.commands.bump.refresh_bump_lockfile") as mock_refresh:
+            return await tools["rrt_bump"](ctx, level="patch", dry_run=True), mock_refresh
+
+    result, mock_refresh = asyncio.run(_run())
+    assert result[0].error is None, result[0]
+    mock_refresh.assert_called_once()
+    assert mock_refresh.call_args.kwargs["dry_run"] is True
+
+
+def test_rrt_bump_generated_asset_failure_returns_error(tmp_path: Path) -> None:
+    """A generated-asset refresh failure surfaces as a per-group error, not a crash."""
+    from repo_release_tools.config import GeneratedAsset
+
+    tools = _ver_tools(tmp_path)
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "fixture"\nversion = "1.0.0"\n', encoding="utf-8"
+    )
+    (tmp_path / "CHANGELOG.md").write_text("# Changelog\n\n## [Unreleased]\n", encoding="utf-8")
+    group = VersionGroup(
+        name="default",
+        release_branch="release/v{version}",
+        changelog_file=tmp_path / "CHANGELOG.md",
+        lock_command=[],
+        generated_files=[],
+        version_targets=[VersionTarget(path=tmp_path / "pyproject.toml", kind="pep621")],
+        generated_assets=[GeneratedAsset(path=Path("out.txt"), command=["true"])],
+        changelog_workflow="incremental",
+    )
+    config = RrtConfig(
+        root=tmp_path,
+        config_file=tmp_path / ".rrt.toml",
+        version_groups=[group],
+        default_group_name="default",
+    )
+    ctx = _ctx(tmp_path, config=config)
+
+    async def _run() -> Any:
+        with patch(
+            "repo_release_tools.commands.bump.refresh_bump_generated_assets", return_value=False
+        ):
+            return await tools["rrt_bump"](ctx, level="patch", dry_run=True)
+
+    result = asyncio.run(_run())
+    assert result[0].error is not None
+    assert "Generated asset refresh failed" in result[0].error
+
+
+def test_rrt_bump_group_filter_selects_one_group(tmp_path: Path) -> None:
+    """The new ``group`` parameter restricts the bump to a single named version group."""
+    tools = _ver_tools(tmp_path)
+    target_a = VersionTarget(path=tmp_path / "a.json", kind="package_json")
+    target_b = VersionTarget(path=tmp_path / "b.json", kind="package_json")
+    (tmp_path / "a.json").write_text('{"name": "a", "version": "1.0.0"}\n', encoding="utf-8")
+    (tmp_path / "b.json").write_text('{"name": "b", "version": "2.0.0"}\n', encoding="utf-8")
+    group_a = VersionGroup(
+        name="a",
+        release_branch="release/a-v{version}",
+        changelog_file=tmp_path / "CHANGELOG.md",
+        lock_command=[],
+        generated_files=[],
+        version_targets=[target_a],
+        changelog_workflow="incremental",
+    )
+    group_b = VersionGroup(
+        name="b",
+        release_branch="release/b-v{version}",
+        changelog_file=tmp_path / "CHANGELOG.md",
+        lock_command=[],
+        generated_files=[],
+        version_targets=[target_b],
+        changelog_workflow="incremental",
+    )
+    config = RrtConfig(
+        root=tmp_path,
+        config_file=tmp_path / ".rrt.toml",
+        version_groups=[group_a, group_b],
+        default_group_name="a",
+    )
+    ctx = _ctx(tmp_path, config=config)
+
+    async def _run() -> Any:
+        return await tools["rrt_bump"](ctx, level="patch", dry_run=True, group="b")
+
+    result = asyncio.run(_run())
+    assert len(result) == 1
+    assert result[0].group == "b"
+    assert result[0].current == "2.0.0"
+    assert result[0].new == "2.0.1"
+
+
+def test_rrt_bump_unknown_group_returns_error(tmp_path: Path) -> None:
+    tools = _ver_tools(tmp_path)
+    _, config = _real_group_config(tmp_path)
+    ctx = _ctx(tmp_path, config=config)
+
+    async def _run() -> Any:
+        return await tools["rrt_bump"](ctx, level="patch", group="does-not-exist")
+
+    result = asyncio.run(_run())
+    assert "error" in result
+    assert "does-not-exist" in result["error"]
 
 
 def test_rrt_bump_version_error(tmp_path: Path) -> None:
@@ -864,6 +1078,120 @@ def test_rrt_publish_snapshot_in_progress_operation(
     assert "rebase" in result.error
 
 
+# ── D4/D6 fix: confirm parameter gates the destructive push ──────────────────
+
+
+def test_rrt_publish_snapshot_dry_run_false_without_confirm_fails_safe(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """D6 fix: dry_run=False alone (confirm omitted/False) must NOT force-push.
+
+    Mirrors the CLI's two-signal requirement (not-dry-run AND
+    --yes-i-know-this-overwrites-remote-history). No git mutation calls should even
+    be attempted -- the tool should short-circuit to the dry-run preview branch.
+    """
+    monkeypatch.setattr(publish_tools.git, "is_git_repository", lambda root: True)
+    monkeypatch.setattr(
+        publish_tools.git,
+        "remote_url",
+        lambda root, name: {"origin": "https://x/a.git", "mirror": "https://x/b.git"}.get(name),
+    )
+    monkeypatch.setattr(publish_tools.git, "in_progress_operation", lambda root: None)
+    run_calls: list[list[str]] = []
+
+    def _fake_run(cmd: list[str], root: Path, *, dry_run: bool, label: str) -> str:
+        run_calls.append(cmd)
+        return ""
+
+    monkeypatch.setattr(publish_tools.git, "run", _fake_run)
+    tools = _publish_tools(tmp_path)
+    ctx = _ctx(tmp_path)
+
+    async def _run() -> PublishSnapshotResult:
+        # confirm intentionally omitted (defaults to False).
+        return await tools["rrt_publish_snapshot"](
+            ctx, remote="mirror", branch="main", dry_run=False
+        )
+
+    result = asyncio.run(_run())
+    assert result.published is False
+    assert result.dry_run is True
+    assert result.error is None
+    assert run_calls == [], f"no git mutation commands should run without confirm; got {run_calls}"
+
+
+def test_rrt_publish_snapshot_confirm_true_without_dry_run_false_still_previews(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """D4/D6 fix: confirm=True alone (dry_run defaults to True) must NOT force-push either.
+
+    Both signals are required; confirm=True is not sufficient on its own.
+    """
+    monkeypatch.setattr(publish_tools.git, "is_git_repository", lambda root: True)
+    monkeypatch.setattr(
+        publish_tools.git,
+        "remote_url",
+        lambda root, name: {"origin": "https://x/a.git", "mirror": "https://x/b.git"}.get(name),
+    )
+    monkeypatch.setattr(publish_tools.git, "in_progress_operation", lambda root: None)
+    run_calls: list[list[str]] = []
+
+    def _fake_run(cmd: list[str], root: Path, *, dry_run: bool, label: str) -> str:
+        run_calls.append(cmd)
+        return ""
+
+    monkeypatch.setattr(publish_tools.git, "run", _fake_run)
+    tools = _publish_tools(tmp_path)
+    ctx = _ctx(tmp_path)
+
+    async def _run() -> PublishSnapshotResult:
+        # dry_run intentionally omitted (defaults to True); confirm=True alone.
+        return await tools["rrt_publish_snapshot"](
+            ctx, remote="mirror", branch="main", confirm=True
+        )
+
+    result = asyncio.run(_run())
+    assert result.published is False
+    assert result.dry_run is True
+    assert run_calls == [], f"confirm=True alone must not push; got {run_calls}"
+
+
+def test_rrt_publish_snapshot_dry_run_false_and_confirm_true_publishes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """D4/D6 fix: both dry_run=False AND confirm=True together force-push."""
+    monkeypatch.setattr(publish_tools.git, "is_git_repository", lambda root: True)
+    monkeypatch.setattr(
+        publish_tools.git,
+        "remote_url",
+        lambda root, name: {"origin": "https://x/a.git", "mirror": "https://x/b.git"}.get(name),
+    )
+    monkeypatch.setattr(publish_tools.git, "in_progress_operation", lambda root: None)
+    monkeypatch.setattr(publish_tools.git, "current_branch", lambda root: "main")
+    monkeypatch.setattr(
+        publish_tools.git, "unique_snapshot_branch_name", lambda root: "snapshot-tmp"
+    )
+    run_calls: list[list[str]] = []
+
+    def _fake_run(cmd: list[str], root: Path, *, dry_run: bool, label: str) -> str:
+        run_calls.append(cmd)
+        return ""
+
+    monkeypatch.setattr(publish_tools.git, "run", _fake_run)
+    tools = _publish_tools(tmp_path)
+    ctx = _ctx(tmp_path)
+
+    async def _run() -> PublishSnapshotResult:
+        return await tools["rrt_publish_snapshot"](
+            ctx, remote="mirror", branch="main", dry_run=False, confirm=True
+        )
+
+    result = asyncio.run(_run())
+    assert result.published is True
+    assert result.dry_run is False
+    assert any(cmd[:2] == ["git", "push"] for cmd in run_calls)
+
+
 def test_rrt_publish_snapshot_apply_success(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -890,7 +1218,7 @@ def test_rrt_publish_snapshot_apply_success(
 
     async def _run() -> PublishSnapshotResult:
         return await tools["rrt_publish_snapshot"](
-            ctx, remote="mirror", branch="main", message="snap", dry_run=False
+            ctx, remote="mirror", branch="main", message="snap", dry_run=False, confirm=True
         )
 
     result = asyncio.run(_run())
@@ -937,6 +1265,7 @@ def test_rrt_publish_snapshot_excludes_matching_paths(
             message="snap",
             exclude=["docs/superpowers/*"],
             dry_run=False,
+            confirm=True,
         )
 
     result = asyncio.run(_run())
@@ -973,7 +1302,7 @@ def test_rrt_publish_snapshot_apply_push_fails(
 
     async def _run() -> PublishSnapshotResult:
         return await tools["rrt_publish_snapshot"](
-            ctx, remote="mirror", branch="main", dry_run=False
+            ctx, remote="mirror", branch="main", dry_run=False, confirm=True
         )
 
     result = asyncio.run(_run())
@@ -1016,7 +1345,7 @@ def test_rrt_publish_snapshot_cleanup_failure_does_not_mask_push_failure(
 
     async def _run() -> PublishSnapshotResult:
         return await tools["rrt_publish_snapshot"](
-            ctx, remote="mirror", branch="main", dry_run=False
+            ctx, remote="mirror", branch="main", dry_run=False, confirm=True
         )
 
     result = asyncio.run(_run())
@@ -1057,7 +1386,7 @@ def test_rrt_publish_snapshot_cleanup_failure_after_success_still_published(
 
     async def _run() -> PublishSnapshotResult:
         return await tools["rrt_publish_snapshot"](
-            ctx, remote="mirror", branch="main", dry_run=False
+            ctx, remote="mirror", branch="main", dry_run=False, confirm=True
         )
 
     result = asyncio.run(_run())


### PR DESCRIPTION
## Summary

Phase 5 (Surface Unification) of the approved modernization plan — the brief's own "Risk: High" phase ("touches every surface at once"). Two independent worktree agents, integrated cleanly (4 commits, zero conflicts).

**D9/D4/D6 fixes — MCP now shares the CLI's pipeline (`mcp/tools/version_tools.py`, `mcp/tools/publish_tools.py`):**
- `rrt_bump` no longer independently loops version targets — it calls the exact same Phase-4 stage functions the CLI's `cmd_bump` uses (`resolve_bump_target` → `apply_bump_files` → `update_changelog` → `refresh_bump_lockfile`/`refresh_bump_generated_assets` → `finalize_bump_git`). Verified byte-identical output (branch name, staged files, commit message) between CLI and MCP on identical fixture repos.
- `rrt_publish_snapshot` gained a `confirm: bool = False` parameter — the destructive path now requires both `dry_run=False` **and** `confirm=True`, mirroring the CLI's two-signal `--yes-i-know-this-overwrites-remote-history` gate. Any other combination fails safe to a dry-run preview.
- The three D9/D4/D6 sentinel tests in `tests/e2e/test_mcp_parity_and_ordering.py` (built in Phase 1 specifically to be flipped once this landed) were updated to assert the fixed behavior; one new positive-case test added (72 e2e total, up from 71). No other e2e test touched.

**`workflow/hooks.py` parser-spec sharing (partial, honestly scoped):**
- **publish-snapshot** (the brief's named example) — extracted `_add_publish_snapshot_arguments(parser)` in `commands/git_sync.py`, now consumed by both the real CLI and `hooks.py`'s subparser. Deletes the copy-pasted duplicate spec; pylint R0801 hits 53→52.
- **drift-check** — replaced hand-built `argparse.Namespace(...)` synthesis with a real subparser + real parse (this exact bug class caused issue #140).
- **folder-check** — same parser-spec sharing pattern.
- **Deliberately deferred** (documented, not forced): the zero-arg hook aliases (config-validate, tag-check, etc. — not the target bug class), `artifacts-check` (inverted `--strict`/`--no-strict` polarity doesn't fit the extraction cleanly), and the `docs-*` family (nested sub-subparsers need real per-mode construction, a larger unit of work).

## Test plan

- [x] `uv run pytest -q -m "not runtime and not e2e"` — 2,961 passed, coverage 100.00%
- [x] `uv run pytest -m e2e --no-cov` — 72 passed (71 original + 1 new; D9/D4/D6 sentinels flipped, everything else byte-identical)
- [x] `uvx pre-commit run --all-files` — clean
- [x] Hook latency vs `analysis/the/P1_LATENCY_BASELINE.md` — 139/134/158 ms, all within the +10% budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjTsHn8U7Lmp9Uax8tNBHG