### PR TITLE
feat(git): add backport-from-target; fix(artifacts): guard vacuous check pass

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -53,12 +53,6 @@ jobs:
         run: uv sync --all-groups
 
       - name: Ruff lint
-        # Skip rrt-artifacts-check here: badge SVGs are git-ignored and generated
-        # fresh, never committed. The dedicated "Snapshot drift checks" job below
-        # regenerates them before verifying artifact integrity, so running the gate
-        # in this job (without that regen step) would fail on a clean checkout.
-        env:
-          SKIP: rrt-artifacts-check
         run: uvx pre-commit run --all-files --show-diff-on-failure
 
   verify:

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -180,7 +180,7 @@
   language: python
   pass_filenames: false
   always_run: true
-  stages: [pre-commit, pre-push]
+  stages: [manual]
   minimum_pre_commit_version: "3.2.0"
 
 - id: rrt-artifacts-snapshot

--- a/.rrt/tree.lock.toml
+++ b/.rrt/tree.lock.toml
@@ -1,10 +1,10 @@
 [meta]
-generated_at = "2026-07-17T16:55:51+00:00"
+generated_at = "2026-07-17T19:04:30+00:00"
 rrt_version = "1.14.0"
 
 [snapshot]
-entry_count = 414
-tree_hash = "sha256:b4b08850c685713ccb996106228b41ec724fe645eba2fa59786a6daa9e98fb60"
-updated_at = "2026-07-17T16:55:51+00:00"
+entry_count = 416
+tree_hash = "sha256:7de3a70fd23a5031ecbbb508e0af4182068dcb942b65c2f713641bca3ef8f616"
+updated_at = "2026-07-17T19:04:30+00:00"
 ignored_count = 34
 phantom_empty_dirs = []

--- a/docs/src/content/docs/commands/git-workflow.mdx
+++ b/docs/src/content/docs/commands/git-workflow.mdx
@@ -30,6 +30,7 @@ description: "Generated command reference for the Git Workflow command group."
   - [`rrt git rebootstrap`](#rrt-git-rebootstrap)
   - [`rrt git purge-cache`](#rrt-git-purge-cache)
   - [`rrt git publish-snapshot`](#rrt-git-publish-snapshot)
+  - [`rrt git backport-from-target`](#rrt-git-backport-from-target)
 {/* rrt:auto:end:toc */}
 
 ## `rrt branch`
@@ -248,7 +249,9 @@ summary first, followed by the details needed to act on the result.
 - **Publish**: `rrt git publish-snapshot` force-pushes a single-commit,
   no-history snapshot of tracked content to a secondary remote (e.g. a public
   mirror); `--exclude` drops specific paths (secrets, internal docs) from
-  that snapshot.
+  that snapshot. `rrt git backport-from-target` is the read-only counterpart:
+  it fetches a publish target and lists commits pending backport to the
+  primary, along with the exact commands to cherry-pick them manually.
 
 #### Responsibilities
 
@@ -290,26 +293,27 @@ Git workflow helpers for repository status, commit, sync, and history operations
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Arguments
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  status            Show a compact branch and worktree status view.
-  diff              Show a compact diff using rrt glyph formatting.
-  log               Show a compact commit history view.
-  doctor            Run a compact repository health report for rrt workflows.
-  sync-status       Analyze unresolved conflicts and whether sync/rebase work is needed.
-  check-dirty-tree  Exit non-zero when the working tree is dirty. Useful in hooks and CI.
-  commit            Create a conventional commit, inferring type from the current branch.
-  commit-all        Stage all files and create a conventional commit from the branch context.
-  squash-local      Squash local commits since upstream or a base ref into one commit.
-  sync              Fetch, stash if needed, and pull the current branch safely.
-  move              Switch branches safely by stashing and restoring local changes.
-  undo-safe         Undo a commit while keeping work staged or in the working tree.
-  rebootstrap       Destroy current git history and create a fresh repository history.
-  purge-cache       Expire reflogs and run git garbage collection.
-  publish-snapshot  Force-push a single-commit snapshot of tracked content to a secondary remote.
+  status                Show a compact branch and worktree status view.
+  diff                  Show a compact diff using rrt glyph formatting.
+  log                   Show a compact commit history view.
+  doctor                Run a compact repository health report for rrt workflows.
+  sync-status           Analyze unresolved conflicts and whether sync/rebase work is needed.
+  check-dirty-tree      Exit non-zero when the working tree is dirty. Useful in hooks and CI.
+  commit                Create a conventional commit, inferring type from the current branch.
+  commit-all            Stage all files and create a conventional commit from the branch context.
+  squash-local          Squash local commits since upstream or a base ref into one commit.
+  sync                  Fetch, stash if needed, and pull the current branch safely.
+  move                  Switch branches safely by stashing and restoring local changes.
+  undo-safe             Undo a commit while keeping work staged or in the working tree.
+  rebootstrap           Destroy current git history and create a fresh repository history.
+  purge-cache           Expire reflogs and run git garbage collection.
+  publish-snapshot      Force-push a single-commit snapshot of tracked content to a secondary remote.
+  backport-from-target  List commits pending backport from a publish-snapshot target.
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Options
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  -h, --help        Show this message and exit.
+  -h, --help            Show this message and exit.
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Examples
@@ -320,6 +324,7 @@ Examples
   $ rrt git sync
   $ rrt git undo-safe
   $ rrt git publish-snapshot --remote mirror --dry-run
+  $ rrt git backport-from-target demo
 ```
 
 ### `rrt git status`
@@ -715,4 +720,33 @@ Examples
   $ rrt git publish-snapshot demo --yes-i-know-this-overwrites-remote-history
   $ rrt git publish-snapshot --remote mirror --branch main --message "Initial commit" --yes-i-know-this-overwrites-remote-history
   $ rrt git publish-snapshot --remote mirror --exclude 'docs/internal/*' --dry-run
+```
+
+### `rrt git backport-from-target`
+
+```text
+Usage:  rrt git backport-from-target [OPTIONS] <target>
+
+Fetch a [tool.rrt.publish_targets.<name>] entry's remote/branch and list the commits present there but not on the primary's tracked branch, along with the exact git checkout -b / git cherry-pick commands to run next. Never cherry-picks, merges, or pushes on its own -- reviewing and landing a change that skipped the primary's own CI needs a human decision.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Arguments
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  <target>        Named [tool.rrt.publish_targets.<name>] entry to resolve remote/branch from.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  -h, --help      Show this message and exit.
+  --remote        Remote name or URL to fetch from. Overrides the target's configured remote.
+  --branch        Remote branch to fetch. Overrides the target's configured branch.
+  --base-ref REF  Primary-side ref to compare against. Defaults to the current branch.
+  --dry-run       Preview without changing git.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Examples
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  $ rrt git backport-from-target demo
+  $ rrt git backport-from-target demo --dry-run
+  $ rrt git backport-from-target demo --base-ref origin/main
 ```

--- a/docs/src/content/docs/commands/git_cmd.mdx
+++ b/docs/src/content/docs/commands/git_cmd.mdx
@@ -27,7 +27,9 @@ summary first, followed by the details needed to act on the result.
 - **Publish**: `rrt git publish-snapshot` force-pushes a single-commit,
   no-history snapshot of tracked content to a secondary remote (e.g. a public
   mirror); `--exclude` drops specific paths (secrets, internal docs) from
-  that snapshot.
+  that snapshot. `rrt git backport-from-target` is the read-only counterpart:
+  it fetches a publish target and lists commits pending backport to the
+  primary, along with the exact commands to cherry-pick them manually.
 
 ## Responsibilities
 

--- a/src/repo_release_tools/commands/git_backport.py
+++ b/src/repo_release_tools/commands/git_backport.py
@@ -1,0 +1,183 @@
+"""Read-only counterpart to `rrt git publish-snapshot`: list commits pending backport.
+
+`backport-from-target` fetches a `[tool.rrt.publish_targets.<name>]` entry's
+remote/branch, lists the commits present there but not on the primary's tracked
+branch, and prints the exact `git checkout -b`/`git cherry-pick` commands to run
+next. It never cherry-picks, merges, or pushes on its own -- a fix made directly
+on a disposable mirror skipped the primary's own CI, so folding it back in needs
+a human decision, not automation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from repo_release_tools.commands._git_shared import add_dry_run_flag
+from repo_release_tools.config import load_or_autodetect_config
+from repo_release_tools.ui import DryRunPrinter, VerbosePrinter
+from repo_release_tools.workflow import git
+
+
+@dataclass(frozen=True)
+class BackportOptions:
+    """Typed view of ``argparse.Namespace`` for ``rrt git backport-from-target``.
+
+    Built once via :meth:`from_args` at the top of
+    :func:`cmd_backport_from_target` so every flag has a single, typed read
+    site instead of scattered ``getattr(args, ..., default)`` calls.
+    """
+
+    verbose: int
+    target: str
+    remote: str | None
+    branch: str | None
+    base_ref: str | None
+    dry_run: bool
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> BackportOptions:
+        """Build a :class:`BackportOptions` from a parsed ``argparse.Namespace``."""
+        return cls(
+            verbose=getattr(args, "verbose", 0) or 0,
+            target=args.target,
+            remote=args.remote,
+            branch=args.branch,
+            base_ref=args.base_ref,
+            dry_run=args.dry_run,
+        )
+
+
+def _pending_commits(root: Path, base_ref: str) -> list[str]:
+    """Return ``sha subject`` lines for commits on FETCH_HEAD not in *base_ref*.
+
+    Rejects a *base_ref* starting with ``-``: the range expression
+    ``<base_ref>..FETCH_HEAD`` is a single positional argument to ``git log``
+    that cannot be guarded with a ``--`` separator (git would then treat the
+    range as a pathspec instead of a revision range), so a leading dash is
+    rejected outright to prevent option-injection (CWE-88) -- mirrors
+    ``workflow/git.py``'s ``commits_ahead`` helper, which guards the same way
+    for the same reason.
+    """
+    if base_ref.startswith("-"):
+        raise ValueError(f"base_ref must not start with '-': {base_ref!r}")
+    out = git.capture(["git", "log", f"{base_ref}..FETCH_HEAD", "--pretty=format:%h %s"], root)
+    return [line for line in out.splitlines() if line]
+
+
+def cmd_backport_from_target(args: argparse.Namespace) -> int:
+    """Fetch a publish target and list commits pending backport to the primary."""
+    opts = BackportOptions.from_args(args)
+    verbose = opts.verbose
+    root = Path.cwd()
+    if not git.is_git_repository(root):
+        p = VerbosePrinter(verbose=verbose)
+        p.line(f"{root} is not inside a Git work tree.", ok=False, stream=sys.stderr)
+        return 1
+
+    config = load_or_autodetect_config(root)
+    target = config.publish_targets.get(opts.target)
+    if target is None:
+        p = VerbosePrinter(verbose=verbose)
+        p.line(
+            f"No publish target named {opts.target!r} in [tool.rrt.publish_targets].",
+            ok=False,
+            stream=sys.stderr,
+        )
+        return 1
+
+    remote = opts.remote or target.remote
+    branch = opts.branch or target.branch
+    base_ref = opts.base_ref or (git.current_branch(root) or "HEAD")
+
+    p = DryRunPrinter(opts.dry_run, verbose=verbose)
+    p.blank_line()
+    p.header(
+        "Backport from target",
+        Target=opts.target,
+        Remote=remote,
+        Branch=branch,
+        Base=base_ref,
+    )
+    p.section("Git")
+    git.run(["git", "fetch", remote, branch], root, dry_run=opts.dry_run, label="git fetch")
+
+    if opts.dry_run:
+        p.blank_line()
+        p.footer("Done. Preview complete — fetch was not run, so no commits were listed.")
+        return 0
+
+    try:
+        commits = _pending_commits(root, base_ref)
+    except ValueError as exc:
+        p2 = VerbosePrinter(verbose=verbose)
+        p2.line(str(exc), ok=False, stream=sys.stderr)
+        return 1
+
+    if not commits:
+        p.blank_line()
+        p.footer(
+            f"Done. {branch} on {remote} has no commits ahead of {base_ref} — nothing to backport.",
+        )
+        return 0
+
+    p.section(f"Pending commits ({len(commits)})")
+    for entry in commits:
+        p.action(entry)
+
+    shas = [entry.split(" ", 1)[0] for entry in reversed(commits)]
+    backport_branch = f"backport/{opts.target}"
+    p.section("Next steps (run manually)")
+    p.action(f"git checkout -b {backport_branch} {base_ref}")
+    p.action(f"git cherry-pick {' '.join(shas)}")
+
+    p.blank_line()
+    p.footer(f"Done. {len(commits)} commit(s) pending backport from {remote}:{branch}.")
+    return 0
+
+
+GIT_BACKPORT_EXAMPLES = (
+    "  $ rrt git backport-from-target demo\n"
+    "  $ rrt git backport-from-target demo --dry-run\n"
+    "  $ rrt git backport-from-target demo --base-ref origin/main"
+)
+
+
+def register_backport(git_sub: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    """Register the ``backport-from-target`` subcommand."""
+    parser = git_sub.add_parser(
+        "backport-from-target",
+        help="List commits pending backport from a publish-snapshot target.",
+        description=(
+            "Fetch a [tool.rrt.publish_targets.<name>] entry's remote/branch and list "
+            "the commits present there but not on the primary's tracked branch, along "
+            "with the exact git checkout -b / git cherry-pick commands to run next. "
+            "Never cherry-picks, merges, or pushes on its own -- reviewing and landing "
+            "a change that skipped the primary's own CI needs a human decision."
+        ),
+        epilog=GIT_BACKPORT_EXAMPLES,
+    )
+    parser.add_argument(
+        "target",
+        help="Named [tool.rrt.publish_targets.<name>] entry to resolve remote/branch from.",
+    )
+    parser.add_argument(
+        "--remote",
+        default=None,
+        help="Remote name or URL to fetch from. Overrides the target's configured remote.",
+    )
+    parser.add_argument(
+        "--branch",
+        default=None,
+        help="Remote branch to fetch. Overrides the target's configured branch.",
+    )
+    parser.add_argument(
+        "--base-ref",
+        default=None,
+        metavar="REF",
+        help="Primary-side ref to compare against. Defaults to the current branch.",
+    )
+    add_dry_run_flag(parser)
+    parser.set_defaults(handler=cmd_backport_from_target)

--- a/src/repo_release_tools/commands/git_cmd.py
+++ b/src/repo_release_tools/commands/git_cmd.py
@@ -43,6 +43,14 @@ summary first, followed by the details needed to act on the result.
   fresh history snapshot or empty bootstrap commit.
 - `purge-cache` expires reflogs and runs `git gc` to reclaim local cache space.
 
+### Publish
+
+- `publish-snapshot` force-pushes a single-commit, no-history snapshot of tracked
+  content to a secondary remote (e.g. a public mirror).
+- `backport-from-target` is the read-only counterpart: it fetches a publish
+  target and lists commits present there but not on the primary, along with the
+  exact commands to cherry-pick them back manually.
+
 ## Behavior details
 
 - Commit subjects use conventional commit syntax with optional scope and
@@ -65,6 +73,7 @@ $ rrt git sync --dry-run
 $ rrt git squash-local --base-ref origin/main "ship parser"
 $ rrt git rebootstrap --yes-i-know-this-destroys-history --dry-run
 $ rrt git purge-cache --dry-run
+$ rrt git backport-from-target demo
 ```
 
 ## Safety notes
@@ -81,6 +90,7 @@ from __future__ import annotations
 
 import argparse
 
+from repo_release_tools.commands.git_backport import register_backport
 from repo_release_tools.commands.git_commit import register_commit
 from repo_release_tools.commands.git_inspect import register_inspect
 from repo_release_tools.commands.git_sync import register_sync
@@ -91,7 +101,8 @@ GIT_EPILOG = (
     '  $ rrt git commit --type fix "make output clearer"\n'
     "  $ rrt git sync\n"
     "  $ rrt git undo-safe\n"
-    "  $ rrt git publish-snapshot --remote mirror --dry-run"
+    "  $ rrt git publish-snapshot --remote mirror --dry-run\n"
+    "  $ rrt git backport-from-target demo"
 )
 
 
@@ -112,3 +123,4 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
     register_inspect(git_sub)
     register_commit(git_sub)
     register_sync(git_sub)
+    register_backport(git_sub)

--- a/src/repo_release_tools/state.py
+++ b/src/repo_release_tools/state.py
@@ -489,8 +489,10 @@ def artifacts_lock_is_current(
     """Compare current artifact hashes against the artifacts lockfile.
 
     Drifts on: hash mismatch, file tracked in lock but now missing, file
-    matched by a target but not yet in the lock, or input files changed
-    since the lock was written.
+    matched by a target but not yet in the lock, input files changed since the
+    lock was written, or a target's glob matching zero files with no
+    ``command`` configured to generate them (otherwise ``--check --strict``
+    would vacuously pass over an empty integrity set).
 
     Returns ``(is_current, list_of_drift_messages)``.
     """
@@ -504,6 +506,7 @@ def artifacts_lock_is_current(
     for target in artifact_targets:
         pattern = str(target.get("path", ""))
         inputs_globs: list[str] = target.get("inputs", [])  # type: ignore[assignment]
+        command: list[str] = target.get("command", [])  # type: ignore[assignment]
 
         # Input-staleness check
         if inputs_globs:
@@ -521,9 +524,13 @@ def artifacts_lock_is_current(
                     f" (target: {pattern}) — run rrt artifacts --regenerate or --snapshot"
                 )
 
-        for matched in sorted(repo_root.glob(pattern)):
-            if not matched.is_file():
-                continue
+        matched_files = [m for m in sorted(repo_root.glob(pattern)) if m.is_file()]
+        if not matched_files and not command:
+            drifted.append(
+                f"Target matched 0 files and has no command configured to generate"
+                f" them (target: {pattern}) — nothing to verify"
+            )
+        for matched in matched_files:
             rel = str(matched.relative_to(repo_root))
             seen_paths.add(rel)
             locked = locked_files.get(rel)

--- a/src/repo_release_tools/workflow/git.py
+++ b/src/repo_release_tools/workflow/git.py
@@ -20,7 +20,9 @@ summary first, followed by the details needed to act on the result.
 - **Publish**: `rrt git publish-snapshot` force-pushes a single-commit,
   no-history snapshot of tracked content to a secondary remote (e.g. a public
   mirror); `--exclude` drops specific paths (secrets, internal docs) from
-  that snapshot.
+  that snapshot. `rrt git backport-from-target` is the read-only counterpart:
+  it fetches a publish target and lists commits pending backport to the
+  primary, along with the exact commands to cherry-pick them manually.
 
 ## Responsibilities
 

--- a/tests/commands/test_artifacts_cmd.py
+++ b/tests/commands/test_artifacts_cmd.py
@@ -603,6 +603,65 @@ class TestCmdArtifactsCheckStaleness:
 
 
 # ---------------------------------------------------------------------------
+# cmd_artifacts --check with a target matching zero files (vacuous-pass guard)
+# ---------------------------------------------------------------------------
+
+
+class TestCmdArtifactsCheckZeroMatch:
+    """Tests for the zero-match/no-command drift guard in artifacts_lock_is_current."""
+
+    def test_check_strict_fails_on_zero_match_no_command(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        config = _make_config(tmp_path, targets=[{"path": "badges/*.svg"}])
+        monkeypatch.chdir(tmp_path)
+        with unittest.mock.patch(
+            "repo_release_tools.commands.artifacts_cmd.load_or_autodetect_config",
+            return_value=config,
+        ):
+            cmd_artifacts(_make_args(snapshot=True))
+            rc = cmd_artifacts(_make_args(check=True, strict=True))
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "matched 0 files" in err
+
+    def test_check_advisory_warns_on_zero_match_no_command(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        config = _make_config(tmp_path, targets=[{"path": "badges/*.svg"}])
+        monkeypatch.chdir(tmp_path)
+        with unittest.mock.patch(
+            "repo_release_tools.commands.artifacts_cmd.load_or_autodetect_config",
+            return_value=config,
+        ):
+            cmd_artifacts(_make_args(snapshot=True))
+            rc = cmd_artifacts(_make_args(check=True))
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "matched 0 files" in out
+
+    def test_check_zero_match_with_command_configured_is_silent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        target = ArtifactTarget(path="badges/*.svg", description="", command=["true"], inputs=[])
+        config = _make_config(tmp_path, artifact_targets=[target])
+        monkeypatch.chdir(tmp_path)
+        with unittest.mock.patch(
+            "repo_release_tools.commands.artifacts_cmd.load_or_autodetect_config",
+            return_value=config,
+        ):
+            cmd_artifacts(_make_args(snapshot=True))
+            rc = cmd_artifacts(_make_args(check=True, strict=True))
+        assert rc == 0
+
+
+# ---------------------------------------------------------------------------
 # cmd_artifacts --dry-run validation
 # ---------------------------------------------------------------------------
 

--- a/tests/commands/test_git_backport.py
+++ b/tests/commands/test_git_backport.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import argparse
+import pathlib
+
+import pytest
+
+from repo_release_tools.commands import git_backport
+from repo_release_tools.config.model import PublishTarget, RrtConfig
+
+
+def test_register_adds_git_backport_from_target_parser() -> None:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    git_sub = subparsers.add_parser("git")
+    inner = git_sub.add_subparsers(dest="git_command", parser_class=type(git_sub))
+    git_backport.register_backport(inner)
+
+    args = parser.parse_args(["git", "backport-from-target", "demo", "--remote", "mirror"])
+
+    assert args.command == "git"
+    assert args.git_command == "backport-from-target"
+    assert args.target == "demo"
+    assert args.remote == "mirror"
+    assert args.handler.__name__ == "cmd_backport_from_target"
+
+
+def test_backport_requires_git_repository(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(git_backport.git, "is_git_repository", lambda root: False)
+    args = argparse.Namespace(target="demo", remote=None, branch=None, base_ref=None, dry_run=False)
+    assert git_backport.cmd_backport_from_target(args) == 1
+    assert "is not inside a Git work tree" in capsys.readouterr().err
+
+
+def test_backport_rejects_unknown_config_target(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config = RrtConfig(root=tmp_path, config_file=tmp_path / "pyproject.toml", version_groups=[])
+    monkeypatch.setattr(git_backport, "load_or_autodetect_config", lambda root: config)
+    monkeypatch.setattr(git_backport.git, "is_git_repository", lambda root: True)
+    args = argparse.Namespace(
+        target="missing", remote=None, branch=None, base_ref=None, dry_run=False
+    )
+    monkeypatch.chdir(tmp_path)
+    assert git_backport.cmd_backport_from_target(args) == 1
+    err = capsys.readouterr().err
+    assert "No publish target named 'missing'" in err
+
+
+def _config_with_demo_target(tmp_path: pathlib.Path) -> RrtConfig:
+    return RrtConfig(
+        root=tmp_path,
+        config_file=tmp_path / "pyproject.toml",
+        version_groups=[],
+        publish_targets={"demo": PublishTarget(remote="mirror", branch="main")},
+    )
+
+
+def test_backport_rejects_base_ref_starting_with_dash(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config = _config_with_demo_target(tmp_path)
+    monkeypatch.setattr(git_backport, "load_or_autodetect_config", lambda root: config)
+    monkeypatch.setattr(git_backport.git, "is_git_repository", lambda root: True)
+    monkeypatch.setattr(git_backport.git, "current_branch", lambda root: "main")
+    monkeypatch.setattr(git_backport.git, "run", lambda cmd, cwd, *, dry_run, label: "")
+
+    args = argparse.Namespace(
+        target="demo", remote=None, branch=None, base_ref="--force", dry_run=False
+    )
+    monkeypatch.chdir(tmp_path)
+    assert git_backport.cmd_backport_from_target(args) == 1
+    assert "must not start with '-'" in capsys.readouterr().err
+
+
+def test_backport_happy_path_lists_commits_and_prints_next_steps(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config = _config_with_demo_target(tmp_path)
+    monkeypatch.setattr(git_backport, "load_or_autodetect_config", lambda root: config)
+    monkeypatch.setattr(git_backport.git, "is_git_repository", lambda root: True)
+    monkeypatch.setattr(git_backport.git, "current_branch", lambda root: "main")
+
+    fetch_commands: list[list[str]] = []
+    monkeypatch.setattr(
+        git_backport.git,
+        "run",
+        lambda cmd, cwd, *, dry_run, label: fetch_commands.append(cmd) or "",
+    )
+    monkeypatch.setattr(
+        git_backport.git,
+        "capture",
+        lambda cmd, cwd: "def5678 fix docs\nabc1234 tweak workflow",
+    )
+
+    args = argparse.Namespace(target="demo", remote=None, branch=None, base_ref=None, dry_run=False)
+    monkeypatch.chdir(tmp_path)
+    assert git_backport.cmd_backport_from_target(args) == 0
+
+    assert fetch_commands == [["git", "fetch", "mirror", "main"]]
+
+    out = capsys.readouterr().out
+    assert "def5678 fix docs" in out
+    assert "abc1234 tweak workflow" in out
+    assert "git checkout -b backport/demo main" in out
+    # Cherry-pick order must be oldest-first (reversed from git log's newest-first).
+    assert "git cherry-pick abc1234 def5678" in out
+
+
+def test_backport_dry_run_skips_fetch_and_listing(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config = _config_with_demo_target(tmp_path)
+    monkeypatch.setattr(git_backport, "load_or_autodetect_config", lambda root: config)
+    monkeypatch.setattr(git_backport.git, "is_git_repository", lambda root: True)
+    monkeypatch.setattr(git_backport.git, "current_branch", lambda root: "main")
+
+    run_calls: list[tuple[list[str], bool]] = []
+    monkeypatch.setattr(
+        git_backport.git,
+        "run",
+        lambda cmd, cwd, *, dry_run, label: run_calls.append((cmd, dry_run)) or "",
+    )
+
+    def _unexpected_capture(cmd: list[str], cwd: pathlib.Path) -> str:
+        raise AssertionError("capture should not be called in dry-run mode")
+
+    monkeypatch.setattr(git_backport.git, "capture", _unexpected_capture)
+
+    args = argparse.Namespace(target="demo", remote=None, branch=None, base_ref=None, dry_run=True)
+    monkeypatch.chdir(tmp_path)
+    assert git_backport.cmd_backport_from_target(args) == 0
+    assert run_calls == [(["git", "fetch", "mirror", "main"], True)]
+    assert "[DRY RUN]" in capsys.readouterr().out
+
+
+def test_backport_no_pending_commits_returns_friendly_message(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config = _config_with_demo_target(tmp_path)
+    monkeypatch.setattr(git_backport, "load_or_autodetect_config", lambda root: config)
+    monkeypatch.setattr(git_backport.git, "is_git_repository", lambda root: True)
+    monkeypatch.setattr(git_backport.git, "current_branch", lambda root: "main")
+    monkeypatch.setattr(git_backport.git, "run", lambda cmd, cwd, *, dry_run, label: "")
+    monkeypatch.setattr(git_backport.git, "capture", lambda cmd, cwd: "")
+
+    args = argparse.Namespace(target="demo", remote=None, branch=None, base_ref=None, dry_run=False)
+    monkeypatch.chdir(tmp_path)
+    assert git_backport.cmd_backport_from_target(args) == 0
+    assert "nothing to backport" in capsys.readouterr().out.lower()
+
+
+def test_backport_remote_branch_base_ref_overrides(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = _config_with_demo_target(tmp_path)
+    monkeypatch.setattr(git_backport, "load_or_autodetect_config", lambda root: config)
+    monkeypatch.setattr(git_backport.git, "is_git_repository", lambda root: True)
+    monkeypatch.setattr(git_backport.git, "current_branch", lambda root: "main")
+
+    fetch_commands: list[list[str]] = []
+    monkeypatch.setattr(
+        git_backport.git,
+        "run",
+        lambda cmd, cwd, *, dry_run, label: fetch_commands.append(cmd) or "",
+    )
+    log_ranges: list[str] = []
+
+    def _capture(cmd: list[str], cwd: pathlib.Path) -> str:
+        log_ranges.append(cmd[2])
+        return ""
+
+    monkeypatch.setattr(git_backport.git, "capture", _capture)
+
+    args = argparse.Namespace(
+        target="demo",
+        remote="override-remote",
+        branch="override-branch",
+        base_ref="origin/main",
+        dry_run=False,
+    )
+    monkeypatch.chdir(tmp_path)
+    assert git_backport.cmd_backport_from_target(args) == 0
+    assert fetch_commands == [["git", "fetch", "override-remote", "override-branch"]]
+    assert log_ranges == ["origin/main..FETCH_HEAD"]

--- a/tests/core/test_state.py
+++ b/tests/core/test_state.py
@@ -597,8 +597,18 @@ class TestArtifactsLockIsCurrent:
         assert not ok
         assert any("missing" in m.lower() for m in msgs)
 
-    def test_no_drift_empty_lock_empty_files(self, tmp_path: Path) -> None:
+    def test_drift_on_zero_match_with_no_command(self, tmp_path: Path) -> None:
+        """A target matching 0 files with no command must not vacuously pass."""
         targets = [{"path": "*.png", "description": ""}]
+        lock_path = tmp_path / "artifacts.lock.toml"
+        write_lock(lock_path, build_artifacts_lock(targets, tmp_path))
+        ok, msgs = artifacts_lock_is_current(lock_path, targets, tmp_path)
+        assert not ok
+        assert any("matched 0 files" in m for m in msgs)
+
+    def test_no_drift_empty_lock_empty_files_with_command(self, tmp_path: Path) -> None:
+        """A target matching 0 files stays silent when a regenerate command is configured."""
+        targets = [{"path": "*.png", "description": "", "command": ["true"]}]
         lock_path = tmp_path / "artifacts.lock.toml"
         write_lock(lock_path, build_artifacts_lock(targets, tmp_path))
         ok, msgs = artifacts_lock_is_current(lock_path, targets, tmp_path)
@@ -750,7 +760,7 @@ class TestArtifactsLockIsCurrentWithInputs:
         current_hash = _compute_inputs_hash(["*.py"], tmp_path)
         assert current_hash is not None
         lock_path = self._make_lock_with_inputs(tmp_path, current_hash)
-        targets = [{"path": "*.svg", "description": "", "command": [], "inputs": ["*.py"]}]
+        targets = [{"path": "*.svg", "description": "", "command": ["true"], "inputs": ["*.py"]}]
         is_ok, msgs = artifacts_lock_is_current(lock_path, targets, tmp_path)
         assert is_ok
         assert msgs == []


### PR DESCRIPTION
## Summary

Two independent fixes, bundled per request:

- **#173** — new `rrt git backport-from-target <target-name>` command: the read-only counterpart to `rrt git publish-snapshot`. Fetches a `[tool.rrt.publish_targets.<name>]` entry, lists commits present on the target's branch but not on the primary, and prints the exact `git checkout -b`/`git cherry-pick` commands to run manually. It never cherry-picks, merges, or pushes itself — landing a change that skipped the primary's own CI needs a human call.
- **#110** — `rrt artifacts --check --strict` no longer vacuously passes when a target's glob matches zero files and no `command` is configured to generate them (previously an empty match set produced an empty drift list, i.e. false confidence instead of a real check). Also republishes the already-locally-corrected `rrt-artifacts-check` hook stage (`[manual]` instead of `[pre-commit, pre-push]`) in `.pre-commit-hooks.yaml`, and removes the now-redundant `SKIP: rrt-artifacts-check` workaround from the lint job.

## Test plan

- [x] `uv run pytest -q -m "not runtime"` — 3249 passed, 100% coverage
- [x] `uvx pre-commit run --all-files` — all hooks pass (pre-existing, unrelated branch-name warning aside from before this branch existed)
- [x] Manually verified `rrt artifacts --check --strict` fails on missing badge SVGs and passes once regenerated
- [x] Manually exercised `rrt git backport-from-target` argparse wiring and dry-run/live behavior via unit tests

Closes #173
Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)