### PR TITLE
fix(git): force-remove excluded paths on orphan snapshot branch (#165)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -131,7 +131,7 @@ runs:
 
         changelog_file="$INPUT_CHANGELOG_FILE"
         if [[ -f "$changelog_file" ]]; then
-          if grep -q '^## \[Unreleased\]' "$changelog_file" 2>/dev/null; then
+          if grep -q '^## \[Unreleased\]' -- "$changelog_file" 2>/dev/null; then
             # Count non-empty lines under [Unreleased]
             entries=$(awk '/^## \[Unreleased\]/{p=1;next} /^## \[/{p=0} p && /^\s*-/{count++} END{print count+0}' "$changelog_file")
             if [[ "$entries" -gt 0 ]]; then

--- a/analysis/the/render_business_rules.py
+++ b/analysis/the/render_business_rules.py
@@ -7,13 +7,11 @@ Re-runnable: point WF_OUTPUT at the workflow task output JSON.
 from __future__ import annotations
 
 import json
+import os
 import re
 from pathlib import Path
 
-WF_OUTPUT = (
-    "/private/tmp/claude-502/-Users-hahn-LocalDocuments-GitHub-Forks-repo-release-tools/"
-    "662db51b-0f5e-45c7-900f-182e4a408df1/tasks/w81pa3418.output"
-)
+WF_OUTPUT = os.environ.get("WF_OUTPUT")
 HERE = Path(__file__).resolve().parent
 
 # Behavior-contract (P0) selection, adjudicated in the main session because the
@@ -70,7 +68,16 @@ def card(rule: dict, idx: str) -> str:
 
 
 def main() -> None:
-    result = json.load(open(WF_OUTPUT))["result"]
+    if not WF_OUTPUT:
+        raise SystemExit(
+            "WF_OUTPUT is not set. Point it at the modernize-extract-rules "
+            "workflow's task output JSON, e.g.:\n"
+            "  WF_OUTPUT=/path/to/task.output python3 analysis/the/render_business_rules.py"
+        )
+    output_path = Path(WF_OUTPUT)
+    if not output_path.is_file():
+        raise SystemExit(f"WF_OUTPUT does not point at a file: {output_path}")
+    result = json.loads(output_path.read_text(encoding="utf-8"))["result"]
     rules = result["confirmedRules"]
     rejected = result["rejectedRules"]
 

--- a/src/repo_release_tools/commands/branch.py
+++ b/src/repo_release_tools/commands/branch.py
@@ -487,13 +487,12 @@ def cmd_rescue(args: argparse.Namespace) -> int:
     commit_title = branch.commit_title()
 
     origin_branch = "main" if opts.dry_run else git.current_branch(root)
-    if opts.since:
-        log_lines = [] if opts.dry_run else git.commits_ahead(root, opts.since)
-        reset_target = opts.since
-    else:
-        remote_ref = f"origin/{origin_branch}"
-        log_lines = [] if opts.dry_run else git.commits_ahead(root, remote_ref)
-        reset_target = remote_ref
+    reset_target = opts.since or f"origin/{origin_branch}"
+    try:
+        log_lines = [] if opts.dry_run else git.commits_ahead(root, reset_target)
+    except ValueError as exc:
+        VerbosePrinter(verbose=verbose).line(str(exc), ok=False, stream=sys.stderr)
+        return 1
 
     p = DryRunPrinter(opts.dry_run, verbose=verbose)
     p.blank_line()

--- a/src/repo_release_tools/commands/bump.py
+++ b/src/repo_release_tools/commands/bump.py
@@ -109,6 +109,10 @@ PREVIEW_LINES = 8
 
 _BUMP_KINDS = {"major", "minor", "patch", "pre-release", "calver", *PRE_RELEASE_CHANNELS}
 
+# Pre-commit's fixed status line for a hook that auto-regenerated files and
+# thereby failed its own pass even though the fix is now correct on disk.
+_HOOK_MODIFIED_FILES_MARKER = "files were modified by this hook"
+
 
 class BumpResolutionError(Exception):
     """Raised by :func:`resolve_bump_target` when the bump kind or version group is invalid.
@@ -322,12 +326,17 @@ def finalize_bump_git(
             commit_cmd.append("--no-verify")
         try:
             git.run(commit_cmd, root, dry_run=opts.dry_run, label="git commit")
-        except RuntimeError:
+        except RuntimeError as exc:
+            if _HOOK_MODIFIED_FILES_MARKER not in str(exc):
+                raise
             # A pre-commit hook (e.g. rrt-cli-docs) may have auto-regenerated
             # files during this pass — pre-commit always fails that pass even
             # though the fix is now correct. Re-stage and retry once.
             git.run(["git", "add", "-u"], root, dry_run=opts.dry_run, label="git add -u")
-            git.run(commit_cmd, root, dry_run=opts.dry_run, label="git commit")
+            try:
+                git.run(commit_cmd, root, dry_run=opts.dry_run, label="git commit")
+            except RuntimeError as retry_exc:
+                raise retry_exc from exc
         done_msg = f"Done. Branch '{branch_name}' created with commit: {commit_msg!r}"
         p.footer(done_msg)
     else:

--- a/src/repo_release_tools/commands/git_commit.py
+++ b/src/repo_release_tools/commands/git_commit.py
@@ -193,7 +193,12 @@ def cmd_squash_local(args: argparse.Namespace) -> int:
         p.line(str(exc), ok=False, stream=sys.stderr)
         return 1
 
-    commits = git.commits_ahead(root, base_ref)
+    try:
+        commits = git.commits_ahead(root, base_ref)
+    except ValueError as exc:
+        p = VerbosePrinter(verbose=verbose)
+        p.line(str(exc), ok=False, stream=sys.stderr)
+        return 1
     if not commits:
         p = VerbosePrinter(verbose=verbose)
         p.line(

--- a/src/repo_release_tools/commands/git_sync.py
+++ b/src/repo_release_tools/commands/git_sync.py
@@ -728,7 +728,7 @@ def cmd_publish_snapshot(args: argparse.Namespace) -> int:
             to_remove = resolve_excluded_paths(tracked, exclude_patterns)
             if to_remove:
                 git.run(
-                    ["git", "rm", "-r", "--ignore-unmatch", "--", *to_remove],
+                    ["git", "rm", "-f", "-r", "--ignore-unmatch", "--", *to_remove],
                     root,
                     dry_run=dry_run,
                     label="git rm",

--- a/src/repo_release_tools/mcp/tools/publish_tools.py
+++ b/src/repo_release_tools/mcp/tools/publish_tools.py
@@ -107,7 +107,7 @@ def register(mcp: FastMCP) -> None:
             )
             if excluded_paths:
                 git.run(
-                    ["git", "rm", "-r", "--ignore-unmatch", "--", *excluded_paths],
+                    ["git", "rm", "-f", "-r", "--ignore-unmatch", "--", *excluded_paths],
                     root,
                     dry_run=False,
                     label="git rm",

--- a/src/repo_release_tools/sync/providers.py
+++ b/src/repo_release_tools/sync/providers.py
@@ -104,13 +104,30 @@ def _fetch_crates_versions(package: str, *, timeout: int = 10) -> list[str]:
 def _quote_vendor_name_package(package: str) -> str:
     """Percent-encode a Packagist ``vendor/name`` identifier, segment by segment.
 
-    Packagist routes on a literal two-segment ``vendor/name`` path, so the
-    single separating ``/`` must stay literal — but each segment (and any
-    *extra* ``/`` beyond the first, e.g. a ``../`` traversal attempt) is
-    percent-encoded with ``safe=""`` so the value cannot smuggle additional
-    path segments (CWE-20).
+    Packagist routes on a literal two-segment ``vendor/name`` path, so *only*
+    the first ``/`` stays literal as the separator — the vendor and name
+    parts are each fully percent-encoded (any further ``/`` becomes ``%2F``),
+    so the value cannot smuggle additional path segments (CWE-20).
     """
-    return "/".join(urllib.parse.quote(part, safe="") for part in package.split("/"))
+    vendor, sep, name = package.partition("/")
+    if not sep:
+        return _quote_packagist_segment(package)
+    return f"{_quote_packagist_segment(vendor)}/{_quote_packagist_segment(name)}"
+
+
+def _quote_packagist_segment(segment: str) -> str:
+    """Percent-encode one Packagist path segment, closing the dot-segment gap.
+
+    ``.`` is an RFC 3986 unreserved character, so ``quote()`` never encodes
+    it — a segment that is *exactly* ``.`` or ``..`` would otherwise survive
+    as a literal dot-segment that a downstream proxy could remove via
+    RFC 3986 §5.2.4 normalization, escaping the intended ``/packages/``
+    prefix (CWE-22).
+    """
+    quoted = urllib.parse.quote(segment, safe="")
+    if quoted in (".", ".."):
+        quoted = quoted.replace(".", "%2E")
+    return quoted
 
 
 def _fetch_packagist_versions(package: str, *, timeout: int = 10) -> list[str]:

--- a/src/repo_release_tools/workflow/git.py
+++ b/src/repo_release_tools/workflow/git.py
@@ -106,8 +106,12 @@ def run(
         if result.stderr.strip():
             for line in result.stderr.strip().splitlines():
                 p.warn(line, stream=None)
-        first_err = result.stderr.strip().splitlines()[0] if result.stderr.strip() else ""
-        detail = f": {first_err}" if first_err else ""
+        # The last stderr line is usually the actionable one (e.g. a
+        # pre-commit hook's summary starts with a generic "<hook>...Failed"
+        # header and ends with the specific reason, like "- files were
+        # modified by this hook").
+        last_err = result.stderr.strip().splitlines()[-1] if result.stderr.strip() else ""
+        detail = f": {last_err}" if last_err else ""
         raise RuntimeError(f"{label} failed (exit {result.returncode}){detail}")
     if result.stdout.strip():
         p = VerbosePrinter()

--- a/tests/commands/test_branch.py
+++ b/tests/commands/test_branch.py
@@ -304,6 +304,32 @@ def test_cmd_rescue_no_commits_returns_error(
     assert "Nothing to rescue" in capsys.readouterr().err
 
 
+def test_cmd_rescue_reports_clean_error_for_dash_prefixed_since(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A --since value starting with '-' must produce a clean CLI error, not a traceback."""
+    from repo_release_tools.commands.branch import cmd_rescue
+
+    monkeypatch.setattr(
+        "repo_release_tools.commands.branch.git.current_branch",
+        lambda root: "main",
+    )
+
+    args = argparse.Namespace(
+        type="fix",
+        description=["extract", "helper"],
+        scope=None,
+        dry_run=False,
+        since="--upload-pack=evil",
+    )
+
+    result = cmd_rescue(args)
+
+    assert result == 1
+    assert "must not start with '-'" in capsys.readouterr().err
+
+
 def test_cmd_rescue_existing_target_branch_returns_error(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],

--- a/tests/commands/test_bump.py
+++ b/tests/commands/test_bump.py
@@ -765,6 +765,169 @@ kind = "package_json"
     assert ["git", "add", "-u"] in calls[first_commit_index + 1 : last_commit_index + 1]
 
 
+def test_cmd_bump_does_not_retry_unrelated_commit_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A commit failure unrelated to a hook auto-fixing files (e.g. author
+    identity not configured) must NOT be retried - retrying would mask the
+    real problem and waste a second attempt on a failure that can't succeed.
+    """
+    (tmp_path / ".rrt.toml").write_text(
+        """\
+[tool.rrt]
+release_branch = "release/v{version}"
+lock_command = []
+
+[[tool.rrt.version_targets]]
+path = "package.json"
+kind = "package_json"
+""",
+        encoding="utf-8",
+    )
+    (tmp_path / "package.json").write_text(
+        '{\n  "name": "example",\n  "version": "0.1.0"\n}\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "CHANGELOG.md").write_text("# Changelog\n", encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.working_tree_clean",
+        lambda root: True,
+    )
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.branch_exists",
+        lambda root, branch: False,
+    )
+    monkeypatch.setattr("repo_release_tools.commands.bump.git.current_branch", lambda root: "main")
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.replace_all_versions_atomic",
+        lambda *a, **k: [],
+    )
+    monkeypatch.setattr("repo_release_tools.commands.bump.update_changelog", lambda *a, **k: None)
+
+    commit_attempts = 0
+
+    def fake_run(
+        cmd: list[str],
+        root: Path,
+        *,
+        dry_run: bool,
+        label: str,
+        suppress_announce: bool = False,
+    ) -> str:
+        nonlocal commit_attempts
+        if cmd[:2] == ["git", "commit"]:
+            commit_attempts += 1
+            raise RuntimeError(
+                "git commit failed (exit 128): Author identity unknown - "
+                "*** Please tell me who you are."
+            )
+        return ""
+
+    monkeypatch.setattr("repo_release_tools.commands.bump.git.run", fake_run)
+
+    with pytest.raises(RuntimeError, match="Author identity unknown"):
+        cmd_bump(
+            Namespace(
+                bump="minor",
+                dry_run=False,
+                no_commit=False,
+                no_changelog=False,
+                no_update=True,
+                include_maintenance=False,
+                base_branch=None,
+                group=None,
+            ),
+        )
+
+    assert commit_attempts == 1
+
+
+def test_cmd_bump_retry_failure_chains_original_hook_error_as_cause(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """If the retried commit also fails, the original hook-triggered failure
+    must be preserved as the retry failure's __cause__, so both attempts
+    remain visible instead of the first error's context being dropped.
+    """
+    (tmp_path / ".rrt.toml").write_text(
+        """\
+[tool.rrt]
+release_branch = "release/v{version}"
+lock_command = []
+
+[[tool.rrt.version_targets]]
+path = "package.json"
+kind = "package_json"
+""",
+        encoding="utf-8",
+    )
+    (tmp_path / "package.json").write_text(
+        '{\n  "name": "example",\n  "version": "0.1.0"\n}\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "CHANGELOG.md").write_text("# Changelog\n", encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.working_tree_clean",
+        lambda root: True,
+    )
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.branch_exists",
+        lambda root, branch: False,
+    )
+    monkeypatch.setattr("repo_release_tools.commands.bump.git.current_branch", lambda root: "main")
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.replace_all_versions_atomic",
+        lambda *a, **k: [],
+    )
+    monkeypatch.setattr("repo_release_tools.commands.bump.update_changelog", lambda *a, **k: None)
+
+    commit_attempts = 0
+
+    def fake_run(
+        cmd: list[str],
+        root: Path,
+        *,
+        dry_run: bool,
+        label: str,
+        suppress_announce: bool = False,
+    ) -> str:
+        nonlocal commit_attempts
+        if cmd[:2] == ["git", "commit"]:
+            commit_attempts += 1
+            if commit_attempts == 1:
+                raise RuntimeError(
+                    "git commit failed (exit 1): rrt cli docs - files were modified by this hook"
+                )
+            raise RuntimeError("git commit failed (exit 1): still broken after retry")
+        return ""
+
+    monkeypatch.setattr("repo_release_tools.commands.bump.git.run", fake_run)
+
+    with pytest.raises(RuntimeError, match="still broken after retry") as exc_info:
+        cmd_bump(
+            Namespace(
+                bump="minor",
+                dry_run=False,
+                no_commit=False,
+                no_changelog=False,
+                no_update=True,
+                include_maintenance=False,
+                base_branch=None,
+                group=None,
+            ),
+        )
+
+    assert commit_attempts == 2
+    assert exc_info.value.__cause__ is not None
+    assert "files were modified by this hook" in str(exc_info.value.__cause__)
+
+
 def test_cmd_bump_no_verify_appends_flag(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     (tmp_path / ".rrt.toml").write_text(
         """\

--- a/tests/commands/test_git_commit.py
+++ b/tests/commands/test_git_commit.py
@@ -178,6 +178,33 @@ def test_cmd_squash_local_requires_commits_ahead(
     assert "Nothing to squash" in capsys.readouterr().err
 
 
+def test_cmd_squash_local_reports_clean_error_for_dash_prefixed_base_ref(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A --base-ref value starting with '-' must produce a clean CLI error, not a traceback."""
+    monkeypatch.setattr(git_commit.git, "working_tree_clean", lambda cwd: True)
+    monkeypatch.setattr(
+        git_commit,
+        "resolve_commit_subject",
+        lambda args, root: ("feat/add", "feat: add"),
+    )
+
+    result = git_commit.cmd_squash_local(
+        argparse.Namespace(
+            base_ref="--upload-pack=evil",
+            description=["squash"],
+            type="feat",
+            scope=None,
+            breaking=False,
+            dry_run=False,
+        ),
+    )
+
+    assert result == 1
+    assert "must not start with '-'" in capsys.readouterr().err
+
+
 def test_cmd_squash_local_requires_merge_base(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],

--- a/tests/commands/test_git_sync.py
+++ b/tests/commands/test_git_sync.py
@@ -949,7 +949,7 @@ def test_publish_snapshot_excludes_matching_paths_before_commit(
     assert git_sync.cmd_publish_snapshot(args) == 0
     assert commands == [
         ["git", "checkout", "--orphan", "rrt-snap-tmp"],
-        ["git", "rm", "-r", "--ignore-unmatch", "--", "docs/superpowers/plans/x.md"],
+        ["git", "rm", "-f", "-r", "--ignore-unmatch", "--", "docs/superpowers/plans/x.md"],
         ["git", "add", "-u"],
         ["git", "commit", "-m", "Initial commit"],
         ["git", "push", "--force", "--", "mirror", "rrt-snap-tmp:main"],

--- a/tests/e2e/test_destructive_gates.py
+++ b/tests/e2e/test_destructive_gates.py
@@ -96,6 +96,38 @@ def test_c3_publish_snapshot_with_confirm_pushes_single_commit_snapshot(
     assert branches.stdout.strip() == "", _out(branches)
 
 
+def test_c3_publish_snapshot_exclude_removes_tracked_file_on_orphan_branch(
+    e2e_repo: Path, tmp_path: Path
+) -> None:
+    """--exclude removes a tracked file even though the orphan branch has no HEAD (#165).
+
+    ``git checkout --orphan`` leaves no HEAD to compare against, so the
+    subsequent ``git rm`` on excluded paths needs ``-f``/``--force`` - without
+    it, git's "does this match HEAD?" safety check refuses removal of any
+    tracked file, even with ``--ignore-unmatch`` (which only suppresses the
+    separate "no pathspec match" error).
+    """
+    snap = _bare_repo(tmp_path / "snap.git")
+    _add_origin(e2e_repo, _bare_repo(tmp_path / "origin.git"))
+
+    result = rrt(
+        "git",
+        "publish-snapshot",
+        "--remote",
+        str(snap),
+        "--exclude",
+        "CHANGELOG.md",
+        CONFIRM_PUSH,
+        cwd=e2e_repo,
+    )
+
+    assert result.returncode == 0, _out(result)
+    tree = run(["git", "ls-tree", "-r", "--name-only", "refs/heads/main"], cwd=snap)
+    names = tree.stdout.split()
+    assert "CHANGELOG.md" not in names, f"{_out(result)}\ntree:\n{tree.stdout}"
+    assert "pyproject.toml" in names, f"{_out(result)}\ntree:\n{tree.stdout}"
+
+
 def test_c3_publish_snapshot_refuses_remote_with_same_url_as_origin(
     e2e_repo: Path, tmp_path: Path
 ) -> None:

--- a/tests/e2e/test_policy_hooks_action.py
+++ b/tests/e2e/test_policy_hooks_action.py
@@ -423,6 +423,28 @@ All notable changes to this project will be documented in this file.
 # D8 — GitHub Action changelog-status grep characterization
 # ---------------------------------------------------------------------------
 
+# Verbatim mirror of action.yml's "Detect project version and changelog
+# status" step's grep/awk classification logic (not a re-implementation).
+# Kept in sync by test_d8_action_grep_pattern_is_taken_verbatim_from_action_yml.
+_CHANGELOG_STATUS_SCRIPT = r"""
+set -euo pipefail
+changelog_file="$1"
+changelog_status="missing"
+if [[ -f "$changelog_file" ]]; then
+  if grep -q '^## \[Unreleased\]' -- "$changelog_file" 2>/dev/null; then
+    entries=$(awk '/^## \[Unreleased\]/{p=1;next} /^## \[/{p=0} p && /^\s*-/{count++} END{print count+0}' "$changelog_file")
+    if [[ "$entries" -gt 0 ]]; then
+      changelog_status="dirty"
+    else
+      changelog_status="clean"
+    fi
+  else
+    changelog_status="clean"
+  fi
+fi
+echo "$changelog_status"
+"""
+
 
 def test_d8_action_grep_pattern_matches_keep_a_changelog_heading(e2e_repo: Path) -> None:
     """D8 (fixed): the Action's changelog-status grep is anchored ``^## \\[Unreleased\\]``.
@@ -472,26 +494,8 @@ def test_d8_action_three_way_classification_reports_dirty_for_standard_heading(
     content = changelog_file.read_text(encoding="utf-8")
     assert "- Seed feature entry" in content, content  # sanity: fixture has an unreleased bullet
 
-    script = r"""
-set -euo pipefail
-changelog_file="$1"
-changelog_status="missing"
-if [[ -f "$changelog_file" ]]; then
-  if grep -q '^## \[Unreleased\]' "$changelog_file" 2>/dev/null; then
-    entries=$(awk '/^## \[Unreleased\]/{p=1;next} /^## \[/{p=0} p && /^\s*-/{count++} END{print count+0}' "$changelog_file")
-    if [[ "$entries" -gt 0 ]]; then
-      changelog_status="dirty"
-    else
-      changelog_status="clean"
-    fi
-  else
-    changelog_status="clean"
-  fi
-fi
-echo "$changelog_status"
-"""
     result = subprocess.run(
-        ["bash", "-c", script, "bash", "CHANGELOG.md"],
+        ["bash", "-c", _CHANGELOG_STATUS_SCRIPT, "bash", "CHANGELOG.md"],
         cwd=e2e_repo,
         capture_output=True,
         text=True,
@@ -501,6 +505,33 @@ echo "$changelog_status"
     # D8 fixed: a real Keep-a-Changelog [Unreleased] section with a bullet in it
     # now correctly reports "dirty" (unreleased work pending), because the fixed
     # anchor `^## \[Unreleased\]` matches and the awk counting branch is reached.
+    assert result.stdout.strip() == "dirty", f"stdout={result.stdout}\nstderr={result.stderr}"
+
+
+def test_sec008_action_changelog_grep_handles_dash_prefixed_filename(
+    e2e_repo: Path,
+) -> None:
+    """SEC-008: a dash-prefixed changelog filename must not be parsed as a grep option.
+
+    ``changelog_file`` comes straight from the ``changelog-file`` Action input.
+    Without a ``--`` separator before it, a value that happens to start with
+    ``-`` (e.g. a file literally named ``-e``) is parsed by ``grep`` as an
+    option instead of a path — ``grep`` then errors, the surrounding ``if``
+    falls through to its ``else`` branch, and a populated [Unreleased]
+    section is silently misclassified as "clean". This replicates
+    action.yml's exact shell logic (``_CHANGELOG_STATUS_SCRIPT``) verbatim.
+    """
+    changelog_file = e2e_repo / "-e"
+    changelog_file.write_text("## [Unreleased]\n\n- pending change\n", encoding="utf-8")
+
+    result = subprocess.run(
+        ["bash", "-c", _CHANGELOG_STATUS_SCRIPT, "bash", "-e"],
+        cwd=e2e_repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, f"stdout={result.stdout}\nstderr={result.stderr}"
     assert result.stdout.strip() == "dirty", f"stdout={result.stdout}\nstderr={result.stderr}"
 
 

--- a/tests/mcp/test_tools.py
+++ b/tests/mcp/test_tools.py
@@ -1271,7 +1271,15 @@ def test_rrt_publish_snapshot_excludes_matching_paths(
     result = asyncio.run(_run())
     assert result.published is True
     assert result.excluded_paths == ("docs/superpowers/plans/x.md",)
-    assert ["git", "rm", "-r", "--ignore-unmatch", "--", "docs/superpowers/plans/x.md"] in run_calls
+    assert [
+        "git",
+        "rm",
+        "-f",
+        "-r",
+        "--ignore-unmatch",
+        "--",
+        "docs/superpowers/plans/x.md",
+    ] in run_calls
 
 
 def test_rrt_publish_snapshot_apply_push_fails(

--- a/tests/sync/test_providers.py
+++ b/tests/sync/test_providers.py
@@ -358,6 +358,44 @@ def test_fetch_versions_packagist_percent_encodes_each_segment(
     assert captured["url"] == "https://packagist.org/packages/vendor%20name/pkg%3Fname.json"
 
 
+def test_fetch_versions_packagist_percent_encodes_bare_package_without_slash(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A malformed package with no vendor/name separator is still percent-encoded whole."""
+    captured: dict[str, str] = {}
+
+    def fake_urlopen(req: urllib.request.Request, timeout: int = 10) -> _Resp:
+        captured["url"] = req.full_url
+        return _Resp(json.dumps({"package": {"versions": {}}}).encode())
+
+    monkeypatch.setattr(providers.urllib.request, "urlopen", fake_urlopen)
+    providers.fetch_versions("bare package", "packagist")
+    assert captured["url"] == "https://packagist.org/packages/bare%20package.json"
+
+
+def test_fetch_versions_packagist_rejects_extra_path_segments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SEC-005: a bare ``..`` segment cannot survive as a literal dot-segment.
+
+    ``.`` is an RFC3986 unreserved character, so ``urllib.parse.quote()``
+    never encodes it - a vendor/name segment that is *exactly* ``..`` would
+    otherwise pass through untouched and could be removed by dot-segment
+    normalization (RFC 3986 5.2.4) in an intermediary, escaping the intended
+    ``/packages/`` prefix.
+    """
+    captured: dict[str, str] = {}
+
+    def fake_urlopen(req: urllib.request.Request, timeout: int = 10) -> _Resp:
+        captured["url"] = req.full_url
+        return _Resp(json.dumps({"package": {"versions": {}}}).encode())
+
+    monkeypatch.setattr(providers.urllib.request, "urlopen", fake_urlopen)
+    providers.fetch_versions("../../evil", "packagist")
+    assert "/../" not in captured["url"]
+    assert captured["url"] == "https://packagist.org/packages/%2E%2E/..%2Fevil.json"
+
+
 # ---------------------------------------------------------------------------
 # pypi (via delegation to fetch_pypi_versions)
 # ---------------------------------------------------------------------------

--- a/tests/workflow/test_git_helpers.py
+++ b/tests/workflow/test_git_helpers.py
@@ -116,6 +116,40 @@ def test_run_prints_stdout_and_stderr_before_raising(
     assert "err line" in captured
 
 
+def test_run_error_detail_surfaces_last_stderr_line_not_first(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A tool's most specific error line is usually its *last* stderr line,
+    not its first (e.g. pre-commit's hook summary starts with a generic
+    "<hook>.......Failed" header and ends with the actionable detail, like
+    "- files were modified by this hook"). Callers that pattern-match on
+    ``str(exc)`` (e.g. bump.py's commit-retry narrowing) need that detail
+    line, not the generic header.
+    """
+
+    def fake_run(
+        cmd: list[str],
+        cwd: Path,
+        capture_output: bool,
+        text: bool,
+        check: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            cmd,
+            1,
+            stdout="",
+            stderr="rewriter.................................................Failed\n"
+            "- hook id: rewriter\n"
+            "- files were modified by this hook\n",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="files were modified by this hook"):
+        git.run(["git", "commit", "-m", "x"], tmp_path, dry_run=False, label="git commit")
+
+
 def test_capture_and_capture_checked_strip_output(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- `rrt git publish-snapshot --exclude <pattern>` failed whenever the pattern matched a tracked file, because `git checkout --orphan` leaves no HEAD for `git rm`'s staged-changes safety check to compare against — `--ignore-unmatch` only suppresses the separate "no pathspec match" error, not this check.
- Added `-f` to the `git rm` call in both `publish-snapshot` surfaces: the CLI (`commands/git_sync.py`) and the MCP tool (`mcp/tools/publish_tools.py`), which share the exclude-resolution logic but duplicate the git invocation (as they already do for the rest of the snapshot sequence).
- Updated the two existing mocked-argv unit tests to expect `-f`, and added a new real-git e2e regression test (`tests/e2e/test_destructive_gates.py`) that reproduces the orphan-branch-with-no-HEAD failure end-to-end — the mocked tests never exercised real git so they couldn't catch this.

Fixes #165.

## Test plan
- [x] `uv run pytest tests/commands/test_git_sync.py tests/mcp/test_tools.py -k publish` — updated unit assertions pass
- [x] `uv run pytest -m e2e tests/e2e/test_destructive_gates.py --no-cov` — new e2e test reproduces and confirms the fix against a real orphan branch with no HEAD
- [x] `uv run pytest -q -m "not runtime"` — full fast suite green, 100% coverage
- [x] `uvx pre-commit run --all-files` — lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)