### PR TITLE
ci(hooks): self-enforce rrt-branch-name in this repo's own pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,14 @@ default_install_hook_types: [pre-commit, pre-push]
 repos:
   - repo: local
     hooks:
+      - id: rrt-branch-name
+        name: rrt branch name
+        entry: uv run rrt-hooks pre-commit
+        language: system
+        always_run: true
+        pass_filenames: false
+        stages: [pre-commit]
+
       - id: rrt-no-raw-print
         name: rrt no raw print
         entry: python3 scripts/check_no_raw_prints.py


### PR DESCRIPTION
## Summary

This repo publishes `rrt-branch-name` via `.pre-commit-hooks.yaml` for downstream consumers, backed by `validate_branch_name()` and documented in CLAUDE.md's `<type>/<kebab-slug>` branch convention — but never wired the hook into its own `.pre-commit-config.yaml`, so this repo's own branches were never actually checked locally.

Adds the same entry consumers get:

```yaml
- id: rrt-branch-name
  name: rrt branch name
  entry: uv run rrt-hooks pre-commit
  language: system
  always_run: true
  pass_filenames: false
  stages: [pre-commit]
```

Placed first in the hook list since it's a cheap, fail-fast policy gate.

## Rollout note

⚠️ This only runs at commit time (`pre-commit` stage — **not** `pre-push` or CI's own `pre-commit run --all-files`, since GitHub Actions checkouts run in detached-HEAD state where `git branch --show-current` is empty, and `validate_branch_name("")` is valid by design). Any other branch currently open with a non-conforming name — e.g. GitHub's auto-generated `NNN-issue-title` branches, or worktree-tool-generated names — will start failing this check **locally** on its next new commit after this lands on `main`. Existing commits and open PRs are not retroactively affected.

Discovered while working PR #167 (issue #103) from a worktree whose branch name doesn't conform to the convention and would have failed `validate_branch_name()` — but silently didn't, because this hook was never wired up locally.

## Test plan

- [x] `uv run rrt-hooks pre-commit` passes on this branch (`ci/enforce-branch-name-hook`)
- [x] `uvx pre-commit run rrt-branch-name --all-files` passes on this branch
- [x] Manually created a scratch worktree on branch `invalid-branch-name-test` and confirmed the hook correctly rejects it:
  ```
  ✖ Commit blocked by branch naming policy.
  → Branch 'invalid-branch-name-test' must use <type>/<kebab-case-description>.
  ```
- [x] `uvx pre-commit run --all-files` — all 20 hooks pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)