### PR TITLE
feat(release): warn on pin_target version drift in release check

### DIFF
--- a/docs/src/content/docs/commands/version-release.mdx
+++ b/docs/src/content/docs/commands/version-release.mdx
@@ -516,6 +516,7 @@ For each resolved version group, the command checks:
 - version target values can be read
 - pin target patterns compile as regular expressions
 - pin target files contain at least one match
+- pin target captured versions match the group's canonical version
 - the group changelog file exists
 
 It also checks any global pin targets, deduplicating repeated path/pattern
@@ -529,6 +530,8 @@ the end.
 - missing targets and missing changelog files are errors
 - unreadable version content is reported as a warning
 - pin patterns that compile but do not match are reported as a warning
+- pin patterns that match but capture a stale version (drift from the
+  group's canonical version) are reported as a warning
 - valid matches and readable targets are reported as OK
 
 ### Config discovery behavior
@@ -587,6 +590,13 @@ Error: pin target pattern has no matches in 'docs/conf.py'
 ```
 → The pattern compiles but matches nothing. Check the regex, or set
 `pin_target_missing = "warn"` to downgrade to a warning during migration.
+
+```
+Warning: docs/README.md drift: pin has '0.15.17', expected '0.15.18'
+```
+→ The pin pattern matched, but the captured version is stale — the file
+was not updated on the last release. Run `rrt bump` to refresh pin targets,
+or check for a release step that skipped this file.
 
 ```
 Error: changelog file 'CHANGELOG.md' not found

--- a/src/repo_release_tools/commands/release_cmd.py
+++ b/src/repo_release_tools/commands/release_cmd.py
@@ -14,6 +14,7 @@ For each resolved version group, the command checks:
 - version target values can be read
 - pin target patterns compile as regular expressions
 - pin target files contain at least one match
+- pin target captured versions match the group's canonical version
 - the group changelog file exists
 
 It also checks any global pin targets, deduplicating repeated path/pattern
@@ -27,6 +28,8 @@ the end.
 - missing targets and missing changelog files are errors
 - unreadable version content is reported as a warning
 - pin patterns that compile but do not match are reported as a warning
+- pin patterns that match but capture a stale version (drift from the
+  group's canonical version) are reported as a warning
 - valid matches and readable targets are reported as OK
 
 ## Config discovery behavior
@@ -118,6 +121,13 @@ Error: pin target pattern has no matches in 'docs/conf.py'
 `pin_target_missing = "warn"` to downgrade to a warning during migration.
 
 ```
+Warning: docs/README.md drift: pin has '0.15.17', expected '0.15.18'
+```
+→ The pin pattern matched, but the captured version is stale — the file
+was not updated on the last release. Run `rrt bump` to refresh pin targets,
+or check for a release step that skipped this file.
+
+```
 Error: changelog file 'CHANGELOG.md' not found
 ```
 → First-release setup: the changelog file doesn't exist yet. Create it
@@ -153,8 +163,18 @@ def _check_version_target(target: VersionTarget, root: Path) -> tuple[str, bool,
         return f"{relative}{suffix} version unreadable", True, "warning"
 
 
-def _check_pin_target(pin: PinTarget, root: Path) -> tuple[str, bool, str]:
-    """Return the status message, whether it is okay, and its severity."""
+def _check_pin_target(
+    pin: PinTarget,
+    root: Path,
+    expected_version: str | None,
+) -> tuple[str, bool, str]:
+    """Return the status message, whether it is okay, and its severity.
+
+    *expected_version* is the group's canonical current version (``None``
+    when it could not be read). When the pin's captured version group
+    differs from it, this is reported as a non-blocking "drift" warning —
+    the pattern still matched, but the file is stale.
+    """
     relative = str(pin.path.relative_to(root))
 
     if not pin.path.exists():
@@ -166,8 +186,18 @@ def _check_pin_target(pin: PinTarget, root: Path) -> tuple[str, bool, str]:
         return f"{relative} bad pattern: {exc}", False, "error"
 
     text = pin.path.read_text(encoding="utf-8")
-    if compiled.search(text) is None:
+    match = compiled.search(text)
+    if match is None:
         return f"{relative} no match", True, "warning"
+
+    if expected_version is not None:
+        current = match.group(2)
+        if current != expected_version:
+            return (
+                f"{relative} drift: pin has {current!r}, expected {expected_version!r}",
+                True,
+                "warning",
+            )
 
     return f"{relative} match", True, "ok"
 
@@ -220,6 +250,11 @@ def _check_release_group(
 
     all_pins = group.pin_targets + config.global_pin_targets
     if all_pins:
+        try:
+            expected_version = read_version_string(group.primary_target())
+        except (RuntimeError, ValueError):
+            expected_version = None
+
         seen: set[tuple[object, str]] = set()
         unique_pins = []
         for pin in all_pins:
@@ -229,7 +264,7 @@ def _check_release_group(
                 unique_pins.append(pin)
 
         for pin in unique_pins:
-            message, ok, severity = _check_pin_target(pin, root)
+            message, ok, severity = _check_pin_target(pin, root, expected_version)
             statuses.append((message, severity))
             if not ok:
                 group_ok = False

--- a/src/repo_release_tools/config/model.py
+++ b/src/repo_release_tools/config/model.py
@@ -181,7 +181,8 @@ GENERIC_TOOL_RRT_EXAMPLE = dedent(
     # Replace this starter target with the file that owns your version string.
     [[tool.rrt.version_targets]]
     path = "path/to/version-file"
-    pattern = '^(const Version = ")([^"]+)(")$'
+    kind = "pattern"
+    pattern = '^VERSION = "([^"]+)"$'
     """,
 ).strip()
 
@@ -275,10 +276,14 @@ class VersionTarget:
 class PinTarget:
     r"""A single doc/CI pin target updated by 'rrt bump'.
 
-    Unlike ``VersionTarget``, ``PinTarget`` is write-only and does not
-    participate in version consistency checks.  Use it to keep version pins
-    in documentation and CI configs (e.g. ``@v1.2.3`` or ``rev: v1.2.3``)
-    in sync with every release.
+    Unlike ``VersionTarget``, ``PinTarget`` is write-only — ``rrt bump``
+    always overwrites it unconditionally rather than reading it first. Use
+    it to keep version pins in documentation and CI configs (e.g.
+    ``@v1.2.3`` or ``rev: v1.2.3``) in sync with every release.
+    ``rrt release check`` does read pin targets, non-destructively: it
+    warns (without failing) when a pin's captured version has drifted from
+    the group's canonical version, so stale pins are visible before they
+    accumulate.
 
     The ``pattern`` must follow the 3-group convention used by
     ``VersionTarget`` custom patterns:

--- a/tests/commands/test_release_cmd.py
+++ b/tests/commands/test_release_cmd.py
@@ -291,6 +291,81 @@ def test_release_check_pin_no_match_warns_not_errors(
     assert "no match" in capsys.readouterr().out
 
 
+def test_release_check_pin_matches_canonical_version(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Pin whose captured version equals the group's canonical version reports match."""
+    monkeypatch.chdir(tmp_path)
+    pin_file = tmp_path / "docs" / "page.md"
+    pin_file.parent.mkdir(parents=True)
+    pin_file.write_text("uses: Anselmoo/repo-release-tools@v1.2.3\n", encoding="utf-8")
+    pin = PinTarget(path=pin_file, pattern=_VALID_PIN_PATTERN)
+    conf = _make_config(tmp_path, pin_targets=[pin])
+    _write_version_file(conf.version_groups[0].version_targets[0].path)
+    (tmp_path / "CHANGELOG.md").write_text("# Changelog\n", encoding="utf-8")
+    monkeypatch.setattr(release_cmd, "load_or_autodetect_config", lambda _: conf)
+
+    rc = release_cmd.cmd_release_check(_ARGS)
+
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "drift" not in out
+    assert "docs/page.md match" in out
+
+
+def test_release_check_pin_drift_warns_not_errors(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Pin whose captured version differs from the canonical version warns, not errors."""
+    monkeypatch.chdir(tmp_path)
+    pin_file = tmp_path / "docs" / "page.md"
+    pin_file.parent.mkdir(parents=True)
+    pin_file.write_text("uses: Anselmoo/repo-release-tools@v9.9.9\n", encoding="utf-8")
+    pin = PinTarget(path=pin_file, pattern=_VALID_PIN_PATTERN)
+    conf = _make_config(tmp_path, pin_targets=[pin])
+    _write_version_file(conf.version_groups[0].version_targets[0].path)
+    (tmp_path / "CHANGELOG.md").write_text("# Changelog\n", encoding="utf-8")
+    monkeypatch.setattr(release_cmd, "load_or_autodetect_config", lambda _: conf)
+
+    rc = release_cmd.cmd_release_check(_ARGS)
+
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "drift" in out
+    assert "9.9.9" in out
+    assert "1.2.3" in out
+
+
+def test_release_check_pin_drift_skipped_when_version_unreadable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """When the canonical version can't be read, pins fall back to match-only (no drift)."""
+    monkeypatch.chdir(tmp_path)
+    pin_file = tmp_path / "docs" / "page.md"
+    pin_file.parent.mkdir(parents=True)
+    pin_file.write_text("uses: Anselmoo/repo-release-tools@v9.9.9\n", encoding="utf-8")
+    pin = PinTarget(path=pin_file, pattern=_VALID_PIN_PATTERN)
+    conf = _make_config(tmp_path, pin_targets=[pin])
+    version_path = conf.version_groups[0].version_targets[0].path
+    version_path.parent.mkdir(parents=True, exist_ok=True)
+    version_path.write_text("no version assignment here\n", encoding="utf-8")
+    (tmp_path / "CHANGELOG.md").write_text("# Changelog\n", encoding="utf-8")
+    monkeypatch.setattr(release_cmd, "load_or_autodetect_config", lambda _: conf)
+
+    rc = release_cmd.cmd_release_check(_ARGS)
+
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "drift" not in out
+    assert "docs/page.md match" in out
+
+
 def test_release_check_global_pins_deduplicated(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -353,7 +428,7 @@ def test_release_check_pin_target_obsolete_status(
     (tmp_path / "CHANGELOG.md").write_text("# Changelog\n", encoding="utf-8")
     monkeypatch.setattr(release_cmd, "load_or_autodetect_config", lambda _: conf)
 
-    def mock_check_pin(_: object, __: Path) -> tuple[str, bool, str]:
+    def mock_check_pin(_: object, __: Path, ___: str | None) -> tuple[str, bool, str]:
         return ("docs/page.md (obsolete: deprecated)", True, "obsolete")
 
     monkeypatch.setattr(release_cmd, "_check_pin_target", mock_check_pin)


### PR DESCRIPTION
## Summary

Closes #103.

`kind='pattern'` version targets — the core ask of #103 (extracting a version via regex, e.g. `ruff==0.15.18` from a dependency pin) — already shipped in #107 and are fully implemented, tested, and documented. What was still missing was the issue's other acceptance criterion:

> `rrt release check` would then validate that all pin_target patterns match the extracted version, catching drift before it accumulates.

Previously `_check_pin_target()` only verified a pin's regex matched *something* in the file — it never compared the captured version group against the group's canonical current version, so a stale pin (e.g. a README badge left at an old version) passed silently.

- `_check_pin_target` now accepts the group's resolved canonical version and compares it against the pin's captured group, reporting a **non-blocking warning** on drift (`rrt release check` still exits 0 — matches `PinTarget`'s existing best-effort philosophy and how "no match" is already treated).
- `_check_release_group` resolves the canonical version once per group, tolerating an unreadable version target by skipping the drift comparison (falls back to existing match/no-match behavior).
- Updated `PinTarget`'s docstring, which previously stated it "does not participate in version consistency checks" — no longer accurate.
- Regenerated `docs/commands/version-release.mdx` with the new check description and a drift example.
- Refreshed the `GENERIC_TOOL_RRT_EXAMPLE` starter config to show the preferred `kind='pattern'` form instead of the legacy 3-group pattern.

## Test plan

- [x] `uv run pytest tests/commands/test_release_cmd.py -q` — new tests for match / drift-warning / unreadable-canonical-version fallback, plus updated obsolete-status mock signature
- [x] `uv run pytest -q -m "not runtime"` — 3076 passed, 100% coverage
- [x] `uvx pre-commit run --all-files` — clean, no unexpected file changes
- [x] Manual smoke test with a deliberately stale pin target — drift warning renders correctly, exit code 0
- [x] Manual smoke test reproducing the exact `ruff-pre-commit` scenario from #103 (mixed stale/current pins) — works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)