### PR TITLE
fix(bump): resolve changelog mode from the resolved group, not the ambiguous config

### DIFF
--- a/src/repo_release_tools/commands/bump.py
+++ b/src/repo_release_tools/commands/bump.py
@@ -390,11 +390,11 @@ def apply_version(
     return changed
 
 
-def resolve_changelog_mode(config: RrtConfig, requested_mode: str | None) -> str:
+def resolve_changelog_mode(group: VersionGroup, requested_mode: str | None) -> str:
     """Resolve the changelog update mode from CLI input and workflow defaults."""
     if requested_mode is not None:
         return requested_mode
-    return "generate" if config.changelog_workflow == "squash" else "auto"
+    return "generate" if group.changelog_workflow == "squash" else "auto"
 
 
 def git_log_since_latest_tag(root: Path) -> list[str]:
@@ -652,7 +652,7 @@ def cmd_bump(args: argparse.Namespace) -> int:
     if not opts.no_changelog:
         p.section("Updating changelog")
         effective_changelog_mode = resolve_changelog_mode(
-            config,
+            group,
             opts.changelog_mode,
         )
         update_changelog(

--- a/src/repo_release_tools/mcp/tools/version_tools.py
+++ b/src/repo_release_tools/mcp/tools/version_tools.py
@@ -139,7 +139,7 @@ def register(mcp: FastMCP) -> None:
                     target_group, new, config, dry_run=dry_run
                 )
 
-                effective_changelog_mode = bump_cmd.resolve_changelog_mode(config, None)
+                effective_changelog_mode = bump_cmd.resolve_changelog_mode(target_group, None)
                 bump_cmd.update_changelog(
                     bump_cmd.RrtConfig(
                         root=config.root,

--- a/tests/commands/test_bump.py
+++ b/tests/commands/test_bump.py
@@ -363,14 +363,8 @@ def test_resolve_changelog_mode_prefers_requested_mode(tmp_path: Path) -> None:
         version_targets=[target],
         changelog_workflow="incremental",
     )
-    config = RrtConfig(
-        root=tmp_path,
-        config_file=tmp_path / ".rrt.toml",
-        version_groups=[group],
-        default_group_name="default",
-    )
 
-    assert resolve_changelog_mode(config, "promote") == "promote"
+    assert resolve_changelog_mode(group, "promote") == "promote"
 
 
 def test_resolve_changelog_mode_defaults_to_auto_for_incremental(tmp_path: Path) -> None:
@@ -385,14 +379,8 @@ def test_resolve_changelog_mode_defaults_to_auto_for_incremental(tmp_path: Path)
         version_targets=[target],
         changelog_workflow="incremental",
     )
-    config = RrtConfig(
-        root=tmp_path,
-        config_file=tmp_path / ".rrt.toml",
-        version_groups=[group],
-        default_group_name="default",
-    )
 
-    assert resolve_changelog_mode(config, None) == "auto"
+    assert resolve_changelog_mode(group, None) == "auto"
 
 
 def test_resolve_changelog_mode_defaults_to_generate_for_squash(tmp_path: Path) -> None:
@@ -407,14 +395,42 @@ def test_resolve_changelog_mode_defaults_to_generate_for_squash(tmp_path: Path) 
         version_targets=[target],
         changelog_workflow="squash",
     )
-    config = RrtConfig(
+
+    assert resolve_changelog_mode(group, None) == "generate"
+
+
+def test_resolve_changelog_mode_with_multiple_groups_configured(tmp_path: Path) -> None:
+    """Regression test for #175: resolving a single group's mode must not require the
+    ambiguous multi-group config to pick a default group.
+    """
+    target = VersionTarget(path=tmp_path / "pyproject.toml", kind="pep621")
+    quality_group = VersionGroup(
+        name="quality",
+        release_branch="release/quality/v{version}",
+        changelog_file=tmp_path / "quality" / "CHANGELOG.md",
+        lock_command=[],
+        generated_files=[],
+        version_targets=[target],
+        changelog_workflow="incremental",
+    )
+    compass_group = VersionGroup(
+        name="compass",
+        release_branch="release/compass/v{version}",
+        changelog_file=tmp_path / "compass" / "CHANGELOG.md",
+        lock_command=[],
+        generated_files=[],
+        version_targets=[target],
+        changelog_workflow="squash",
+    )
+    # Multiple groups, no default_group_name -- config.resolve_group() would raise here.
+    RrtConfig(
         root=tmp_path,
         config_file=tmp_path / ".rrt.toml",
-        version_groups=[group],
-        default_group_name="default",
+        version_groups=[quality_group, compass_group],
     )
 
-    assert resolve_changelog_mode(config, None) == "generate"
+    assert resolve_changelog_mode(quality_group, None) == "auto"
+    assert resolve_changelog_mode(compass_group, None) == "generate"
 
 
 def test_git_log_since_latest_tag_uses_latest_tag_range(


### PR DESCRIPTION
## Summary

- Fixes `rrt bump --group <name>` failing with `[ERROR] Multiple version groups configured...` whenever 2+ `[[tool.rrt.version_groups]]` are configured and `--changelog-mode` is *not* explicitly passed — even though a valid `--group` was already given.
- Root cause: `resolve_changelog_mode()` read `config.changelog_workflow`, a backward-compat property that calls `RrtConfig.resolve_group()` with no name — which raises on any multi-group config with no `default_group_name`, ignoring the already-resolved `--group`.
- Fix: `resolve_changelog_mode()` now takes the resolved `VersionGroup` directly instead of the ambiguous multi-group `RrtConfig`, mirroring the pattern already used for `update_changelog()`. Applied at both call sites: `commands/bump.py::cmd_bump` and `mcp/tools/version_tools.py`'s per-group bump loop.

Fixes #175

## Test plan

- [x] Updated 3 existing `resolve_changelog_mode` unit tests to pass a `VersionGroup`
- [x] Added a regression test with a 2-group config (no `default_group_name`) reproducing the exact ambiguity the old signature couldn't handle
- [x] `uv run pytest -q -m "not runtime"` — 3108 passed, 100% coverage
- [x] Manually reproduced the issue's repro (2-group `.rrt.toml`, `rrt bump patch --group quality --dry-run --no-commit`, no `--changelog-mode`) — now exits 0 instead of 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
