### PR TITLE
feat(bump,tag): batch --group across multiple version_groups

### DIFF
--- a/.rrt/tree.lock.toml
+++ b/.rrt/tree.lock.toml
@@ -1,10 +1,10 @@
 [meta]
-generated_at = "2026-07-17T19:04:30+00:00"
+generated_at = "2026-07-30T05:03:14+00:00"
 rrt_version = "1.14.0"
 
 [snapshot]
-entry_count = 416
-tree_hash = "sha256:7de3a70fd23a5031ecbbb508e0af4182068dcb942b65c2f713641bca3ef8f616"
-updated_at = "2026-07-17T19:04:30+00:00"
+entry_count = 417
+tree_hash = "sha256:968a0224c04c06903cf5b87824519313aece4b030658a772b63d0bf7403ff269"
+updated_at = "2026-07-30T05:03:14+00:00"
 ignored_count = 34
 phantom_empty_dirs = []

--- a/docs/src/content/docs/commands/version-release.mdx
+++ b/docs/src/content/docs/commands/version-release.mdx
@@ -168,6 +168,14 @@ rrt bump minor --group backend
 rrt bump patch --group sdk
 ```
 
+Bump several groups in one invocation with a comma-separated list -- each
+group gets its own release branch and commit, identical to running the
+command once per group:
+
+```bash
+rrt bump patch --group backend,sdk
+```
+
 When a single group is configured, `--group` is optional. With multiple
 groups, set `default_group_name` to select the default:
 
@@ -213,7 +221,7 @@ Content
 Git
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   --base-branch BRANCH    Branch to base the release on.
-  --group GROUP           Version group to bump when multiple groups are configured.
+  --group GROUP           Version group to bump when multiple groups are configured. Pass a comma-separated list (e.g. 'a,b,c') to bump several groups in one invocation, each with its own release branch and commit.
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Examples
@@ -222,6 +230,7 @@ Examples
   $ rrt bump minor --dry-run
   $ rrt bump 2.1.0 --no-changelog --no-commit
   $ rrt bump major --base-branch develop
+  $ rrt bump patch --group self-assess,cupertino,confab
 ```
 
 ## `rrt changelog`
@@ -1022,12 +1031,12 @@ Arguments
 Options
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   -h, --help       Show this message and exit.
-  --prefix PREFIX  Tag prefix (default: 'v'). Pass empty string for no prefix.
+  --prefix PREFIX  Tag prefix (default: 'v'). Pass empty string for no prefix. Include the '{group}' token to render each group's name when --group lists multiple groups (e.g. '{group}-v').
   --message MSG    Annotation message. Defaults to 'Release <tag>'.
   --push           Push the tag to origin after creating it.
   --force          Delete and recreate the tag if it already exists.
   --dry-run        Preview what would happen without making changes.
-  --group GROUP    Version group to read when multiple groups are configured.
+  --group GROUP    Version group to read when multiple groups are configured. Pass a comma-separated list (e.g. 'a,b,c') to tag several groups in one invocation; --prefix must then include the '{group}' token.
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Examples
@@ -1035,8 +1044,10 @@ Examples
   $ rrt tag create
   $ rrt tag create --push
   $ rrt tag create --prefix '' --message 'Release 1.2.3'
+  $ rrt tag create --group backend,sdk --prefix '{group}-v'
   $ rrt tag check
   $ rrt tag check --strict
+  $ rrt tag check --group backend,sdk --prefix '{group}-v'
 ```
 
 ### `rrt tag check`
@@ -1054,9 +1065,9 @@ Arguments
 Options
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   -h, --help       Show this message and exit.
-  --prefix PREFIX  Expected tag prefix (default: 'v').
+  --prefix PREFIX  Expected tag prefix (default: 'v'). Include the '{group}' token to render each group's name when --group lists multiple groups (e.g. '{group}-v').
   --strict         Fail if the expected tag for the current version is missing.
-  --group GROUP    Version group to read when multiple groups are configured.
+  --group GROUP    Version group to read when multiple groups are configured. Pass a comma-separated list (e.g. 'a,b,c') to check several groups in one invocation; --prefix must then include the '{group}' token.
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Examples
@@ -1064,6 +1075,8 @@ Examples
   $ rrt tag create
   $ rrt tag create --push
   $ rrt tag create --prefix '' --message 'Release 1.2.3'
+  $ rrt tag create --group backend,sdk --prefix '{group}-v'
   $ rrt tag check
   $ rrt tag check --strict
+  $ rrt tag check --group backend,sdk --prefix '{group}-v'
 ```

--- a/src/repo_release_tools/commands/_common.py
+++ b/src/repo_release_tools/commands/_common.py
@@ -88,3 +88,29 @@ def describe_config_load_error(
             text=format_missing_tool_rrt_guidance(root, iter_config_files(root)),
         )
     return ConfigLoadError(kind="other", text=str(exc))
+
+
+def parse_group_names(raw: str) -> list[str]:
+    """Split a comma-separated ``--group`` value into stripped, non-empty names.
+
+    Mirrors ``workspace.py``'s ``_resolve_packages`` split/strip/drop-empty
+    idiom for ``--packages``, minus the path resolution (group names are
+    just config lookups via ``config.resolve_group(name)``). Order is
+    preserved so error messages and per-group output stay predictable.
+    """
+    return [part.strip() for part in raw.split(",") if part.strip()]
+
+
+def find_duplicate_group_names(names: list[str]) -> list[str]:
+    """Return distinct names that appear more than once, in first-seen order.
+
+    A duplicate in a ``--group a,a,b`` batch is almost certainly a typo, so
+    callers reject it outright rather than silently processing it twice.
+    """
+    seen: set[str] = set()
+    dupes: list[str] = []
+    for name in names:
+        if name in seen and name not in dupes:
+            dupes.append(name)
+        seen.add(name)
+    return dupes

--- a/src/repo_release_tools/commands/bump.py
+++ b/src/repo_release_tools/commands/bump.py
@@ -78,7 +78,11 @@ from repo_release_tools.changelog import (
     insert_generated_section,
     promote_unreleased,
 )
-from repo_release_tools.commands._common import describe_config_load_error
+from repo_release_tools.commands._common import (
+    describe_config_load_error,
+    find_duplicate_group_names,
+    parse_group_names,
+)
 from repo_release_tools.commands._version_render import render_version_write_events
 from repo_release_tools.config import (
     RrtConfig,
@@ -88,7 +92,12 @@ from repo_release_tools.config import (
     iter_config_files,  # noqa: F401 -- re-exported for test monkeypatch compatibility
     load_or_autodetect_config,
 )
-from repo_release_tools.preflight import PreflightError, run_preflight
+from repo_release_tools.preflight import (
+    PreflightError,
+    check_config_consistent,
+    check_version_targets_readable,
+    run_preflight,
+)
 from repo_release_tools.ui import (
     GLYPHS,
     DryRunPrinter,
@@ -563,6 +572,143 @@ class Options:
         )
 
 
+def _cmd_bump_batch(
+    opts: Options,
+    config: RrtConfig,
+    root: Path,
+    group_names: list[str],
+) -> int:
+    """Bump every group in *group_names* in one invocation (issue #191).
+
+    Reuses every per-group helper ``cmd_bump`` already has --
+    :func:`resolve_bump_target`, :func:`run_preflight`, :func:`apply_bump_files`,
+    :func:`resolve_changelog_mode`, :func:`update_changelog`,
+    :func:`refresh_bump_lockfile`, :func:`refresh_bump_generated_assets`, and
+    :func:`finalize_bump_git` -- unchanged. Each group gets its own release
+    branch and commit, identical to running ``rrt bump`` once per group by
+    hand. Every group is resolved and validated before anything is written
+    (fail-fast, no partial state); any failure -- in validation or during
+    apply -- stops the whole batch immediately.
+    """
+    verbose = opts.verbose
+
+    if opts.no_commit:
+        VerbosePrinter(verbose=verbose).line(
+            "--no-commit is not supported with a multi-group --group batch (each "
+            "group's checkout would carry the previous group's uncommitted changes "
+            "onto the next branch); commit each group or bump one at a time.",
+            ok=False,
+            stream=sys.stderr,
+        )
+        return 1
+
+    # --- Phase 1: resolve and validate every group before writing anything -----
+    validated: list[tuple[BumpTarget, str]] = []
+    for name in group_names:
+        sub_opts = dataclasses.replace(opts, group=name)
+        try:
+            target = resolve_bump_target(config, sub_opts)
+        except BumpResolutionError as exc:
+            VerbosePrinter(verbose=verbose).line(str(exc), ok=False, stream=sys.stderr)
+            return 1
+
+        branch_name = target.group.release_branch.format(version=target.new)
+        if not opts.dry_run:
+            try:
+                check_config_consistent(config)
+                check_version_targets_readable(target.group)
+            except PreflightError as exc:
+                VerbosePrinter(verbose=verbose).line(str(exc), ok=False, stream=sys.stderr)
+                return 1
+            if git.branch_exists(root, branch_name) and not opts.force:
+                VerbosePrinter(verbose=verbose).line(
+                    f"Branch '{branch_name}' already exists. Delete it first or "
+                    "choose a different version.",
+                    ok=False,
+                    stream=sys.stderr,
+                )
+                return 1
+
+        validated.append((target, branch_name))
+
+    # --- Phase 2: apply every group ---------------------------------------------
+    pr = DryRunPrinter(opts.dry_run, verbose=verbose)
+    pr.blank_line()
+    pr.header("Version bump", Groups=str(len(validated)), Bump=opts.bump)
+
+    for target, branch_name in validated:
+        group, current, new = target.group, target.current, target.new
+        current_branch = "<current>" if opts.dry_run else git.current_branch(root)
+        base = opts.base_branch or current_branch
+
+        pr.section(f"{group.name}: {current} {GLYPHS.arrow.right} {new}")
+        pr.meta("Branch", branch_name)
+        pr.meta("Base", base)
+
+        try:
+            run_preflight(config, dry_run=opts.dry_run, group=group)
+        except PreflightError as exc:
+            VerbosePrinter(verbose=verbose).line(str(exc), ok=False, stream=sys.stderr)
+            return 1
+
+        if not opts.dry_run:
+            branch_exists = git.branch_exists(root, branch_name)
+            if current_branch != base:
+                git.run(["git", "checkout", base], root, dry_run=False, label="git checkout base")
+            if branch_exists:
+                VerbosePrinter(verbose=verbose).line(
+                    f"Branch '{branch_name}' already exists. Resetting it with --force."
+                )
+
+        pr.section("Updating version strings")
+
+        all_pins = group.pin_targets + config.global_pin_targets
+        no_pin_sync = opts.no_pin_sync
+        if all_pins and not no_pin_sync:
+            pr.section("Updating doc pins")
+
+        apply_group = dataclasses.replace(group, pin_targets=[]) if no_pin_sync else group
+        apply_config = dataclasses.replace(config, global_pin_targets=[]) if no_pin_sync else config
+        changed_paths = apply_bump_files(apply_group, new, apply_config, dry_run=opts.dry_run)
+
+        if not opts.no_changelog:
+            effective_changelog_mode = resolve_changelog_mode(group, opts.changelog_mode)
+            update_changelog(
+                RrtConfig(
+                    root=config.root,
+                    config_file=config.config_file,
+                    version_groups=[group],
+                    default_group_name=group.name,
+                ),
+                str(new),
+                include_maintenance=opts.include_maintenance,
+                dry_run=opts.dry_run,
+                changelog_mode=effective_changelog_mode,
+            )
+
+        if group.lock_command and not opts.no_update:
+            refresh_bump_lockfile(group, root, dry_run=opts.dry_run, verbose=verbose)
+
+        if group.generated_assets and not opts.no_update:
+            if not refresh_bump_generated_assets(
+                group, root, dry_run=opts.dry_run, verbose=verbose
+            ):
+                return 1
+
+        finalize_bump_git(
+            group,
+            new,
+            changed_paths,
+            root,
+            branch_name=branch_name,
+            base=base,
+            force=opts.force,
+            opts=opts,
+        )
+
+    return 0
+
+
 def cmd_bump(args: argparse.Namespace) -> int:
     """Bump project version using [tool.rrt]."""
     opts = Options.from_args(args)
@@ -590,6 +736,23 @@ def cmd_bump(args: argparse.Namespace) -> int:
         if mismatch := check_autodetected_version_consistency(config):
             p.line(mismatch, ok=False, stream=sys.stderr)
             return 1
+
+    if opts.group is not None and "," in opts.group:
+        group_names = parse_group_names(opts.group)
+        if not group_names:
+            p = VerbosePrinter(verbose=verbose)
+            p.line(f"--group has no valid group names: {opts.group!r}", ok=False, stream=sys.stderr)
+            return 1
+        if dupes := find_duplicate_group_names(group_names):
+            p = VerbosePrinter(verbose=verbose)
+            p.line(
+                "Duplicate group name(s) in --group: "
+                f"{', '.join(repr(d) for d in dupes)}. Each group may be listed only once.",
+                ok=False,
+                stream=sys.stderr,
+            )
+            return 1
+        return _cmd_bump_batch(opts, config, root, group_names)
 
     try:
         target = resolve_bump_target(config, opts)
@@ -692,7 +855,8 @@ _BUMP_EXAMPLES = (
     "  $ rrt bump patch\n"
     "  $ rrt bump minor --dry-run\n"
     "  $ rrt bump 2.1.0 --no-changelog --no-commit\n"
-    "  $ rrt bump major --base-branch develop"
+    "  $ rrt bump major --base-branch develop\n"
+    "  $ rrt bump patch --group self-assess,cupertino,confab"
 )
 
 
@@ -778,7 +942,11 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
         "--group",
         default=None,
         metavar="GROUP",
-        help="Version group to bump when multiple groups are configured.",
+        help=(
+            "Version group to bump when multiple groups are configured. "
+            "Pass a comma-separated list (e.g. 'a,b,c') to bump several groups "
+            "in one invocation, each with its own release branch and commit."
+        ),
     )
     parser.set_defaults(handler=cmd_bump)
 
@@ -890,6 +1058,14 @@ Bump a specific group:
 ```bash
 rrt bump minor --group backend
 rrt bump patch --group sdk
+```
+
+Bump several groups in one invocation with a comma-separated list -- each
+group gets its own release branch and commit, identical to running the
+command once per group:
+
+```bash
+rrt bump patch --group backend,sdk
 ```
 
 When a single group is configured, `--group` is optional. With multiple

--- a/src/repo_release_tools/commands/tag.py
+++ b/src/repo_release_tools/commands/tag.py
@@ -66,8 +66,13 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-from repo_release_tools.commands._common import describe_config_load_error
+from repo_release_tools.commands._common import (
+    describe_config_load_error,
+    find_duplicate_group_names,
+    parse_group_names,
+)
 from repo_release_tools.config import (
+    VersionGroup,
     find_repo_root,
     iter_config_files,
     load_or_autodetect_config,
@@ -82,6 +87,17 @@ def _git(args: list[str], cwd: Path, *, check: bool = True) -> subprocess.Comple
 
 def _tag_name(version: str, prefix: str) -> str:
     return f"{prefix}{version}"
+
+
+def _tag_name_for_group(version: str, prefix: str, group_name: str) -> str:
+    """Render --prefix's {group} token (batch mode only), then build the tag name.
+
+    Uses ``str.replace``, not ``str.format``: a plain ``.format(group=...)``
+    would raise ``KeyError`` on any *other* stray ``{...}`` in a user's custom
+    prefix (e.g. ``--prefix "release-{build}"``). ``.replace`` only ever
+    touches the one documented token and is a no-op for any prefix without it.
+    """
+    return f"{prefix.replace('{group}', group_name)}{version}"
 
 
 def _load_config_and_version(root: Path, group_name: str | None) -> tuple[object, str] | None:
@@ -161,11 +177,122 @@ class TagCreateOptions:
         )
 
 
+def _cmd_tag_create_batch(opts: TagCreateOptions, root: Path, group_names: list[str]) -> int:
+    """Create tags for every group in *group_names* in one invocation (issue #191).
+
+    Validates every group name and checks every tag for a pre-existing
+    conflict before creating any tag (fail-fast, no partial state) --
+    mirrors ``_cmd_bump_batch``'s two-phase design.
+    """
+    verbose = opts.verbose
+    try:
+        config = load_or_autodetect_config(root)
+    except FileNotFoundError as exc:
+        err = describe_config_load_error(exc, root, no_config_file_checked=iter_config_files(root))
+        VerbosePrinter(verbose=verbose).line(err.text, ok=False, stream=sys.stderr)
+        return 1
+    except (ValueError, RuntimeError) as exc:
+        err = describe_config_load_error(exc, root)
+        p = VerbosePrinter(verbose=verbose)
+        if err.kind == "missing_tool_rrt":
+            p.line("No [tool.rrt] configuration found.", ok=False, stream=sys.stderr)
+        else:
+            p.line(err.text, ok=False, stream=sys.stderr)
+        return 1
+
+    existing = _existing_tags(root)
+
+    # --- Phase 1: resolve and validate every group before tagging anything -----
+    validated: list[tuple[VersionGroup, str, str]] = []
+    for name in group_names:
+        try:
+            group = config.resolve_group(name)
+        except ValueError as exc:
+            VerbosePrinter(verbose=verbose).line(str(exc), ok=False, stream=sys.stderr)
+            return 1
+        version = str(read_group_current_version(group))
+        tag = _tag_name_for_group(version, opts.prefix, group.name)
+        if tag in existing and not opts.force:
+            VerbosePrinter(verbose=verbose).line(
+                f"Tag '{tag}' already exists (group {group.name!r}). Use --force to overwrite.",
+                ok=False,
+                stream=sys.stderr,
+            )
+            return 1
+        validated.append((group, version, tag))
+
+    # --- Phase 2: create every tag -----------------------------------------------
+    p = DryRunPrinter(opts.dry_run, verbose=verbose)
+    p.blank_line()
+    p.header("Tag create", Groups=str(len(validated)))
+
+    for group, _version, tag in validated:
+        msg = opts.message or f"Release {tag}"
+        p.section(group.name)
+        p.meta("Tag", tag)
+        p.meta("Message", msg)
+
+        if opts.dry_run:
+            p.line(f"would run: git tag -a {tag} -m {msg!r}")
+            continue
+
+        try:
+            if tag in existing and opts.force:
+                _git(["git", "tag", "-d", tag], root)
+            _git(["git", "tag", "-a", tag, "-m", msg], root)
+        except subprocess.CalledProcessError as exc:
+            VerbosePrinter(verbose=verbose).line(
+                f"git tag failed: {exc.stderr.strip()}", ok=False, stream=sys.stderr
+            )
+            return 1
+        p.ok(f"Created tag {tag!r}")
+
+        if opts.push:
+            try:
+                _git(["git", "push", "origin", tag], root)
+                p.ok(f"Pushed {tag!r} to origin")
+            except subprocess.CalledProcessError as exc:
+                VerbosePrinter(verbose=verbose).line(
+                    f"git push failed: {exc.stderr.strip()}", ok=False, stream=sys.stderr
+                )
+                return 1
+
+    if opts.dry_run:
+        p.line("no changes were made")
+
+    return 0
+
+
 def cmd_tag_create(args: argparse.Namespace) -> int:
     """Create an annotated git tag matching the current configured version."""
     opts = TagCreateOptions.from_args(args)
     verbose = opts.verbose
     root = find_repo_root(Path.cwd())
+
+    if opts.group is not None and "," in opts.group:
+        group_names = parse_group_names(opts.group)
+        if not group_names:
+            VerbosePrinter(verbose=verbose).line(
+                f"--group has no valid group names: {opts.group!r}", ok=False, stream=sys.stderr
+            )
+            return 1
+        if dupes := find_duplicate_group_names(group_names):
+            VerbosePrinter(verbose=verbose).line(
+                "Duplicate group name(s) in --group: "
+                f"{', '.join(repr(d) for d in dupes)}. Each group may be listed only once.",
+                ok=False,
+                stream=sys.stderr,
+            )
+            return 1
+        if "{group}" not in opts.prefix:
+            VerbosePrinter(verbose=verbose).line(
+                "--prefix must include the '{group}' placeholder when --group lists "
+                f"multiple groups (got --prefix {opts.prefix!r}). Example: --prefix '{{group}}-v'.",
+                ok=False,
+                stream=sys.stderr,
+            )
+            return 1
+        return _cmd_tag_create_batch(opts, root, group_names)
 
     result = _load_config_and_version(root, opts.group)
     if result is None:
@@ -251,11 +378,105 @@ class TagCheckOptions:
         )
 
 
+def _cmd_tag_check_batch(opts: TagCheckOptions, root: Path, group_names: list[str]) -> int:
+    """Check tags for every group in *group_names*, aggregating results (issue #191).
+
+    Read-only, so unlike the bump/tag-create batches this evaluates every
+    group even after one fails -- there is no "apply" step to protect, and a
+    user wants to see every group's mismatches in one pass, not stop at the
+    first. Each group is checked with the exact single-group logic
+    ``cmd_tag_check`` already uses, just with ``{group}`` rendered to that
+    group's name in the expected prefix.
+    """
+    verbose = opts.verbose
+    try:
+        config = load_or_autodetect_config(root)
+    except FileNotFoundError as exc:
+        err = describe_config_load_error(exc, root, no_config_file_checked=iter_config_files(root))
+        VerbosePrinter(verbose=verbose).line(err.text, ok=False, stream=sys.stderr)
+        return 1
+    except (ValueError, RuntimeError) as exc:
+        err = describe_config_load_error(exc, root)
+        p = VerbosePrinter(verbose=verbose)
+        if err.kind == "missing_tool_rrt":
+            p.line("No [tool.rrt] configuration found.", ok=False, stream=sys.stderr)
+        else:
+            p.line(err.text, ok=False, stream=sys.stderr)
+        return 1
+
+    resolved: list[tuple[VersionGroup, str]] = []
+    for name in group_names:
+        try:
+            group = config.resolve_group(name)
+        except ValueError as exc:
+            VerbosePrinter(verbose=verbose).line(str(exc), ok=False, stream=sys.stderr)
+            return 1
+        resolved.append((group, str(read_group_current_version(group))))
+
+    existing_tags = _existing_tags(root)
+    p = VerbosePrinter(verbose=verbose)
+    p.blank_line()
+    p.header("Tag check", Groups=str(len(resolved)), Total=str(len(existing_tags)))
+
+    any_errors = False
+    for group, version in resolved:
+        group_prefix = opts.prefix.replace("{group}", group.name)
+        expected_tag = f"{group_prefix}{version}"
+        p.section(group.name)
+
+        errors: list[str] = []
+        for tag in existing_tags:
+            if not tag.startswith(group_prefix):
+                errors.append(f"Tag '{tag}' does not match prefix '{group_prefix}'")
+
+        if expected_tag not in existing_tags:
+            if opts.strict:
+                errors.append(f"Expected tag '{expected_tag}' not found (run `rrt tag create`)")
+            else:
+                p.line(
+                    f"  Expected tag '{expected_tag}' not found (run `rrt tag create`)", ok=False
+                )
+
+        if errors:
+            any_errors = True
+            for err in errors:
+                p.line(f"  {err}", ok=False)
+        else:
+            p.ok(f"Tag '{expected_tag}' is present and consistent.")
+
+    return 1 if any_errors else 0
+
+
 def cmd_tag_check(args: argparse.Namespace) -> int:
     """Validate existing tags match the configured naming convention."""
     opts = TagCheckOptions.from_args(args)
     verbose = opts.verbose
     root = find_repo_root(Path.cwd())
+
+    if opts.group is not None and "," in opts.group:
+        group_names = parse_group_names(opts.group)
+        if not group_names:
+            VerbosePrinter(verbose=verbose).line(
+                f"--group has no valid group names: {opts.group!r}", ok=False, stream=sys.stderr
+            )
+            return 1
+        if dupes := find_duplicate_group_names(group_names):
+            VerbosePrinter(verbose=verbose).line(
+                "Duplicate group name(s) in --group: "
+                f"{', '.join(repr(d) for d in dupes)}. Each group may be listed only once.",
+                ok=False,
+                stream=sys.stderr,
+            )
+            return 1
+        if "{group}" not in opts.prefix:
+            VerbosePrinter(verbose=verbose).line(
+                "--prefix must include the '{group}' placeholder when --group lists "
+                f"multiple groups (got --prefix {opts.prefix!r}). Example: --prefix '{{group}}-v'.",
+                ok=False,
+                stream=sys.stderr,
+            )
+            return 1
+        return _cmd_tag_check_batch(opts, root, group_names)
 
     result = _load_config_and_version(root, opts.group)
     if result is None:
@@ -295,8 +516,10 @@ _TAG_EPILOG = (
     "  $ rrt tag create\n"
     "  $ rrt tag create --push\n"
     "  $ rrt tag create --prefix '' --message 'Release 1.2.3'\n"
+    "  $ rrt tag create --group backend,sdk --prefix '{group}-v'\n"
     "  $ rrt tag check\n"
-    "  $ rrt tag check --strict"
+    "  $ rrt tag check --strict\n"
+    "  $ rrt tag check --group backend,sdk --prefix '{group}-v'"
 )
 
 
@@ -327,7 +550,11 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
         "--prefix",
         default="v",
         metavar="PREFIX",
-        help="Tag prefix (default: 'v'). Pass empty string for no prefix.",
+        help=(
+            "Tag prefix (default: 'v'). Pass empty string for no prefix. "
+            "Include the '{group}' token to render each group's name when "
+            "--group lists multiple groups (e.g. '{group}-v')."
+        ),
     )
     create_parser.add_argument(
         "--message",
@@ -354,7 +581,11 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
         "--group",
         default=None,
         metavar="GROUP",
-        help="Version group to read when multiple groups are configured.",
+        help=(
+            "Version group to read when multiple groups are configured. "
+            "Pass a comma-separated list (e.g. 'a,b,c') to tag several groups "
+            "in one invocation; --prefix must then include the '{group}' token."
+        ),
     )
     create_parser.set_defaults(handler=cmd_tag_create)
 
@@ -369,7 +600,11 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
         "--prefix",
         default="v",
         metavar="PREFIX",
-        help="Expected tag prefix (default: 'v').",
+        help=(
+            "Expected tag prefix (default: 'v'). Include the '{group}' token to "
+            "render each group's name when --group lists multiple groups "
+            "(e.g. '{group}-v')."
+        ),
     )
     check_parser.add_argument(
         "--strict",
@@ -380,6 +615,10 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
         "--group",
         default=None,
         metavar="GROUP",
-        help="Version group to read when multiple groups are configured.",
+        help=(
+            "Version group to read when multiple groups are configured. "
+            "Pass a comma-separated list (e.g. 'a,b,c') to check several groups "
+            "in one invocation; --prefix must then include the '{group}' token."
+        ),
     )
     check_parser.set_defaults(handler=cmd_tag_check)

--- a/tests/commands/test_bump.py
+++ b/tests/commands/test_bump.py
@@ -15,6 +15,7 @@ import pytest
 from repo_release_tools.commands.bump import (
     BumpResolutionError,
     Options,
+    _cmd_bump_batch,
     apply_bump_files,
     cmd_bump,
     finalize_bump_git,
@@ -33,6 +34,7 @@ from repo_release_tools.config import (
     VersionGroup,
     VersionTarget,
 )
+from repo_release_tools.preflight import PreflightError
 from repo_release_tools.version.calver import CalVersion
 from repo_release_tools.version.semver import Version
 from repo_release_tools.version.targets import VersionWriteEvent
@@ -3176,3 +3178,561 @@ def test_cmd_bump_calver_from_calver_version(
     import re
 
     assert re.search(r"\d{4}\.\d+\.\d+", new_content), f"CalVer not found in {new_content!r}"
+
+
+# ---------------------------------------------------------------------------
+# Batch `--group a,b,c` (issue #191)
+# ---------------------------------------------------------------------------
+
+_BATCH_TOML = """\
+[tool.rrt]
+
+[[tool.rrt.version_groups]]
+name = "alpha"
+release_branch = "release/alpha/v{version}"
+
+[[tool.rrt.version_groups.version_targets]]
+path = "alpha.json"
+kind = "package_json"
+
+[[tool.rrt.version_groups]]
+name = "beta"
+release_branch = "release/beta/v{version}"
+
+[[tool.rrt.version_groups.version_targets]]
+path = "beta.json"
+kind = "package_json"
+"""
+
+
+def _write_batch_config(
+    tmp_path: Path, alpha_version: str = "1.0.0", beta_version: str = "2.0.0"
+) -> None:
+    (tmp_path / ".rrt.toml").write_text(_BATCH_TOML, encoding="utf-8")
+    (tmp_path / "alpha.json").write_text(
+        f'{{"name":"alpha","version":"{alpha_version}"}}', encoding="utf-8"
+    )
+    (tmp_path / "beta.json").write_text(
+        f'{{"name":"beta","version":"{beta_version}"}}', encoding="utf-8"
+    )
+
+
+def test_cmd_bump_batch_bumps_all_listed_groups(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Dry-run batch bump previews every listed group in one invocation."""
+    _write_batch_config(tmp_path)
+
+    cwd = Path.cwd()
+    os.chdir(tmp_path)
+    try:
+        result = cmd_bump(
+            Namespace(
+                bump="patch",
+                dry_run=True,
+                no_commit=False,
+                no_changelog=True,
+                no_update=True,
+                include_maintenance=False,
+                base_branch=None,
+                group="alpha,beta",
+            ),
+        )
+    finally:
+        os.chdir(cwd)
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "release/alpha/v1.0.1" in captured.out
+    assert "release/beta/v2.0.1" in captured.out
+    assert "Groups" in captured.out
+
+
+def test_cmd_bump_batch_creates_separate_commits_per_group(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Real (non-dry-run) batch bump checks out and commits each group separately."""
+    _write_batch_config(tmp_path)
+
+    calls: list[list[str]] = []
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.working_tree_clean", lambda root: True
+    )
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.branch_exists", lambda root, branch: False
+    )
+    monkeypatch.setattr("repo_release_tools.commands.bump.git.current_branch", lambda root: "main")
+    monkeypatch.setattr("repo_release_tools.commands.bump.update_changelog", lambda *a, **k: None)
+
+    def fake_run(
+        cmd: list[str], root: Path, *, dry_run: bool, label: str, suppress_announce: bool = False
+    ) -> str:
+        calls.append(cmd)
+        return ""
+
+    monkeypatch.setattr("repo_release_tools.commands.bump.git.run", fake_run)
+
+    result = cmd_bump(
+        Namespace(
+            bump="patch",
+            dry_run=False,
+            no_commit=False,
+            no_changelog=False,
+            no_update=True,
+            include_maintenance=False,
+            base_branch=None,
+            group="alpha,beta",
+        ),
+    )
+
+    assert result == 0
+    checkouts = [c for c in calls if c[:3] == ["git", "checkout", "-b"]]
+    commits = [c for c in calls if c[:2] == ["git", "commit"]]
+    assert len(checkouts) == 2
+    assert len(commits) == 2
+    assert any(c[3] == "release/alpha/v1.0.1" for c in checkouts)
+    assert any(c[3] == "release/beta/v2.0.1" for c in checkouts)
+
+
+def test_cmd_bump_batch_unknown_group_in_list_fails_before_any_write(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An unknown group name in the list fails the whole batch before any write."""
+    _write_batch_config(tmp_path)
+
+    cwd = Path.cwd()
+    os.chdir(tmp_path)
+    try:
+        result = cmd_bump(
+            Namespace(
+                bump="patch",
+                dry_run=True,
+                no_commit=False,
+                no_changelog=True,
+                no_update=True,
+                include_maintenance=False,
+                base_branch=None,
+                group="alpha,doesnotexist",
+            ),
+        )
+    finally:
+        os.chdir(cwd)
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "Unknown version group" in captured.err
+
+
+def test_cmd_bump_batch_duplicate_group_name_fails_before_any_write(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A repeated group name in the list fails fast with a clear error."""
+    _write_batch_config(tmp_path)
+
+    cwd = Path.cwd()
+    os.chdir(tmp_path)
+    try:
+        result = cmd_bump(
+            Namespace(
+                bump="patch",
+                dry_run=True,
+                no_commit=False,
+                no_changelog=True,
+                no_update=True,
+                include_maintenance=False,
+                base_branch=None,
+                group="alpha,alpha,beta",
+            ),
+        )
+    finally:
+        os.chdir(cwd)
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "Duplicate group name" in captured.err
+    assert "'alpha'" in captured.err
+
+
+def test_cmd_bump_batch_rejects_no_commit(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--no-commit is rejected outright for a multi-group batch."""
+    _write_batch_config(tmp_path)
+
+    cwd = Path.cwd()
+    os.chdir(tmp_path)
+    try:
+        result = cmd_bump(
+            Namespace(
+                bump="patch",
+                dry_run=True,
+                no_commit=True,
+                no_changelog=True,
+                no_update=True,
+                include_maintenance=False,
+                base_branch=None,
+                group="alpha,beta",
+            ),
+        )
+    finally:
+        os.chdir(cwd)
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "--no-commit is not supported" in captured.err
+
+
+def test_cmd_bump_batch_existing_branch_without_force_fails_all(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """One group's pre-existing branch blocks the whole batch (validate-all-then-apply-all)."""
+    _write_batch_config(tmp_path)
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.working_tree_clean", lambda root: True
+    )
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.branch_exists",
+        lambda root, branch: "beta" in branch,
+    )
+    monkeypatch.setattr("repo_release_tools.commands.bump.git.current_branch", lambda root: "main")
+
+    result = cmd_bump(
+        Namespace(
+            bump="patch",
+            dry_run=False,
+            force=False,
+            no_commit=False,
+            no_changelog=True,
+            no_update=True,
+            include_maintenance=False,
+            base_branch=None,
+            group="alpha,beta",
+        ),
+    )
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "already exists" in captured.err
+    assert "Version bump" not in captured.out
+
+
+def test_cmd_bump_single_group_comma_free_unaffected(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A single, comma-free --group value still takes the pre-existing single-group path."""
+    _write_batch_config(tmp_path)
+
+    cwd = Path.cwd()
+    os.chdir(tmp_path)
+    try:
+        result = cmd_bump(
+            Namespace(
+                bump="patch",
+                dry_run=True,
+                no_commit=True,
+                no_changelog=True,
+                no_update=True,
+                include_maintenance=False,
+                base_branch=None,
+                group="alpha",
+            ),
+        )
+    finally:
+        os.chdir(cwd)
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "release/alpha/v1.0.1" in captured.out
+    assert "Groups" not in captured.out
+
+
+def test_cmd_bump_batch_empty_group_names_fails(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A --group value that is only commas/whitespace fails before any group resolves."""
+    _write_batch_config(tmp_path)
+
+    cwd = Path.cwd()
+    os.chdir(tmp_path)
+    try:
+        result = cmd_bump(
+            Namespace(
+                bump="patch",
+                dry_run=True,
+                no_commit=False,
+                no_changelog=True,
+                no_update=True,
+                include_maintenance=False,
+                base_branch=None,
+                group=" , ,",
+            ),
+        )
+    finally:
+        os.chdir(cwd)
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "no valid group names" in captured.err
+
+
+def test_cmd_bump_batch_phase1_preflight_failure_stops_batch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A Phase-1 preflight failure (e.g. unreadable version target) stops the batch."""
+    _write_batch_config(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    def _boom(group: VersionGroup) -> None:
+        raise PreflightError(f"boom for {group.name}")
+
+    monkeypatch.setattr("repo_release_tools.commands.bump.check_version_targets_readable", _boom)
+
+    result = cmd_bump(
+        Namespace(
+            bump="patch",
+            dry_run=False,
+            force=False,
+            no_commit=False,
+            no_changelog=True,
+            no_update=True,
+            include_maintenance=False,
+            base_branch=None,
+            group="alpha,beta",
+        ),
+    )
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "boom for alpha" in captured.err
+
+
+def test_cmd_bump_batch_phase2_preflight_failure_stops_batch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A Phase-2 preflight failure (dirty working tree) stops the batch before any commit."""
+    _write_batch_config(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.branch_exists", lambda root, branch: False
+    )
+    monkeypatch.setattr("repo_release_tools.commands.bump.git.current_branch", lambda root: "main")
+    monkeypatch.setattr("repo_release_tools.workflow.git.working_tree_clean", lambda root: False)
+
+    result = cmd_bump(
+        Namespace(
+            bump="patch",
+            dry_run=False,
+            force=False,
+            no_commit=False,
+            no_changelog=True,
+            no_update=True,
+            include_maintenance=False,
+            base_branch=None,
+            group="alpha,beta",
+        ),
+    )
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "uncommitted changes" in captured.err
+
+
+def test_cmd_bump_batch_checks_out_base_branch_when_different(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Checks out --base-branch when it differs from the current branch."""
+    _write_batch_config(tmp_path)
+    calls: list[list[str]] = []
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.working_tree_clean", lambda root: True
+    )
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.branch_exists", lambda root, branch: False
+    )
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.current_branch", lambda root: "feature/x"
+    )
+    monkeypatch.setattr("repo_release_tools.commands.bump.update_changelog", lambda *a, **k: None)
+
+    def fake_run(
+        cmd: list[str], root: Path, *, dry_run: bool, label: str, suppress_announce: bool = False
+    ) -> str:
+        calls.append(cmd)
+        return ""
+
+    monkeypatch.setattr("repo_release_tools.commands.bump.git.run", fake_run)
+
+    result = cmd_bump(
+        Namespace(
+            bump="patch",
+            dry_run=False,
+            no_commit=False,
+            no_changelog=False,
+            no_update=True,
+            include_maintenance=False,
+            base_branch="main",
+            group="alpha,beta",
+        ),
+    )
+
+    assert result == 0
+    assert ["git", "checkout", "main"] in calls
+
+
+def test_cmd_bump_batch_force_resets_existing_branch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--force resets an already-existing release branch for each group."""
+    _write_batch_config(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.working_tree_clean", lambda root: True
+    )
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.branch_exists", lambda root, branch: True
+    )
+    monkeypatch.setattr("repo_release_tools.commands.bump.git.current_branch", lambda root: "main")
+    monkeypatch.setattr("repo_release_tools.commands.bump.update_changelog", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.run",
+        lambda cmd, root, *, dry_run, label, suppress_announce=False: "",
+    )
+
+    result = cmd_bump(
+        Namespace(
+            bump="patch",
+            dry_run=False,
+            force=True,
+            no_commit=False,
+            no_changelog=False,
+            no_update=True,
+            include_maintenance=False,
+            base_branch=None,
+            group="alpha,beta",
+        ),
+    )
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "Resetting it with --force" in captured.out
+
+
+def test_cmd_bump_batch_prints_pin_sync_section(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Prints the 'Updating doc pins' section when a group has pin targets."""
+    (tmp_path / "alpha.json").write_text('{"name":"alpha","version":"1.0.0"}', encoding="utf-8")
+    pin_file = tmp_path / "docs.md"
+    pin_file.write_text("version: 1.0.0\n", encoding="utf-8")
+    target = VersionTarget(path=tmp_path / "alpha.json", kind="package_json")
+    pin = PinTarget(path=pin_file, pattern=r"(version: )(\d+\.\d+\.\d+)()")
+    group = VersionGroup(
+        name="alpha",
+        release_branch="release/alpha/v{version}",
+        changelog_file=tmp_path / "CHANGELOG.md",
+        lock_command=[],
+        generated_files=[],
+        version_targets=[target],
+        pin_targets=[pin],
+    )
+    config = RrtConfig(
+        root=tmp_path,
+        config_file=tmp_path / ".rrt.toml",
+        version_groups=[group],
+        default_group_name="alpha",
+    )
+    opts = _options(group="alpha", dry_run=True, no_commit=False, no_changelog=True, no_update=True)
+
+    result = _cmd_bump_batch(opts, config, tmp_path, ["alpha"])
+
+    assert result == 0
+    assert "Updating doc pins" in capsys.readouterr().out
+
+
+def test_cmd_bump_batch_runs_lock_command(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Runs a group's configured lock command when --no-update is not set."""
+    (tmp_path / "alpha.json").write_text('{"name":"alpha","version":"1.0.0"}', encoding="utf-8")
+    target = VersionTarget(path=tmp_path / "alpha.json", kind="package_json")
+    group = VersionGroup(
+        name="alpha",
+        release_branch="release/alpha/v{version}",
+        changelog_file=tmp_path / "CHANGELOG.md",
+        lock_command=["true"],
+        generated_files=[],
+        version_targets=[target],
+    )
+    config = RrtConfig(
+        root=tmp_path,
+        config_file=tmp_path / ".rrt.toml",
+        version_groups=[group],
+        default_group_name="alpha",
+    )
+    opts = _options(
+        group="alpha", dry_run=True, no_commit=False, no_changelog=True, no_update=False
+    )
+
+    result = _cmd_bump_batch(opts, config, tmp_path, ["alpha"])
+
+    assert result == 0
+    assert "Refreshing lockfiles" in capsys.readouterr().out
+
+
+def test_cmd_bump_batch_generated_asset_failure_stops_batch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A real generated-asset failure stops the batch (Phase 2 early return)."""
+    (tmp_path / "alpha.json").write_text('{"name":"alpha","version":"1.0.0"}', encoding="utf-8")
+    target = VersionTarget(path=tmp_path / "alpha.json", kind="package_json")
+    asset = GeneratedAsset(path=Path("out.txt"), command=["false"])
+    group = VersionGroup(
+        name="alpha",
+        release_branch="release/alpha/v{version}",
+        changelog_file=tmp_path / "CHANGELOG.md",
+        lock_command=[],
+        generated_files=[],
+        version_targets=[target],
+        generated_assets=[asset],
+    )
+    config = RrtConfig(
+        root=tmp_path,
+        config_file=tmp_path / ".rrt.toml",
+        version_groups=[group],
+        default_group_name="alpha",
+    )
+    opts = _options(
+        group="alpha", dry_run=True, no_commit=False, no_changelog=True, no_update=False
+    )
+
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.refresh_bump_generated_assets",
+        lambda group, root, *, dry_run, verbose=0: False,
+    )
+
+    result = _cmd_bump_batch(opts, config, tmp_path, ["alpha"])
+
+    assert result == 1

--- a/tests/commands/test_common.py
+++ b/tests/commands/test_common.py
@@ -1,0 +1,34 @@
+"""Tests for shared `commands/_common.py` helpers."""
+
+from __future__ import annotations
+
+from repo_release_tools.commands._common import (
+    find_duplicate_group_names,
+    parse_group_names,
+)
+
+
+def test_parse_group_names_splits_and_strips() -> None:
+    """Splits a comma-separated value into stripped names, order preserved."""
+    assert parse_group_names("alpha,beta,gamma") == ["alpha", "beta", "gamma"]
+    assert parse_group_names(" alpha , beta ") == ["alpha", "beta"]
+
+
+def test_parse_group_names_drops_empty_segments() -> None:
+    """Drops empty/whitespace-only segments (trailing commas, doubled commas)."""
+    assert parse_group_names("alpha,,beta") == ["alpha", "beta"]
+    assert parse_group_names("alpha,beta,") == ["alpha", "beta"]
+    assert parse_group_names(" , , ") == []
+    assert parse_group_names("") == []
+
+
+def test_find_duplicate_group_names_detects_repeats() -> None:
+    """Returns each repeated name once, in first-seen order."""
+    assert find_duplicate_group_names(["alpha", "alpha", "beta"]) == ["alpha"]
+    assert find_duplicate_group_names(["a", "b", "a", "b", "c"]) == ["a", "b"]
+
+
+def test_find_duplicate_group_names_empty_when_all_unique() -> None:
+    """Returns an empty list when every name is unique."""
+    assert find_duplicate_group_names(["alpha", "beta", "gamma"]) == []
+    assert find_duplicate_group_names([]) == []

--- a/tests/commands/test_tag.py
+++ b/tests/commands/test_tag.py
@@ -14,6 +14,7 @@ from repo_release_tools.commands.tag import (
     _git,
     _load_config_and_version,
     _tag_name,
+    _tag_name_for_group,
     cmd_tag_check,
     cmd_tag_create,
 )
@@ -500,3 +501,543 @@ def test_load_config_and_version_resolve_group_value_error(
     result = _load_config_and_version(tmp_path, "staging")
     assert result is None
     assert "unknown group 'staging'" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# Batch `--group a,b,c` and `{group}` prefix token (issue #191)
+# ---------------------------------------------------------------------------
+
+
+def _make_multi_group_config(tmp_path: Path, versions: dict[str, str]) -> RrtConfig:
+    groups = []
+    for name, version in versions.items():
+        init_file = tmp_path / name / "__init__.py"
+        init_file.parent.mkdir(parents=True, exist_ok=True)
+        init_file.write_text(f'__version__ = "{version}"\n', encoding="utf-8")
+        target = VersionTarget(path=init_file, kind="python_version")
+        groups.append(
+            VersionGroup(
+                name=name,
+                release_branch=f"release/{name}/v{{version}}",
+                changelog_file=tmp_path / name / "CHANGELOG.md",
+                lock_command=[],
+                generated_files=[],
+                version_targets=[target],
+                pin_targets=[],
+            )
+        )
+    return RrtConfig(
+        root=tmp_path,
+        config_file=tmp_path / "pyproject.toml",
+        version_groups=groups,
+        default_group_name=None,
+    )
+
+
+def test_tag_name_for_group_renders_group_token() -> None:
+    """Substitutes {group} with the group's name before the version."""
+    assert _tag_name_for_group("1.2.3", "{group}-v", "alpha") == "alpha-v1.2.3"
+
+
+def test_tag_name_for_group_no_op_without_token() -> None:
+    """Behaves exactly like _tag_name when --prefix has no {group} token."""
+    assert _tag_name_for_group("1.2.3", "v", "alpha") == "v1.2.3"
+
+
+def test_tag_name_for_group_preserves_unrelated_braces() -> None:
+    """A stray unrelated `{...}` in a custom prefix is left untouched (no KeyError)."""
+    assert _tag_name_for_group("1.2.3", "release-{build}-", "alpha") == "release-{build}-1.2.3"
+
+
+def test_cmd_tag_create_batch_creates_tags_for_all_groups(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Creates one correctly-prefixed tag per listed group in one invocation."""
+    monkeypatch.chdir(tmp_path)
+    conf = _make_multi_group_config(tmp_path, {"alpha": "1.0.0", "beta": "2.0.0"})
+    monkeypatch.setattr("repo_release_tools.commands.tag.load_or_autodetect_config", lambda _: conf)
+    monkeypatch.setattr("repo_release_tools.commands.tag._existing_tags", lambda _: [])
+
+    git_calls: list[list[str]] = []
+
+    def _fake_git(cmd: list[str], _root: Path, **kwargs: object) -> MagicMock:
+        git_calls.append(cmd)
+        m = MagicMock()
+        m.stderr = ""
+        return m
+
+    monkeypatch.setattr("repo_release_tools.commands.tag._git", _fake_git)
+
+    rc = cmd_tag_create(_args_create(prefix="{group}-v", group="alpha,beta"))
+
+    assert rc == 0
+    tag_calls = [c for c in git_calls if "tag" in c and "-a" in c]
+    assert any("alpha-v1.0.0" in c for c in tag_calls)
+    assert any("beta-v2.0.0" in c for c in tag_calls)
+    out = capsys.readouterr().out
+    assert "Created tag 'alpha-v1.0.0'" in out
+    assert "Created tag 'beta-v2.0.0'" in out
+
+
+def test_cmd_tag_create_batch_requires_group_token_in_prefix(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Fails fast if --prefix omits {group} while --group lists multiple groups."""
+    monkeypatch.chdir(tmp_path)
+    conf = _make_multi_group_config(tmp_path, {"alpha": "1.0.0", "beta": "2.0.0"})
+    monkeypatch.setattr("repo_release_tools.commands.tag.load_or_autodetect_config", lambda _: conf)
+
+    rc = cmd_tag_create(_args_create(prefix="v", group="alpha,beta"))
+
+    assert rc == 1
+    assert "must include the '{group}' placeholder" in capsys.readouterr().err
+
+
+def test_cmd_tag_create_batch_unknown_group_fails_before_any_tag(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An unknown group name in the list fails the whole batch before tagging anything."""
+    monkeypatch.chdir(tmp_path)
+    conf = _make_multi_group_config(tmp_path, {"alpha": "1.0.0"})
+    monkeypatch.setattr("repo_release_tools.commands.tag.load_or_autodetect_config", lambda _: conf)
+    monkeypatch.setattr("repo_release_tools.commands.tag._existing_tags", lambda _: [])
+
+    rc = cmd_tag_create(_args_create(prefix="{group}-v", group="alpha,doesnotexist"))
+
+    assert rc == 1
+    assert "Unknown version group" in capsys.readouterr().err
+
+
+def test_cmd_tag_create_batch_duplicate_group_fails_before_any_tag(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A repeated group name in the list fails fast with a clear error."""
+    monkeypatch.chdir(tmp_path)
+    conf = _make_multi_group_config(tmp_path, {"alpha": "1.0.0", "beta": "2.0.0"})
+    monkeypatch.setattr("repo_release_tools.commands.tag.load_or_autodetect_config", lambda _: conf)
+
+    rc = cmd_tag_create(_args_create(prefix="{group}-v", group="alpha,alpha,beta"))
+
+    assert rc == 1
+    captured = capsys.readouterr().err
+    assert "Duplicate group name" in captured
+    assert "'alpha'" in captured
+
+
+def test_cmd_tag_create_batch_existing_tag_without_force_fails_all(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A pre-existing tag for one group blocks the whole batch (validate-all-then-apply-all)."""
+    monkeypatch.chdir(tmp_path)
+    conf = _make_multi_group_config(tmp_path, {"alpha": "1.0.0", "beta": "2.0.0"})
+    monkeypatch.setattr("repo_release_tools.commands.tag.load_or_autodetect_config", lambda _: conf)
+    monkeypatch.setattr("repo_release_tools.commands.tag._existing_tags", lambda _: ["beta-v2.0.0"])
+
+    git_calls: list[list[str]] = []
+    monkeypatch.setattr(
+        "repo_release_tools.commands.tag._git",
+        lambda cmd, _root, **kwargs: git_calls.append(cmd),
+    )
+
+    rc = cmd_tag_create(_args_create(prefix="{group}-v", group="alpha,beta"))
+
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "already exists" in captured.err
+    assert not git_calls
+
+
+def test_cmd_tag_create_batch_dry_run_no_tags_created(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Dry-run batch previews every tag without creating any of them."""
+    monkeypatch.chdir(tmp_path)
+    conf = _make_multi_group_config(tmp_path, {"alpha": "1.0.0", "beta": "2.0.0"})
+    monkeypatch.setattr("repo_release_tools.commands.tag.load_or_autodetect_config", lambda _: conf)
+    monkeypatch.setattr("repo_release_tools.commands.tag._existing_tags", lambda _: [])
+
+    git_calls: list[list[str]] = []
+    monkeypatch.setattr(
+        "repo_release_tools.commands.tag._git",
+        lambda cmd, _root, **kwargs: git_calls.append(cmd),
+    )
+
+    rc = cmd_tag_create(_args_create(prefix="{group}-v", group="alpha,beta", dry_run=True))
+
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert not git_calls
+    assert "would run: git tag -a alpha-v1.0.0" in out
+    assert "would run: git tag -a beta-v2.0.0" in out
+    assert "no changes were made" in out
+
+
+def test_cmd_tag_check_batch_aggregates_results_across_all_groups(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Evaluates every group even when an earlier one has errors, aggregating the result."""
+    monkeypatch.chdir(tmp_path)
+    conf = _make_multi_group_config(tmp_path, {"alpha": "1.0.0", "beta": "2.0.0"})
+    monkeypatch.setattr("repo_release_tools.commands.tag.load_or_autodetect_config", lambda _: conf)
+    monkeypatch.setattr("repo_release_tools.commands.tag._existing_tags", lambda _: ["beta-v2.0.0"])
+
+    rc = cmd_tag_check(_args_check(prefix="{group}-v", strict=True, group="alpha,beta"))
+
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "alpha-v1.0.0" in out
+    assert "beta-v2.0.0" in out
+    assert "is present and consistent" in out
+
+
+def test_cmd_tag_check_batch_requires_group_token_in_prefix(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Fails fast if --prefix omits {group} while --group lists multiple groups."""
+    monkeypatch.chdir(tmp_path)
+    conf = _make_multi_group_config(tmp_path, {"alpha": "1.0.0", "beta": "2.0.0"})
+    monkeypatch.setattr("repo_release_tools.commands.tag.load_or_autodetect_config", lambda _: conf)
+
+    rc = cmd_tag_check(_args_check(prefix="v", group="alpha,beta"))
+
+    assert rc == 1
+    assert "must include the '{group}' placeholder" in capsys.readouterr().err
+
+
+def test_cmd_tag_create_single_group_unaffected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A single, comma-free --group value still takes the pre-existing single-group path."""
+    monkeypatch.chdir(tmp_path)
+    conf = _make_config(tmp_path)
+    monkeypatch.setattr("repo_release_tools.commands.tag.load_or_autodetect_config", lambda _: conf)
+    monkeypatch.setattr("repo_release_tools.commands.tag._existing_tags", lambda _: [])
+
+    git_calls: list[list[str]] = []
+
+    def _fake_git(cmd: list[str], _root: Path, **kwargs: object) -> MagicMock:
+        git_calls.append(cmd)
+        m = MagicMock()
+        m.stderr = ""
+        return m
+
+    monkeypatch.setattr("repo_release_tools.commands.tag._git", _fake_git)
+
+    rc = cmd_tag_create(_args_create(group="default"))
+
+    assert rc == 0
+    assert any("v1.2.3" in c for c in git_calls if "tag" in c and "-a" in c)
+
+
+def test_cmd_tag_check_single_group_unaffected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A single, comma-free --group value still takes the pre-existing single-group path."""
+    monkeypatch.chdir(tmp_path)
+    conf = _make_config(tmp_path)
+    monkeypatch.setattr("repo_release_tools.commands.tag.load_or_autodetect_config", lambda _: conf)
+    monkeypatch.setattr("repo_release_tools.commands.tag._existing_tags", lambda _: ["v1.2.3"])
+
+    rc = cmd_tag_check(_args_check(group="default"))
+
+    assert rc == 0
+    assert "is present and consistent" in capsys.readouterr().out
+
+
+def test_cmd_tag_create_batch_no_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Returns 1 when no rrt config is found for a batch invocation."""
+    monkeypatch.chdir(tmp_path)
+    rc = cmd_tag_create(_args_create(prefix="{group}-v", group="alpha,beta"))
+    assert rc == 1
+    assert capsys.readouterr().err
+
+
+def test_cmd_tag_create_batch_is_missing_rrt_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Returns 1 when config ValueError signals missing [tool.rrt] config."""
+    from repo_release_tools.config import MissingRrtConfigError
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_release_tools.commands.tag.load_or_autodetect_config",
+        lambda _: (_ for _ in ()).throw(MissingRrtConfigError("no rrt")),
+    )
+    rc = cmd_tag_create(_args_create(prefix="{group}-v", group="alpha,beta"))
+    assert rc == 1
+    assert capsys.readouterr().err
+
+
+def test_cmd_tag_create_batch_value_error_non_rrt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Returns 1 when config raises a generic ValueError."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_release_tools.commands.tag.load_or_autodetect_config",
+        lambda _: (_ for _ in ()).throw(ValueError("generic error")),
+    )
+    rc = cmd_tag_create(_args_create(prefix="{group}-v", group="alpha,beta"))
+    assert rc == 1
+    assert capsys.readouterr().err
+
+
+def test_cmd_tag_create_batch_force_deletes_and_recreates(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--force deletes and recreates an already-existing tag for one group in the batch."""
+    monkeypatch.chdir(tmp_path)
+    conf = _make_multi_group_config(tmp_path, {"alpha": "1.0.0", "beta": "2.0.0"})
+    monkeypatch.setattr("repo_release_tools.commands.tag.load_or_autodetect_config", lambda _: conf)
+    monkeypatch.setattr(
+        "repo_release_tools.commands.tag._existing_tags", lambda _: ["alpha-v1.0.0"]
+    )
+
+    git_calls: list[list[str]] = []
+
+    def _fake_git(cmd: list[str], _root: Path, **kwargs: object) -> MagicMock:
+        git_calls.append(cmd)
+        m = MagicMock()
+        m.stderr = ""
+        return m
+
+    monkeypatch.setattr("repo_release_tools.commands.tag._git", _fake_git)
+
+    rc = cmd_tag_create(_args_create(prefix="{group}-v", group="alpha,beta", force=True))
+
+    assert rc == 0
+    delete_calls = [c for c in git_calls if "tag" in c and "-d" in c]
+    assert any("alpha-v1.0.0" in c for c in delete_calls)
+
+
+def test_cmd_tag_create_batch_git_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Returns 1 and stops the batch when `git tag` fails for a group."""
+    monkeypatch.chdir(tmp_path)
+    conf = _make_multi_group_config(tmp_path, {"alpha": "1.0.0", "beta": "2.0.0"})
+    monkeypatch.setattr("repo_release_tools.commands.tag.load_or_autodetect_config", lambda _: conf)
+    monkeypatch.setattr("repo_release_tools.commands.tag._existing_tags", lambda _: [])
+
+    def _fail_git(cmd: list[str], _root: Path, **kwargs: object) -> MagicMock:
+        if "-a" in cmd:
+            exc = subprocess.CalledProcessError(1, cmd)
+            exc.stderr = "fatal: tag already exists"
+            raise exc
+        m = MagicMock()
+        m.stderr = ""
+        return m
+
+    monkeypatch.setattr("repo_release_tools.commands.tag._git", _fail_git)
+
+    rc = cmd_tag_create(_args_create(prefix="{group}-v", group="alpha,beta"))
+
+    assert rc == 1
+    assert "git tag failed" in capsys.readouterr().err
+
+
+def test_cmd_tag_create_batch_with_push(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--push pushes each group's tag to origin after creating it."""
+    monkeypatch.chdir(tmp_path)
+    conf = _make_multi_group_config(tmp_path, {"alpha": "1.0.0", "beta": "2.0.0"})
+    monkeypatch.setattr("repo_release_tools.commands.tag.load_or_autodetect_config", lambda _: conf)
+    monkeypatch.setattr("repo_release_tools.commands.tag._existing_tags", lambda _: [])
+
+    git_calls: list[list[str]] = []
+
+    def _fake_git(cmd: list[str], _root: Path, **kwargs: object) -> MagicMock:
+        git_calls.append(cmd)
+        m = MagicMock()
+        m.stderr = ""
+        return m
+
+    monkeypatch.setattr("repo_release_tools.commands.tag._git", _fake_git)
+
+    rc = cmd_tag_create(_args_create(prefix="{group}-v", group="alpha,beta", push=True))
+
+    assert rc == 0
+    assert any("push" in c and "alpha-v1.0.0" in c for c in git_calls)
+    assert "Pushed 'alpha-v1.0.0' to origin" in capsys.readouterr().out
+
+
+def test_cmd_tag_create_batch_push_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Returns 1 and stops the batch when `git push` fails for a group."""
+    monkeypatch.chdir(tmp_path)
+    conf = _make_multi_group_config(tmp_path, {"alpha": "1.0.0", "beta": "2.0.0"})
+    monkeypatch.setattr("repo_release_tools.commands.tag.load_or_autodetect_config", lambda _: conf)
+    monkeypatch.setattr("repo_release_tools.commands.tag._existing_tags", lambda _: [])
+
+    def _fake_git(cmd: list[str], _root: Path, **kwargs: object) -> MagicMock:
+        if "push" in cmd:
+            exc = subprocess.CalledProcessError(1, cmd)
+            exc.stderr = "remote: repository not found"
+            raise exc
+        m = MagicMock()
+        m.stderr = ""
+        return m
+
+    monkeypatch.setattr("repo_release_tools.commands.tag._git", _fake_git)
+
+    rc = cmd_tag_create(_args_create(prefix="{group}-v", group="alpha,beta", push=True))
+
+    assert rc == 1
+    assert "git push failed" in capsys.readouterr().err
+
+
+def test_cmd_tag_create_batch_empty_group_names_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A --group value that is only commas/whitespace fails before any group resolves."""
+    monkeypatch.chdir(tmp_path)
+    rc = cmd_tag_create(_args_create(group=" , ,"))
+    assert rc == 1
+    assert "no valid group names" in capsys.readouterr().err
+
+
+def test_cmd_tag_check_batch_no_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Returns 1 when no rrt config is found for a batch invocation."""
+    monkeypatch.chdir(tmp_path)
+    rc = cmd_tag_check(_args_check(prefix="{group}-v", group="alpha,beta"))
+    assert rc == 1
+    assert capsys.readouterr().err
+
+
+def test_cmd_tag_check_batch_is_missing_rrt_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Returns 1 when config ValueError signals missing [tool.rrt] config."""
+    from repo_release_tools.config import MissingRrtConfigError
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_release_tools.commands.tag.load_or_autodetect_config",
+        lambda _: (_ for _ in ()).throw(MissingRrtConfigError("no rrt")),
+    )
+    rc = cmd_tag_check(_args_check(prefix="{group}-v", group="alpha,beta"))
+    assert rc == 1
+    assert capsys.readouterr().err
+
+
+def test_cmd_tag_check_batch_value_error_non_rrt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Returns 1 when config raises a generic ValueError."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_release_tools.commands.tag.load_or_autodetect_config",
+        lambda _: (_ for _ in ()).throw(ValueError("generic error")),
+    )
+    rc = cmd_tag_check(_args_check(prefix="{group}-v", group="alpha,beta"))
+    assert rc == 1
+    assert capsys.readouterr().err
+
+
+def test_cmd_tag_check_batch_unknown_group_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An unknown group name in the list fails before checking anything."""
+    monkeypatch.chdir(tmp_path)
+    conf = _make_multi_group_config(tmp_path, {"alpha": "1.0.0"})
+    monkeypatch.setattr("repo_release_tools.commands.tag.load_or_autodetect_config", lambda _: conf)
+
+    rc = cmd_tag_check(_args_check(prefix="{group}-v", group="alpha,doesnotexist"))
+
+    assert rc == 1
+    assert "Unknown version group" in capsys.readouterr().err
+
+
+def test_cmd_tag_check_batch_reports_missing_tag_when_not_strict(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Non-strict mode reports a missing expected tag without failing the group."""
+    monkeypatch.chdir(tmp_path)
+    conf = _make_multi_group_config(tmp_path, {"alpha": "1.0.0", "beta": "2.0.0"})
+    monkeypatch.setattr("repo_release_tools.commands.tag.load_or_autodetect_config", lambda _: conf)
+    monkeypatch.setattr("repo_release_tools.commands.tag._existing_tags", lambda _: [])
+
+    rc = cmd_tag_check(_args_check(prefix="{group}-v", strict=False, group="alpha,beta"))
+
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Expected tag 'alpha-v1.0.0' not found" in out
+
+
+def test_cmd_tag_check_batch_duplicate_group_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A repeated group name in the list fails fast with a clear error."""
+    monkeypatch.chdir(tmp_path)
+    rc = cmd_tag_check(_args_check(prefix="{group}-v", group="alpha,alpha,beta"))
+
+    assert rc == 1
+    captured = capsys.readouterr().err
+    assert "Duplicate group name" in captured
+    assert "'alpha'" in captured
+
+
+def test_cmd_tag_check_batch_empty_group_names_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A --group value that is only commas/whitespace fails before any group resolves."""
+    monkeypatch.chdir(tmp_path)
+    rc = cmd_tag_check(_args_check(group=" , ,"))
+    assert rc == 1
+    assert "no valid group names" in capsys.readouterr().err


### PR DESCRIPTION
## Summary
- `rrt bump`, `rrt tag create`, and `rrt tag check` now accept a comma-separated `--group` list (e.g. `--group self-assess,cupertino,confab`), so one invocation covers what previously required N sequential commands per `version_groups` entry
- `tag create`/`tag check --prefix` gains a `{group}` template token (required whenever `--group` lists 2+ groups) so each group gets its own correctly-prefixed tag in one pass
- Batch bump creates one release branch + commit per group (identical git history to running `rrt bump` N times by hand); all three commands validate every group up front and fail fast with no partial state before writing/tagging anything
- Single-group invocations are unaffected — the new code paths only activate when `--group` contains a comma

Closes #191

## Test plan
- [x] `uv run pytest -q -m "not runtime"` — 3296 passed, 100% coverage
- [x] `uvx pre-commit run --all-files` equivalent checks (branch name, ruff, ty, docs) all pass via commit hooks
- [x] New tests cover: valid multi-group batches, unknown/duplicate group names, missing `{group}` token, pre-existing branch/tag conflicts without `--force`, `--no-commit` rejection in batch mode, dry-run previews, and single-group regression guards

🤖 Generated with [Claude Code](https://claude.com/claude-code)