### PR TITLE
Phase 6c: require bearer-token auth for MCP HTTP transport (SEC-002)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - **action**: use env-var indirection for `verbose` and `changelog-file` Action inputs instead of interpolating them directly into shell script text (SEC-001)
 - **action**: correct the changelog-status grep so a populated `[Unreleased]` section is classified `dirty` instead of always falling through to `clean` (D8)
 - **action**: build the `health-summary` output with `jq -nc` instead of string interpolation, preventing a `"` in the detected version from corrupting the JSON output (SEC-006)
+- **mcp**: require a bearer token (`--auth-token` / `RRT_MCP_AUTH_TOKEN`) for the MCP server's `--transport http` mode, refusing to start an unauthenticated HTTP listener; `stdio` transport is unaffected (SEC-002)
 
 ## [1.11.2] - 2026-07-10
 ### Added

--- a/docs/src/content/docs/mcp-server.mdx
+++ b/docs/src/content/docs/mcp-server.mdx
@@ -64,9 +64,28 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`
 
 ### HTTP transport
 
+`--transport http` binds a real network listener — unlike `stdio`, anyone who
+can reach `--host`:`--port` could invoke every `rrt_*` tool, including
+destructive ones like `rrt_bump` and `rrt_publish_snapshot`. To prevent that,
+HTTP transport **requires a bearer token**: pass `--auth-token` or set
+`RRT_MCP_AUTH_TOKEN`. If neither is set, the server refuses to start rather
+than opening an unauthenticated port. `--host` still defaults to `127.0.0.1`
+(loopback-only) unless overridden.
+
 ```bash
+# Token via flag
+uv run rrt-mcp --transport http --port 8000 --auth-token "$(openssl rand -hex 32)"
+
+# Token via env var
+export RRT_MCP_AUTH_TOKEN="$(openssl rand -hex 32)"
 uv run rrt-mcp --transport http --port 8000
 ```
+
+Clients connect with the same token as a bearer credential, e.g. an
+`Authorization: Bearer <token>` header or FastMCP's `Client(url, auth=token)`.
+
+`stdio` transport (the default) is process-local and piped over stdin/stdout —
+no token is required or checked.
 
 ---
 

--- a/src/repo_release_tools/mcp/server.py
+++ b/src/repo_release_tools/mcp/server.py
@@ -1,7 +1,24 @@
-"""Main FastMCP server for rrt — exposes rrt capabilities as MCP tools, resources, and prompts."""
+"""Main FastMCP server for rrt — exposes rrt capabilities as MCP tools, resources, and prompts.
+
+HTTP transport authentication (SEC-002)
+----------------------------------------
+``stdio`` transport (the default) is process-local, piped over stdin/stdout, and
+needs no authentication. ``--transport http`` binds a real network listener —
+anyone who can reach ``--host``:``--port`` can invoke every ``rrt_*`` tool,
+including destructive ones like ``rrt_bump`` and ``rrt_publish_snapshot``.
+
+To prevent that, ``--transport http`` requires a bearer token, supplied via
+``--auth-token`` or the ``RRT_MCP_AUTH_TOKEN`` environment variable. The token
+is wired in via FastMCP's built-in ``StaticTokenVerifier``
+(``fastmcp.server.auth``); comparison happens inside FastMCP/starlette, not by
+hand-rolled string comparison here. If ``--transport http`` is selected and no
+token is configured, the server refuses to start rather than opening an
+unauthenticated port. ``--host`` still defaults to ``127.0.0.1``.
+"""
 
 from __future__ import annotations
 
+import os
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any, AsyncGenerator
@@ -10,11 +27,14 @@ from fastmcp import FastMCP
 
 from repo_release_tools import __version__
 from repo_release_tools.config import find_repo_root
+from repo_release_tools.ui import cli_error
 
 from .apps import register_apps
 from .prompts import register_prompts
 from .resources import register_resources
 from .tools import register_tools
+
+AUTH_TOKEN_ENV_VAR = "RRT_MCP_AUTH_TOKEN"
 
 
 def _find_repo_root() -> Path:
@@ -39,8 +59,23 @@ async def _lifespan(server: FastMCP[Any]) -> AsyncGenerator[dict[str, Any], None
     yield {"root": root, "config": config, "config_error": config_error}
 
 
-def create_server() -> FastMCP[Any]:
-    """Create and configure the rrt FastMCP server."""
+def _build_auth_provider(token: str) -> Any:
+    """Build a FastMCP token verifier for the given bearer token.
+
+    Uses FastMCP's built-in ``StaticTokenVerifier`` rather than hand-rolled
+    comparison — token matching happens inside FastMCP/starlette.
+    """
+    from fastmcp.server.auth import StaticTokenVerifier
+
+    return StaticTokenVerifier(tokens={token: {"client_id": "rrt-mcp-http"}})
+
+
+def create_server(*, auth_token: str | None = None) -> FastMCP[Any]:
+    """Create and configure the rrt FastMCP server.
+
+    ``auth_token``, when provided, wires a bearer-token verifier into the
+    server for the HTTP transport (see module docstring for SEC-002 context).
+    """
     mcp: FastMCP[Any] = FastMCP(
         name="repo-release-tools",
         instructions=(
@@ -52,6 +87,7 @@ def create_server() -> FastMCP[Any]:
         ),
         version=__version__,
         lifespan=_lifespan,
+        auth=_build_auth_provider(auth_token) if auth_token else None,
     )
 
     register_tools(mcp)
@@ -98,12 +134,31 @@ def main() -> None:
         default=8000,
         help="Port for HTTP transport (default: 8000)",
     )
+    parser.add_argument(
+        "--auth-token",
+        default=None,
+        help=(
+            "Bearer token required by HTTP transport clients "
+            f"(default: read from {AUTH_TOKEN_ENV_VAR}). Ignored for stdio transport."
+        ),
+    )
     args = parser.parse_args()
 
-    server = create_server()
     if args.transport == "http":
+        token = args.auth_token or os.environ.get(AUTH_TOKEN_ENV_VAR)
+        if not token:
+            sys.stderr.write(
+                cli_error(
+                    "refusing to start unauthenticated HTTP transport",
+                    hint=(f"set --auth-token or {AUTH_TOKEN_ENV_VAR}, or use --transport stdio"),
+                )
+                + "\n"
+            )
+            sys.exit(1)
+        server = create_server(auth_token=token)
         server.run(transport="http", host=args.host, port=args.port)
     else:
+        server = create_server()
         server.run(transport="stdio")
 
 

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -14,7 +14,14 @@ pytest.importorskip("fastmcp", reason="[mcp] extra not installed")
 
 from fastmcp import FastMCP
 
-from repo_release_tools.mcp.server import _find_repo_root, _lifespan, create_server, main
+from repo_release_tools.mcp.server import (
+    AUTH_TOKEN_ENV_VAR,
+    _build_auth_provider,
+    _find_repo_root,
+    _lifespan,
+    create_server,
+    main,
+)
 
 pytestmark = pytest.mark.mcp
 
@@ -154,8 +161,92 @@ def test_main_stdio(monkeypatch: Any) -> None:
 
 
 def test_main_http(monkeypatch: Any) -> None:
-    monkeypatch.setattr(sys, "argv", ["rrt-mcp", "--transport", "http", "--port", "9000"])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["rrt-mcp", "--transport", "http", "--port", "9000", "--auth-token", "s3cr3t"],
+    )
+    mock_server = MagicMock()
+    with patch(
+        "repo_release_tools.mcp.server.create_server", return_value=mock_server
+    ) as mock_create:
+        main()
+    mock_create.assert_called_once_with(auth_token="s3cr3t")
+    mock_server.run.assert_called_once_with(transport="http", host="127.0.0.1", port=9000)
+
+
+# ── HTTP transport authentication (SEC-002) ─────────────────────────────────
+
+
+def test_build_auth_provider_wires_token() -> None:
+    """_build_auth_provider returns a FastMCP StaticTokenVerifier for the token."""
+    from fastmcp.server.auth import StaticTokenVerifier
+
+    provider = _build_auth_provider("my-token")
+    assert isinstance(provider, StaticTokenVerifier)
+
+
+def test_create_server_no_auth_by_default() -> None:
+    """create_server() with no auth_token leaves the server unauthenticated (stdio use)."""
+    server = create_server()
+    assert server.auth is None
+
+
+def test_create_server_with_auth_token_wires_provider() -> None:
+    """create_server(auth_token=...) wires a StaticTokenVerifier into the FastMCP server."""
+    from fastmcp.server.auth import StaticTokenVerifier
+
+    server = create_server(auth_token="my-token")
+    assert isinstance(server.auth, StaticTokenVerifier)
+
+
+def test_main_stdio_ignores_auth_token_env(monkeypatch: Any) -> None:
+    """stdio transport starts normally even with no token configured (no regression)."""
+    monkeypatch.delenv(AUTH_TOKEN_ENV_VAR, raising=False)
+    monkeypatch.setattr(sys, "argv", ["rrt-mcp"])
+    mock_server = MagicMock()
+    with patch(
+        "repo_release_tools.mcp.server.create_server", return_value=mock_server
+    ) as mock_create:
+        main()
+    mock_create.assert_called_once_with()
+    mock_server.run.assert_called_once_with(transport="stdio")
+
+
+def test_main_http_no_token_refuses_to_start(monkeypatch: Any) -> None:
+    """http transport with no token (flag or env var) refuses to start."""
+    monkeypatch.delenv(AUTH_TOKEN_ENV_VAR, raising=False)
+    monkeypatch.setattr(sys, "argv", ["rrt-mcp", "--transport", "http"])
     mock_server = MagicMock()
     with patch("repo_release_tools.mcp.server.create_server", return_value=mock_server):
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+    assert exc_info.value.code == 1
+    mock_server.run.assert_not_called()
+
+
+def test_main_http_token_from_env_var(monkeypatch: Any) -> None:
+    """http transport reads the token from RRT_MCP_AUTH_TOKEN when --auth-token is absent."""
+    monkeypatch.setenv(AUTH_TOKEN_ENV_VAR, "env-token")
+    monkeypatch.setattr(sys, "argv", ["rrt-mcp", "--transport", "http"])
+    mock_server = MagicMock()
+    with patch(
+        "repo_release_tools.mcp.server.create_server", return_value=mock_server
+    ) as mock_create:
         main()
-    mock_server.run.assert_called_once_with(transport="http", host="127.0.0.1", port=9000)
+    mock_create.assert_called_once_with(auth_token="env-token")
+    mock_server.run.assert_called_once_with(transport="http", host="127.0.0.1", port=8000)
+
+
+def test_main_http_flag_overrides_env_var(monkeypatch: Any) -> None:
+    """--auth-token takes precedence over RRT_MCP_AUTH_TOKEN when both are set."""
+    monkeypatch.setenv(AUTH_TOKEN_ENV_VAR, "env-token")
+    monkeypatch.setattr(
+        sys, "argv", ["rrt-mcp", "--transport", "http", "--auth-token", "flag-token"]
+    )
+    mock_server = MagicMock()
+    with patch(
+        "repo_release_tools.mcp.server.create_server", return_value=mock_server
+    ) as mock_create:
+        main()
+    mock_create.assert_called_once_with(auth_token="flag-token")


### PR DESCRIPTION
Closes the one gap left after Phase 6b: `analysis/the/MODERNIZATION_BRIEF.md` listed SEC-002 (MCP HTTP transport auth) as landing with Phase 5, but it was never actually implemented — the `--transport http` option in `mcp/server.py` bound a real network listener with zero authentication. This was an open question (§7-Q6) that never got answered.

## What changed

`src/repo_release_tools/mcp/server.py`:
- Added `AUTH_TOKEN_ENV_VAR = "RRT_MCP_AUTH_TOKEN"` and a `_build_auth_provider(token)` helper wrapping FastMCP's own `StaticTokenVerifier` (`fastmcp.server.auth`) — token checking happens inside FastMCP/starlette, not hand-rolled.
- `create_server(*, auth_token: str | None = None)` wires `auth=` into `FastMCP(...)` only when a token is supplied.
- New `--auth-token` CLI flag. When `--transport http` is selected, the token resolves from `--auth-token` or `RRT_MCP_AUTH_TOKEN` (flag wins); if neither is set, the server refuses to start (`cli_error(...)`, exit 1) instead of opening an unauthenticated port.
- `stdio` transport (the default) is completely unaffected — no new required flags, no behavior change. `--host` stays at its `127.0.0.1` localhost-default.

Tests added in `tests/mcp/test_server.py` following the existing `pytest.importorskip("fastmcp")` convention: auth-provider wiring, stdio no-op, http fail-safe refusal without a token, token from flag vs. env var.

Docs: new "HTTP transport" section in `docs/src/content/docs/mcp-server.mdx`; `mcp/server.py`'s module docstring also documents the SEC-002 threat model.

## Test plan
- [x] `uv run pytest -q -m "not runtime and not e2e"` — 2992 passed, 100.00% coverage (fastmcp actually installed and exercised, not import-skipped — `mcp/server.py` shows 100% line coverage)
- [x] `uv run pytest -m e2e --no-cov -q` — 72/72 passed; confirmed `tests/e2e/test_mcp_parity_and_ordering.py` never exercises `--transport http` startup, so no update was needed there
- [x] `uvx pre-commit run --all-files` — clean
- [x] `uv run rrt drift check` — lockfile current

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjTsHn8U7Lmp9Uax8tNBHG