### PR TITLE
feat(fields): Markdown/MDX/RST anchor targets + fix misleading git-commit error

### DIFF
--- a/.rrt/tree.lock.toml
+++ b/.rrt/tree.lock.toml
@@ -1,10 +1,10 @@
 [meta]
-generated_at = "2026-07-17T10:50:41+00:00"
-rrt_version = "1.13.1"
+generated_at = "2026-07-17T16:55:51+00:00"
+rrt_version = "1.14.0"
 
 [snapshot]
-entry_count = 412
-tree_hash = "sha256:7fb0e47664ce50472f020db4bb29dfb2f7346defea959a235818c8c475b2fe65"
-updated_at = "2026-07-17T10:50:41+00:00"
-ignored_count = 206
+entry_count = 414
+tree_hash = "sha256:b4b08850c685713ccb996106228b41ec724fe645eba2fa59786a6daa9e98fb60"
+updated_at = "2026-07-17T16:55:51+00:00"
+ignored_count = 34
 phantom_empty_dirs = []

--- a/docs/src/content/docs/commands/repo-health.mdx
+++ b/docs/src/content/docs/commands/repo-health.mdx
@@ -303,14 +303,23 @@ source = "plugins/self-assess/.claude-plugin/plugin.json"
 source_field = "description"
 targets = [
   { path = ".claude-plugin/marketplace.json", field = "plugins[name=self-assess].description" },
+  { path = "README.md", anchor = "self-assess-description" },
 ]
 ```
 
 - `source` — relative path to the source-of-truth JSON file.
 - `source_field` — a path into the parsed source JSON (see "Field path
   syntax" below).
-- `targets` — a list of `{path, field}` write destinations. `path` is the
-  target JSON file; `field` uses the same path syntax as `source_field`.
+- `targets` — a list of write destinations, each setting exactly one of:
+  - `field` — a JSON target. `path` is the target JSON file; `field` uses
+    the same path syntax as `source_field`.
+  - `anchor` — a Markdown/MDX/RST target. `path` is the prose file; `anchor`
+    is the anchor id of an `<!-- rrt:auto:start:<id> -->` /
+    `{/* rrt:auto:start:<id> */}` / `.. rrt:auto:start:<id>` block already
+    present in that file (format auto-detected from the file extension, the
+    same primitive used by `rrt docs publish`/`inject` and `rrt tree
+    --inject`). A target file missing the anchor markers fails loudly
+    (exit 1) rather than being silently skipped.
 
 #### Field path syntax
 
@@ -347,10 +356,13 @@ rrt fields --list
 
 ### Caveats
 
-- Only JSON source/target files are supported in this first pass (TOML/YAML
-  sources are not handled).
-- A target field path must resolve to an existing key on an existing
+- Only JSON source files are supported in this first pass (TOML/YAML sources
+  are not handled). Targets may be JSON (`field`) or Markdown/MDX/RST
+  (`anchor`).
+- A `field` target path must resolve to an existing key on an existing
   object — `--sync` will not create new keys.
+- An `anchor` target file must already contain the matching anchor marker
+  pair; `--sync`/`--check` fail loudly rather than creating or skipping it.
 
 ```text
 Usage:  rrt fields [OPTIONS]

--- a/src/repo_release_tools/commands/fields_cmd.py
+++ b/src/repo_release_tools/commands/fields_cmd.py
@@ -26,14 +26,23 @@ source = "plugins/self-assess/.claude-plugin/plugin.json"
 source_field = "description"
 targets = [
   { path = ".claude-plugin/marketplace.json", field = "plugins[name=self-assess].description" },
+  { path = "README.md", anchor = "self-assess-description" },
 ]
 ```
 
 - `source` — relative path to the source-of-truth JSON file.
 - `source_field` — a path into the parsed source JSON (see "Field path
   syntax" below).
-- `targets` — a list of `{path, field}` write destinations. `path` is the
-  target JSON file; `field` uses the same path syntax as `source_field`.
+- `targets` — a list of write destinations, each setting exactly one of:
+  - `field` — a JSON target. `path` is the target JSON file; `field` uses
+    the same path syntax as `source_field`.
+  - `anchor` — a Markdown/MDX/RST target. `path` is the prose file; `anchor`
+    is the anchor id of an `<!-- rrt:auto:start:<id> -->` /
+    `{/* rrt:auto:start:<id> */}` / `.. rrt:auto:start:<id>` block already
+    present in that file (format auto-detected from the file extension, the
+    same primitive used by `rrt docs publish`/`inject` and `rrt tree
+    --inject`). A target file missing the anchor markers fails loudly
+    (exit 1) rather than being silently skipped.
 
 ### Field path syntax
 
@@ -70,10 +79,13 @@ rrt fields --list
 
 ## Caveats
 
-- Only JSON source/target files are supported in this first pass (TOML/YAML
-  sources are not handled).
-- A target field path must resolve to an existing key on an existing
+- Only JSON source files are supported in this first pass (TOML/YAML sources
+  are not handled). Targets may be JSON (`field`) or Markdown/MDX/RST
+  (`anchor`).
+- A `field` target path must resolve to an existing key on an existing
   object — `--sync` will not create new keys.
+- An `anchor` target file must already contain the matching anchor marker
+  pair; `--sync`/`--check` fail loudly rather than creating or skipping it.
 """
 
 from __future__ import annotations
@@ -91,7 +103,12 @@ from repo_release_tools.config import (
     find_repo_root,
     load_or_autodetect_config,
 )
-from repo_release_tools.config.model import FieldTarget
+from repo_release_tools.config.model import FieldTarget, FieldTargetEntry
+from repo_release_tools.tools.inject import (
+    _detect_inject_format,
+    extract_anchored_block,
+    replace_anchored_block,
+)
 from repo_release_tools.ui import (
     DryRunPrinter,
     VerbosePrinter,
@@ -215,22 +232,45 @@ def _write_json_file(path: Path, data: Any) -> None:
     path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
 
 
+def _read_text_file(path: Path) -> str:
+    """Read a target file's raw text, raising ``FieldPathError`` on failure."""
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise FieldPathError(f"cannot read {path}: {exc}") from exc
+
+
+def _target_label(entry: FieldTargetEntry) -> str:
+    """Return a human-readable label for a target entry: its field path or anchor id."""
+    if entry.anchor is not None:
+        return f"anchor:{entry.anchor}"
+    return entry.field or ""
+
+
 @dataclass(frozen=True)
 class FieldComparison:
-    """Result of comparing one target field against its source field."""
+    """Result of comparing one target (a JSON field or an anchor block) against its source field."""
 
     source: str
     source_field: str
     target_path: str
-    target_field: str
+    target_field: str | None = None
+    target_anchor: str | None = None
     source_value: Any = None
     target_value: Any = None
     error: str | None = None
 
     @property
     def matches(self) -> bool:
-        """Return whether the target field currently matches the source field."""
+        """Return whether the target currently matches the source field."""
         return self.error is None and self.source_value == self.target_value
+
+    @property
+    def target_label(self) -> str:
+        """Return a human-readable label: the field path, or ``anchor:<id>``."""
+        if self.target_anchor is not None:
+            return f"anchor:{self.target_anchor}"
+        return self.target_field or ""
 
 
 def _compare_field_target(field_target: FieldTarget, root: Path) -> list[FieldComparison]:
@@ -253,33 +293,53 @@ def _compare_field_target(field_target: FieldTarget, root: Path) -> list[FieldCo
                     source_field=field_target.source_field,
                     target_path=entry.path,
                     target_field=entry.field,
+                    target_anchor=entry.anchor,
                     error=source_error,
                 )
             )
             continue
         target_path = root / entry.path
         try:
-            target_data = _load_json_file(target_path)
-            target_value = resolve_field(target_data, entry.field)
-            results.append(
-                FieldComparison(
-                    source=field_target.source,
-                    source_field=field_target.source_field,
-                    target_path=entry.path,
-                    target_field=entry.field,
-                    source_value=source_value,
-                    target_value=target_value,
+            if entry.anchor is not None:
+                text = _read_text_file(target_path)
+                fmt = _detect_inject_format(target_path)
+                extracted = extract_anchored_block(text, anchor_id=entry.anchor, fmt=fmt)
+                if extracted is None:
+                    raise FieldPathError(f"missing anchor markers for {entry.anchor!r}")
+                results.append(
+                    FieldComparison(
+                        source=field_target.source,
+                        source_field=field_target.source_field,
+                        target_path=entry.path,
+                        target_anchor=entry.anchor,
+                        source_value=str(source_value).strip(),
+                        target_value=extracted.strip(),
+                    )
                 )
-            )
-        except FieldPathError as exc:
+            else:
+                assert entry.field is not None  # exactly one of field/anchor per validate()
+                target_data = _load_json_file(target_path)
+                target_value = resolve_field(target_data, entry.field)
+                results.append(
+                    FieldComparison(
+                        source=field_target.source,
+                        source_field=field_target.source_field,
+                        target_path=entry.path,
+                        target_field=entry.field,
+                        source_value=source_value,
+                        target_value=target_value,
+                    )
+                )
+        except ValueError as exc:
             results.append(
                 FieldComparison(
                     source=field_target.source,
                     source_field=field_target.source_field,
                     target_path=entry.path,
                     target_field=entry.field,
+                    target_anchor=entry.anchor,
                     source_value=source_value,
-                    error=f"{entry.path}#{entry.field}: {exc}",
+                    error=f"{entry.path}#{_target_label(entry)}: {exc}",
                 )
             )
     return results
@@ -342,10 +402,10 @@ def _run_fields_check(
 
     for c in problems:
         if c.error:
-            msg = f"{c.source}#{c.source_field} -> {c.target_path}#{c.target_field}: {c.error}"
+            msg = f"{c.source}#{c.source_field} -> {c.target_path}#{c.target_label}: {c.error}"
         else:
             msg = (
-                f"{c.source}#{c.source_field} -> {c.target_path}#{c.target_field}: "
+                f"{c.source}#{c.source_field} -> {c.target_path}#{c.target_label}: "
                 f"mismatch (source={c.source_value!r}, target={c.target_value!r})"
             )
         if strict:
@@ -379,7 +439,7 @@ def _run_fields_sync(
     errors = [c for c in comparisons if c.error]
     for c in errors:
         rp.line(
-            f"{c.source}#{c.source_field} -> {c.target_path}#{c.target_field}: {c.error}",
+            f"{c.source}#{c.source_field} -> {c.target_path}#{c.target_label}: {c.error}",
             ok=False,
             stream=sys.stderr,
         )
@@ -387,6 +447,7 @@ def _run_fields_sync(
         return 1
 
     loaded: dict[Path, Any] = {}
+    loaded_text: dict[Path, str] = {}
     written = 0
     unchanged = 0
     for c in comparisons:
@@ -395,9 +456,25 @@ def _run_fields_sync(
             continue
         target_path = root / c.target_path
         if dry_run:
-            rp.would_write(c.target_path, f"{c.target_field} = {c.source_value!r}")
+            rp.would_write(c.target_path, f"{c.target_label} = {c.source_value!r}")
             written += 1
             continue
+        if c.target_anchor is not None:
+            text = loaded_text.get(target_path)
+            if text is None:
+                text = target_path.read_text(encoding="utf-8")
+            fmt = _detect_inject_format(target_path)
+            updated = replace_anchored_block(
+                text, anchor_id=c.target_anchor, content=str(c.source_value), fmt=fmt
+            )
+            # The anchor markers were already confirmed present for this exact
+            # (path, anchor_id, fmt) during the error-gated comparison above,
+            # so replace_anchored_block cannot return None here.
+            assert updated is not None
+            loaded_text[target_path] = updated
+            written += 1
+            continue
+        assert c.target_field is not None  # target_anchor is None, so this is a JSON target
         data = loaded.get(target_path)
         if data is None:
             data = _load_json_file(target_path)
@@ -408,16 +485,19 @@ def _run_fields_sync(
     if not dry_run:
         for target_path, data in loaded.items():
             _write_json_file(target_path, data)
+        for target_path, text in loaded_text.items():
+            target_path.write_text(text, encoding="utf-8")
 
     if written == 0:
         rp.footer(f"All {unchanged} field mapping(s) already in sync — nothing to write.")
         return 0
 
+    total_files = len(loaded) + len(loaded_text)
     if dry_run:
         rp.footer(f"Would update {written} field(s); {unchanged} already in sync.")
     else:
         rp.footer(
-            f"Updated {written} field(s) across {len(loaded)} target file(s); "
+            f"Updated {written} field(s) across {total_files} target file(s); "
             f"{unchanged} already in sync."
         )
     return 0
@@ -434,13 +514,13 @@ def _print_field_list(field_targets: list[FieldTarget], root: Path) -> None:
         label = f"{field_target.source}#{field_target.source_field}"
         p.line(rule(label, width=width))
         for c in _compare_field_target(field_target, root):
-            target_label = f"{c.target_path}#{c.target_field}"
+            label_text = f"{c.target_path}#{c.target_label}"
             if c.error:
-                p.line(f"{target_label:<60}  {c.error}", ok=False)
+                p.line(f"{label_text:<60}  {c.error}", ok=False)
             elif c.matches:
-                p.line(f"{target_label:<60}  ✓", ok=True)
+                p.line(f"{label_text:<60}  ✓", ok=True)
             else:
-                p.line(f"{target_label:<60}  MISMATCH", ok=False)
+                p.line(f"{label_text:<60}  MISMATCH", ok=False)
 
 
 def cmd_fields(args: argparse.Namespace) -> int:

--- a/src/repo_release_tools/config/core.py
+++ b/src/repo_release_tools/config/core.py
@@ -1238,7 +1238,8 @@ def _load_artifact_targets(raw_targets: object) -> list[ArtifactTarget]:
 
 _FIELD_TARGET_ENTRY_FIELDS = [
     _str_field("path", "Each field_targets.targets entry must have a non-empty 'path' string"),
-    _str_field("field", "Each field_targets.targets entry must have a non-empty 'field' string"),
+    _opt_str_field("field", "field_targets.targets.field must be a string when provided"),
+    _opt_str_field("anchor", "field_targets.targets.anchor must be a string when provided"),
 ]
 
 _FIELD_TARGET_FIELDS = [
@@ -1261,7 +1262,8 @@ def _load_field_target_entries(raw_entries: object) -> list[FieldTargetEntry]:
         fields = _walk_fields(typed_item, _FIELD_TARGET_ENTRY_FIELDS)
         entry = FieldTargetEntry(
             path=cast("str", fields["path"]),
-            field=cast("str", fields["field"]),
+            field=cast("str | None", fields["field"]),
+            anchor=cast("str | None", fields["anchor"]),
         )
         entry.validate()
         entries.append(entry)

--- a/src/repo_release_tools/config/model.py
+++ b/src/repo_release_tools/config/model.py
@@ -360,10 +360,14 @@ class ArtifactTarget:
 
 @dataclass(frozen=True)
 class FieldTargetEntry:
-    """A single ``{path, field}`` write destination inside a ``FieldTarget``."""
+    """A single write destination inside a ``FieldTarget``.
+
+    Either a JSON ``field`` or a prose ``anchor`` block, never both.
+    """
 
     path: str
-    field: str
+    field: str | None = None
+    anchor: str | None = None
 
     def validate(self) -> None:
         """Validate the target entry."""
@@ -375,8 +379,10 @@ class FieldTargetEntry:
             raise ValueError(
                 "field_targets.targets.path must not escape the repo root (no '..' components)"
             )
-        if not self.field:
-            raise ValueError("field_targets.targets.field must be a non-empty string")
+        if bool(self.field) == bool(self.anchor):
+            raise ValueError(
+                "field_targets.targets entries must set exactly one of 'field' or 'anchor'"
+            )
 
 
 @dataclass(frozen=True)

--- a/src/repo_release_tools/tools/inject.py
+++ b/src/repo_release_tools/tools/inject.py
@@ -177,23 +177,10 @@ def ensure_anchor_stub(
         path.write_text(updated, encoding="utf-8")
 
 
-def replace_anchored_block(
-    existing: str, *, anchor_id: str, content: str, fmt: str = "md"
-) -> str | None:
-    """Replace the body between matching anchor markers in *existing*.
+def _find_anchor_bounds(lines: list[str], *, anchor_id: str, fmt: str) -> tuple[int, int] | None:
+    """Return the (start_idx, end_idx) of the anchor marker lines in *lines*.
 
-    Args:
-        existing: Full text of the target file.
-        anchor_id: The anchor identifier, e.g. ``"project-tree"``.  Must match
-            ``[A-Za-z0-9][A-Za-z0-9._-]*``.
-        content: New content to place between the markers. Trailing newline is
-            normalised automatically.
-        fmt: ``'md'`` for Markdown HTML-comment anchors (default), ``'rst'`` for
-            reStructuredText comment anchors, ``'mdx'`` for MDX JSX-comment anchors.
-
-    Returns:
-        Updated file text with the block replaced, or ``None`` when the start
-        marker for *anchor_id* is not found in *existing*.
+    Returns ``None`` when the start marker for *anchor_id* is absent.
 
     Raises:
         ValueError: When *anchor_id* is invalid, or when the start marker is
@@ -201,8 +188,6 @@ def replace_anchored_block(
     """
     if not _ANCHOR_ID_RE.fullmatch(anchor_id):
         raise ValueError(f"Invalid anchor id: {anchor_id!r}")
-
-    lines = existing.splitlines(keepends=True)
 
     if fmt == "rst":
         start_re = _anchor_rst_pattern(RST_ANCHOR_START_TOKEN, anchor_id)
@@ -234,6 +219,63 @@ def replace_anchored_block(
     )
     if end_idx is None:
         raise ValueError(f"Missing end anchor for {anchor_id!r} ({end_token_display})")
+
+    return start_idx, end_idx
+
+
+def extract_anchored_block(existing: str, *, anchor_id: str, fmt: str = "md") -> str | None:
+    """Return the body between matching anchor markers in *existing*.
+
+    Args:
+        existing: Full text of the target file.
+        anchor_id: The anchor identifier, e.g. ``"project-tree"``.  Must match
+            ``[A-Za-z0-9][A-Za-z0-9._-]*``.
+        fmt: ``'md'`` for Markdown HTML-comment anchors (default), ``'rst'`` for
+            reStructuredText comment anchors, ``'mdx'`` for MDX JSX-comment anchors.
+
+    Returns:
+        The text strictly between the start and end marker lines, or ``None``
+        when the start marker for *anchor_id* is not found in *existing*.
+
+    Raises:
+        ValueError: When *anchor_id* is invalid, or when the start marker is
+            present but the end marker is absent.
+    """
+    lines = existing.splitlines(keepends=True)
+    bounds = _find_anchor_bounds(lines, anchor_id=anchor_id, fmt=fmt)
+    if bounds is None:
+        return None
+    start_idx, end_idx = bounds
+    return "".join(lines[start_idx + 1 : end_idx])
+
+
+def replace_anchored_block(
+    existing: str, *, anchor_id: str, content: str, fmt: str = "md"
+) -> str | None:
+    """Replace the body between matching anchor markers in *existing*.
+
+    Args:
+        existing: Full text of the target file.
+        anchor_id: The anchor identifier, e.g. ``"project-tree"``.  Must match
+            ``[A-Za-z0-9][A-Za-z0-9._-]*``.
+        content: New content to place between the markers. Trailing newline is
+            normalised automatically.
+        fmt: ``'md'`` for Markdown HTML-comment anchors (default), ``'rst'`` for
+            reStructuredText comment anchors, ``'mdx'`` for MDX JSX-comment anchors.
+
+    Returns:
+        Updated file text with the block replaced, or ``None`` when the start
+        marker for *anchor_id* is not found in *existing*.
+
+    Raises:
+        ValueError: When *anchor_id* is invalid, or when the start marker is
+            present but the end marker is absent.
+    """
+    lines = existing.splitlines(keepends=True)
+    bounds = _find_anchor_bounds(lines, anchor_id=anchor_id, fmt=fmt)
+    if bounds is None:
+        return None
+    start_idx, end_idx = bounds
 
     block = content.rstrip("\n")
     body = f"{block}\n" if block else ""

--- a/src/repo_release_tools/workflow/git.py
+++ b/src/repo_release_tools/workflow/git.py
@@ -78,6 +78,32 @@ GIT_DOC = (
 SOURCE_OWNED_TOPIC_DOCS: tuple[tuple[str, str], ...] = (("git", GIT_DOC),)
 
 
+def _failure_detail(stdout: str, stderr: str) -> str:
+    """Pick the actionable reason from a failed command's captured output.
+
+    Pre-commit's hook summary lines end in "...Passed" or "...Failed"; naively
+    taking the last output line breaks when a later hook happens to pass after
+    an earlier one failed, surfacing the wrong line as the reason. Scan
+    backward through stderr, then stdout, for the last line ending in
+    "Failed" and return it plus any detail lines pre-commit prints
+    immediately after (e.g. "- files were modified by this hook") up to the
+    next blank line. Fall back to the plain last line of either stream if no
+    such marker is found, so a caller still sees *something*.
+    """
+    for text in (stderr, stdout):
+        lines = text.strip().splitlines()
+        for idx in range(len(lines) - 1, -1, -1):
+            if lines[idx].rstrip().endswith("Failed"):
+                detail_lines = [lines[idx]]
+                for follow in lines[idx + 1 :]:
+                    if not follow.strip():
+                        break
+                    detail_lines.append(follow.strip())
+                return " ".join(detail_lines)
+    tail = stderr.strip().splitlines() or stdout.strip().splitlines()
+    return tail[-1] if tail else ""
+
+
 def run(
     cmd: list[str],
     cwd: Path,
@@ -110,12 +136,8 @@ def run(
         if result.stderr.strip():
             for line in result.stderr.strip().splitlines():
                 p.warn(line, stream=None)
-        # The last stderr line is usually the actionable one (e.g. a
-        # pre-commit hook's summary starts with a generic "<hook>...Failed"
-        # header and ends with the specific reason, like "- files were
-        # modified by this hook").
-        last_err = result.stderr.strip().splitlines()[-1] if result.stderr.strip() else ""
-        detail = f": {last_err}" if last_err else ""
+        detail_text = _failure_detail(result.stdout, result.stderr)
+        detail = f": {detail_text}" if detail_text else ""
         raise RuntimeError(f"{label} failed (exit {result.returncode}){detail}")
     if result.stdout.strip():
         p = VerbosePrinter()
@@ -147,7 +169,9 @@ def capture_checked(cmd: list[str], cwd: Path) -> str:
     )
     if result.returncode != 0:
         label = " ".join(cmd)
-        raise RuntimeError(f"{label} failed (exit {result.returncode})")
+        detail_text = _failure_detail(result.stdout, result.stderr)
+        detail = f": {detail_text}" if detail_text else ""
+        raise RuntimeError(f"{label} failed (exit {result.returncode}){detail}")
     return result.stdout.strip()
 
 

--- a/tests/commands/test_fields_cmd.py
+++ b/tests/commands/test_fields_cmd.py
@@ -306,8 +306,22 @@ def test_field_target_entry_validate_escapes_root() -> None:
 
 
 def test_field_target_entry_validate_empty_field() -> None:
-    with pytest.raises(ValueError, match="non-empty string"):
+    with pytest.raises(ValueError, match="exactly one of 'field' or 'anchor'"):
         FieldTargetEntry(path="a.json", field="").validate()
+
+
+def test_field_target_entry_validate_neither_field_nor_anchor() -> None:
+    with pytest.raises(ValueError, match="exactly one of 'field' or 'anchor'"):
+        FieldTargetEntry(path="a.json").validate()
+
+
+def test_field_target_entry_validate_both_field_and_anchor() -> None:
+    with pytest.raises(ValueError, match="exactly one of 'field' or 'anchor'"):
+        FieldTargetEntry(path="a.json", field="x", anchor="y").validate()
+
+
+def test_field_target_entry_validate_anchor_only_ok() -> None:
+    FieldTargetEntry(path="README.md", anchor="self-assess-description").validate()
 
 
 def test_field_target_validate_ok() -> None:
@@ -768,3 +782,248 @@ def test_print_field_list_shows_error(tmp_path: Path, capsys: pytest.CaptureFixt
     _print_field_list([_simple_field_target()], tmp_path)
     captured = capsys.readouterr()
     assert "cannot read" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# anchor targets (#180)
+# ---------------------------------------------------------------------------
+
+_MD_ANCHOR_DOC = (
+    "# werkstoff\n"
+    "\n"
+    "<!-- rrt:auto:start:self-assess-description -->\n"
+    "old description\n"
+    "<!-- rrt:auto:end:self-assess-description -->\n"
+    "\n"
+    "trailing text\n"
+)
+
+_MDX_ANCHOR_DOC = (
+    "# werkstoff\n"
+    "\n"
+    "{/* rrt:auto:start:self-assess-description */}\n"
+    "old description\n"
+    "{/* rrt:auto:end:self-assess-description */}\n"
+    "\n"
+    "trailing text\n"
+)
+
+_RST_ANCHOR_DOC = (
+    "werkstoff\n"
+    "=========\n"
+    "\n"
+    ".. rrt:auto:start:self-assess-description\n"
+    "\n"
+    "old description\n"
+    "\n"
+    ".. rrt:auto:end:self-assess-description\n"
+    "\n"
+    "trailing text\n"
+)
+
+
+def _anchor_field_target(
+    *,
+    source: str = "plugin.json",
+    source_field: str = "description",
+    target_path: str = "README.md",
+    anchor: str = "self-assess-description",
+) -> FieldTarget:
+    return FieldTarget(
+        source=source,
+        source_field=source_field,
+        targets=[FieldTargetEntry(path=target_path, anchor=anchor)],
+    )
+
+
+@pytest.mark.parametrize(
+    ("doc", "filename"),
+    [
+        (_MD_ANCHOR_DOC, "README.md"),
+        (_MDX_ANCHOR_DOC, "README.mdx"),
+        (_RST_ANCHOR_DOC, "README.rst"),
+    ],
+)
+def test_compare_field_target_anchor_match(tmp_path: Path, doc: str, filename: str) -> None:
+    _write_json(tmp_path / "plugin.json", {"description": "old description"})
+    (tmp_path / filename).write_text(doc)
+    ft = _anchor_field_target(target_path=filename)
+    comparisons = _compare_field_target(ft, tmp_path)
+    assert len(comparisons) == 1
+    assert comparisons[0].matches
+    assert comparisons[0].target_label == "anchor:self-assess-description"
+
+
+def test_compare_field_target_anchor_mismatch(tmp_path: Path) -> None:
+    _write_json(tmp_path / "plugin.json", {"description": "new description"})
+    (tmp_path / "README.md").write_text(_MD_ANCHOR_DOC)
+    comparisons = _compare_field_target(_anchor_field_target(), tmp_path)
+    assert len(comparisons) == 1
+    assert not comparisons[0].matches
+    assert comparisons[0].error is None
+
+
+def test_compare_field_target_anchor_missing_markers_errors(tmp_path: Path) -> None:
+    _write_json(tmp_path / "plugin.json", {"description": "d"})
+    (tmp_path / "README.md").write_text("# no anchors here\n")
+    comparisons = _compare_field_target(_anchor_field_target(), tmp_path)
+    assert len(comparisons) == 1
+    assert comparisons[0].error is not None
+    assert "missing anchor markers" in comparisons[0].error
+
+
+def test_compare_field_target_anchor_missing_file_errors(tmp_path: Path) -> None:
+    _write_json(tmp_path / "plugin.json", {"description": "d"})
+    comparisons = _compare_field_target(_anchor_field_target(), tmp_path)
+    assert len(comparisons) == 1
+    assert comparisons[0].error is not None
+    assert "cannot read" in comparisons[0].error
+
+
+def test_compare_field_target_mixed_field_and_anchor_targets(tmp_path: Path) -> None:
+    _write_json(tmp_path / "plugin.json", {"description": "shared value"})
+    _write_json(
+        tmp_path / "marketplace.json",
+        {"plugins": [{"name": "self-assess", "description": "shared value"}]},
+    )
+    (tmp_path / "README.md").write_text(_MD_ANCHOR_DOC.replace("old description", "shared value"))
+    ft = FieldTarget(
+        source="plugin.json",
+        source_field="description",
+        targets=[
+            FieldTargetEntry(
+                path="marketplace.json", field="plugins[name=self-assess].description"
+            ),
+            FieldTargetEntry(path="README.md", anchor="self-assess-description"),
+        ],
+    )
+    comparisons = _compare_field_target(ft, tmp_path)
+    assert len(comparisons) == 2
+    assert all(c.matches for c in comparisons)
+
+
+def test_compare_field_target_mixed_source_error_propagates_to_both(tmp_path: Path) -> None:
+    # plugin.json missing entirely -> source_error should apply to every target.
+    ft = FieldTarget(
+        source="plugin.json",
+        source_field="description",
+        targets=[
+            FieldTargetEntry(
+                path="marketplace.json", field="plugins[name=self-assess].description"
+            ),
+            FieldTargetEntry(path="README.md", anchor="self-assess-description"),
+        ],
+    )
+    comparisons = _compare_field_target(ft, tmp_path)
+    assert len(comparisons) == 2
+    assert all(c.error is not None for c in comparisons)
+    assert comparisons[0].error == comparisons[1].error
+
+
+def test_check_anchor_advisory_warns_on_mismatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    _write_json(tmp_path / "plugin.json", {"description": "new description"})
+    (tmp_path / "README.md").write_text(_MD_ANCHOR_DOC)
+    config = _make_config(tmp_path, field_targets=[_anchor_field_target()])
+    with patch(
+        "repo_release_tools.commands.fields_cmd.load_or_autodetect_config", return_value=config
+    ):
+        rc = cmd_fields(_make_args(check=True))
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "mismatch" in captured.err.lower() or "advisory" in captured.out.lower()
+
+
+def test_check_anchor_strict_missing_markers_exits_1(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    _write_json(tmp_path / "plugin.json", {"description": "d"})
+    (tmp_path / "README.md").write_text("# no anchors here\n")
+    config = _make_config(tmp_path, field_targets=[_anchor_field_target()])
+    with patch(
+        "repo_release_tools.commands.fields_cmd.load_or_autodetect_config", return_value=config
+    ):
+        rc = cmd_fields(_make_args(check=True, strict=True))
+    assert rc == 1
+
+
+def test_sync_writes_anchor_block_preserving_surrounding_content(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    _write_json(tmp_path / "plugin.json", {"description": "brand new description"})
+    (tmp_path / "README.md").write_text(_MD_ANCHOR_DOC)
+    config = _make_config(tmp_path, field_targets=[_anchor_field_target()])
+    with patch(
+        "repo_release_tools.commands.fields_cmd.load_or_autodetect_config", return_value=config
+    ):
+        rc = cmd_fields(_make_args(sync=True))
+    assert rc == 0
+    updated = (tmp_path / "README.md").read_text()
+    assert "brand new description" in updated
+    assert "old description" not in updated
+    assert "# werkstoff" in updated
+    assert "trailing text" in updated
+
+
+def test_sync_anchor_dry_run_does_not_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    _write_json(tmp_path / "plugin.json", {"description": "brand new description"})
+    (tmp_path / "README.md").write_text(_MD_ANCHOR_DOC)
+    original_text = (tmp_path / "README.md").read_text()
+    config = _make_config(tmp_path, field_targets=[_anchor_field_target()])
+    with patch(
+        "repo_release_tools.commands.fields_cmd.load_or_autodetect_config", return_value=config
+    ):
+        rc = cmd_fields(_make_args(sync=True, dry_run=True))
+    assert rc == 0
+    assert (tmp_path / "README.md").read_text() == original_text
+
+
+def test_sync_anchor_missing_markers_fails_loudly(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    _write_json(tmp_path / "plugin.json", {"description": "d"})
+    (tmp_path / "README.md").write_text("# no anchors here\n")
+    config = _make_config(tmp_path, field_targets=[_anchor_field_target()])
+    with patch(
+        "repo_release_tools.commands.fields_cmd.load_or_autodetect_config", return_value=config
+    ):
+        rc = cmd_fields(_make_args(sync=True))
+    assert rc == 1
+
+
+def test_sync_anchor_missing_file_returns_1(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    _write_json(tmp_path / "plugin.json", {"description": "d"})
+    config = _make_config(tmp_path, field_targets=[_anchor_field_target()])
+    with patch(
+        "repo_release_tools.commands.fields_cmd.load_or_autodetect_config", return_value=config
+    ):
+        rc = cmd_fields(_make_args(sync=True))
+    assert rc == 1
+
+
+def test_list_anchor_shows_match(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    _write_json(tmp_path / "plugin.json", {"description": "same"})
+    (tmp_path / "README.md").write_text(_MD_ANCHOR_DOC.replace("old description", "same"))
+    _print_field_list([_anchor_field_target()], tmp_path)
+    captured = capsys.readouterr()
+    assert "✓" in captured.out
+    assert "anchor:self-assess-description" in captured.out
+
+
+def test_list_anchor_shows_mismatch(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    _write_json(tmp_path / "plugin.json", {"description": "new"})
+    (tmp_path / "README.md").write_text(_MD_ANCHOR_DOC)
+    _print_field_list([_anchor_field_target()], tmp_path)
+    captured = capsys.readouterr()
+    assert "MISMATCH" in captured.out

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -3822,8 +3822,18 @@ def test_load_field_target_entries_missing_path() -> None:
 def test_load_field_target_entries_missing_field() -> None:
     from repo_release_tools.config.core import _load_field_target_entries
 
-    with pytest.raises(ValueError, match="non-empty 'field'"):
+    with pytest.raises(ValueError, match="exactly one of 'field' or 'anchor'"):
         _load_field_target_entries([{"path": "marketplace.json"}])
+
+
+def test_load_field_target_entries_anchor_ok() -> None:
+    from repo_release_tools.config.core import _load_field_target_entries
+
+    entries = _load_field_target_entries(
+        [{"path": "README.md", "anchor": "self-assess-description"}]
+    )
+    assert entries[0].field is None
+    assert entries[0].anchor == "self-assess-description"
 
 
 def test_load_field_targets_target_escapes_root() -> None:

--- a/tests/tools/test_inject.py
+++ b/tests/tools/test_inject.py
@@ -1,0 +1,106 @@
+"""Tests for the anchor-based block replace/extract primitives in tools/inject.py."""
+
+from __future__ import annotations
+
+import pytest
+
+from repo_release_tools.tools.inject import extract_anchored_block, replace_anchored_block
+
+MD_DOC = (
+    "# Title\n"
+    "\n"
+    "<!-- rrt:auto:start:demo -->\n"
+    "old body\n"
+    "<!-- rrt:auto:end:demo -->\n"
+    "\n"
+    "trailing text\n"
+)
+
+MDX_DOC = (
+    "# Title\n\n{/* rrt:auto:start:demo */}\nold body\n{/* rrt:auto:end:demo */}\n\ntrailing text\n"
+)
+
+RST_DOC = (
+    "Title\n=====\n\n.. rrt:auto:start:demo\n\nold body\n\n.. rrt:auto:end:demo\n\ntrailing text\n"
+)
+
+
+@pytest.mark.parametrize(
+    ("doc", "fmt"),
+    [(MD_DOC, "md"), (MDX_DOC, "mdx"), (RST_DOC, "rst")],
+)
+def test_extract_anchored_block_returns_body(doc: str, fmt: str) -> None:
+    body = extract_anchored_block(doc, anchor_id="demo", fmt=fmt)
+    assert body is not None
+    assert "old body" in body
+    assert "trailing text" not in body
+
+
+@pytest.mark.parametrize("fmt", ["md", "mdx", "rst"])
+def test_extract_anchored_block_missing_start_returns_none(fmt: str) -> None:
+    assert extract_anchored_block("just some text\n", anchor_id="demo", fmt=fmt) is None
+
+
+@pytest.mark.parametrize(
+    ("doc", "fmt"),
+    [
+        ("<!-- rrt:auto:start:demo -->\nbody\n", "md"),
+        ("{/* rrt:auto:start:demo */}\nbody\n", "mdx"),
+        (".. rrt:auto:start:demo\n\nbody\n", "rst"),
+    ],
+)
+def test_extract_anchored_block_missing_end_raises(doc: str, fmt: str) -> None:
+    with pytest.raises(ValueError, match="Missing end anchor"):
+        extract_anchored_block(doc, anchor_id="demo", fmt=fmt)
+
+
+def test_extract_anchored_block_invalid_anchor_id_raises() -> None:
+    with pytest.raises(ValueError, match="Invalid anchor id"):
+        extract_anchored_block(MD_DOC, anchor_id="-bad", fmt="md")
+
+
+@pytest.mark.parametrize(
+    ("doc", "fmt"),
+    [(MD_DOC, "md"), (MDX_DOC, "mdx"), (RST_DOC, "rst")],
+)
+def test_replace_anchored_block_still_works_after_refactor(doc: str, fmt: str) -> None:
+    """Regression guard: extracting _find_anchor_bounds() out of
+    replace_anchored_block() must not change its existing behavior."""
+    updated = replace_anchored_block(doc, anchor_id="demo", content="new body", fmt=fmt)
+    assert updated is not None
+    assert "new body" in updated
+    assert "old body" not in updated
+    assert "trailing text" in updated
+    assert "Title" in updated
+
+
+@pytest.mark.parametrize("fmt", ["md", "mdx", "rst"])
+def test_replace_anchored_block_missing_start_returns_none(fmt: str) -> None:
+    assert (
+        replace_anchored_block("just some text\n", anchor_id="demo", content="x", fmt=fmt) is None
+    )
+
+
+@pytest.mark.parametrize(
+    ("doc", "fmt"),
+    [
+        ("<!-- rrt:auto:start:demo -->\nbody\n", "md"),
+        ("{/* rrt:auto:start:demo */}\nbody\n", "mdx"),
+        (".. rrt:auto:start:demo\n\nbody\n", "rst"),
+    ],
+)
+def test_replace_anchored_block_missing_end_raises(doc: str, fmt: str) -> None:
+    with pytest.raises(ValueError, match="Missing end anchor"):
+        replace_anchored_block(doc, anchor_id="demo", content="x", fmt=fmt)
+
+
+def test_replace_anchored_block_invalid_anchor_id_raises() -> None:
+    with pytest.raises(ValueError, match="Invalid anchor id"):
+        replace_anchored_block(MD_DOC, anchor_id="-bad", content="x", fmt="md")
+
+
+def test_extract_then_replace_round_trip() -> None:
+    body = extract_anchored_block(MD_DOC, anchor_id="demo", fmt="md")
+    assert body is not None
+    updated = replace_anchored_block(MD_DOC, anchor_id="demo", content=body, fmt="md")
+    assert updated == MD_DOC

--- a/tests/workflow/test_git_helpers.py
+++ b/tests/workflow/test_git_helpers.py
@@ -150,6 +150,115 @@ def test_run_error_detail_surfaces_last_stderr_line_not_first(
         git.run(["git", "commit", "-m", "x"], tmp_path, dry_run=False, label="git commit")
 
 
+def test_run_error_detail_ignores_trailing_passed_hook_line(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Regression test for #182: a hook that passes *after* the actually
+    failing hook must not have its "...Passed" status line mistaken for the
+    failure reason just because it happened to print last.
+    """
+
+    def fake_run(
+        cmd: list[str],
+        cwd: Path,
+        capture_output: bool,
+        text: bool,
+        check: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            cmd,
+            1,
+            stdout="",
+            stderr="rewriter.................................................Failed\n"
+            "- hook id: rewriter\n"
+            "- files were modified by this hook\n"
+            "\n"
+            "check for case conflicts.................................................Passed\n",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        git.run(["git", "commit", "-m", "x"], tmp_path, dry_run=False, label="git commit")
+
+    message = str(exc_info.value)
+    assert "files were modified by this hook" in message
+    assert "check for case conflicts" not in message
+
+
+def test_run_error_detail_multiple_failed_hooks_uses_last(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    def fake_run(
+        cmd: list[str],
+        cwd: Path,
+        capture_output: bool,
+        text: bool,
+        check: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            cmd,
+            1,
+            stdout="",
+            stderr="first-hook...............................................Failed\n"
+            "- first hook detail\n"
+            "\n"
+            "second-hook..............................................Failed\n"
+            "- second hook detail\n",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        git.run(["git", "commit", "-m", "x"], tmp_path, dry_run=False, label="git commit")
+
+    message = str(exc_info.value)
+    assert "second hook detail" in message
+    assert "first hook detail" not in message
+
+
+def test_run_error_detail_falls_back_to_last_line_without_failed_marker(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    def fake_run(
+        cmd: list[str],
+        cwd: Path,
+        capture_output: bool,
+        text: bool,
+        check: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            cmd, 128, stdout="", stderr="fatal: not a git repository\nsome other line\n"
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="some other line"):
+        git.run(["git", "status"], tmp_path, dry_run=False, label="git status")
+
+
+def test_run_error_detail_falls_back_to_stdout_when_stderr_empty(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    def fake_run(
+        cmd: list[str],
+        cwd: Path,
+        capture_output: bool,
+        text: bool,
+        check: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(cmd, 1, stdout="only stdout output\n", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="only stdout output"):
+        git.run(["git", "status"], tmp_path, dry_run=False, label="git status")
+
+
 def test_capture_and_capture_checked_strip_output(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -184,8 +293,33 @@ def test_capture_checked_raises_on_nonzero_exit(
 
     monkeypatch.setattr(subprocess, "run", fake_run)
 
-    with pytest.raises(RuntimeError, match=r"git rev-parse HEAD failed \(exit 7\)"):
+    with pytest.raises(RuntimeError, match=r"git rev-parse HEAD failed \(exit 7\): fatal"):
         git.capture_checked(["git", "rev-parse", "HEAD"], tmp_path)
+
+
+def test_capture_checked_includes_failed_hook_detail(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    def fake_run(
+        cmd: list[str],
+        cwd: Path,
+        capture_output: bool,
+        text: bool,
+        check: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            cmd,
+            1,
+            stdout="",
+            stderr="rewriter.................................................Failed\n"
+            "- files were modified by this hook\n",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="files were modified by this hook"):
+        git.capture_checked(["git", "commit", "-m", "x"], tmp_path)
 
 
 def test_current_branch_branch_exists_and_commits_ahead_delegate(


### PR DESCRIPTION
## Summary

- **#180** — `rrt fields` (JSON-only since #179) now also supports prose targets: a `[[tool.rrt.field_targets]].targets[]` entry can set `anchor` instead of `field` to sync a source value into an existing anchor block (`<!-- rrt:auto:start:<id> -->` / `{/* rrt:auto:start:<id> */}` / `.. rrt:auto:start:<id>`) in a Markdown, MDX, or RST file. Reuses the existing `tools/inject.py` primitive (`replace_anchored_block`), with a new `extract_anchored_block()` added for the `--check`/`--list` read side. A target file missing the anchor markers fails loudly (exit 1) instead of being silently skipped.
- **#182** — `workflow/git.py`'s `run()`/`capture_checked()` picked the *last* stderr line as "the" failure reason, which broke when a later pre-commit hook happened to pass after an earlier one failed — the passing hook's own `...Passed` line was reported as the failure. Both now scan for the last hook line that actually ends in `Failed` (plus its detail lines) instead of trusting stream order.

## Test plan

- [x] `uv run pytest -q -m "not runtime"` — 3237 passed, 100% coverage
- [x] `uv run ruff check` / `uv run ruff format --check` — clean
- [x] `uvx pre-commit run --all-files` — all hooks pass (ty check, docs generation, config validation, etc.)
- [x] New unit tests cover: anchor target check/sync/list across `.md`/`.mdx`/`.rst`, missing-anchor-markers failure, mixed JSON+anchor targets in one entry, and the exact #182 regression scenario (a passing hook's status line trailing after the real failure)

Closes #180
Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)