### PR TITLE
fix(bump): retry commit across cascading auto-fix hook failures

### DIFF
--- a/src/repo_release_tools/commands/bump.py
+++ b/src/repo_release_tools/commands/bump.py
@@ -122,6 +122,13 @@ _BUMP_KINDS = {"major", "minor", "patch", "pre-release", "calver", *PRE_RELEASE_
 # thereby failed its own pass even though the fix is now correct on disk.
 _HOOK_MODIFIED_FILES_MARKER = "files were modified by this hook"
 
+# Upper bound on commit attempts in finalize_bump_git's auto-fix retry loop.
+# More than one auto-fixing hook (ruff, tree/doctor/config-reference
+# auto-update, ...) can cascade across successive commit attempts, so a
+# single retry isn't always enough; this caps the loop rather than retrying
+# forever.
+_MAX_COMMIT_ATTEMPTS = 3
+
 
 class BumpResolutionError(Exception):
     """Raised by :func:`resolve_bump_target` when the bump kind or version group is invalid.
@@ -296,9 +303,11 @@ def finalize_bump_git(
 ) -> None:
     """Checkout the release branch, stage changed files, and commit.
 
-    Ordering is contract: checkout -> stage -> commit. Retries the commit
-    once if a pre-commit hook auto-regenerated files during the first
-    attempt (matches cmd_bump's original inline retry).
+    Ordering is contract: checkout -> stage -> commit. Retries the commit,
+    up to ``_MAX_COMMIT_ATTEMPTS`` times, whenever a pre-commit hook
+    auto-regenerated files during the previous attempt -- more than one
+    auto-fixing hook can trip across successive attempts, so a single retry
+    isn't always enough.
     """
     p = DryRunPrinter(opts.dry_run, verbose=opts.verbose)
     p.section("Git")
@@ -333,19 +342,22 @@ def finalize_bump_git(
         commit_cmd = ["git", "commit", "-m", commit_msg]
         if opts.no_verify:
             commit_cmd.append("--no-verify")
-        try:
-            git.run(commit_cmd, root, dry_run=opts.dry_run, label="git commit")
-        except RuntimeError as exc:
-            if _HOOK_MODIFIED_FILES_MARKER not in str(exc):
-                raise
-            # A pre-commit hook (e.g. rrt-cli-docs) may have auto-regenerated
-            # files during this pass — pre-commit always fails that pass even
-            # though the fix is now correct. Re-stage and retry once.
-            git.run(["git", "add", "-u"], root, dry_run=opts.dry_run, label="git add -u")
+        prev_exc: RuntimeError | None = None
+        for attempt in range(1, _MAX_COMMIT_ATTEMPTS + 1):
             try:
                 git.run(commit_cmd, root, dry_run=opts.dry_run, label="git commit")
-            except RuntimeError as retry_exc:
-                raise retry_exc from exc
+                break
+            except RuntimeError as exc:
+                has_marker = _HOOK_MODIFIED_FILES_MARKER in str(exc)
+                if not has_marker or attempt == _MAX_COMMIT_ATTEMPTS:
+                    if prev_exc is not None:
+                        raise exc from prev_exc
+                    raise
+                # A pre-commit hook (e.g. rrt-cli-docs) may have auto-regenerated
+                # files during this pass — pre-commit always fails that pass even
+                # though the fix is now correct. Re-stage and retry.
+                git.run(["git", "add", "-u"], root, dry_run=opts.dry_run, label="git add -u")
+                prev_exc = exc
         done_msg = f"Done. Branch '{branch_name}' created with commit: {commit_msg!r}"
         p.footer(done_msg)
     else:

--- a/tests/commands/test_bump.py
+++ b/tests/commands/test_bump.py
@@ -783,6 +783,99 @@ kind = "package_json"
     assert ["git", "add", "-u"] in calls[first_commit_index + 1 : last_commit_index + 1]
 
 
+def test_cmd_bump_retries_commit_twice_for_cascading_hook_auto_fixes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Two *different* auto-fixing hooks can each trip the "files were
+    modified by this hook" failure on successive attempts (e.g. rrt-cli-docs
+    regenerates on attempt 1, then rrt-tree-auto-update regenerates on
+    attempt 2). A single retry isn't enough here; bump must keep retrying,
+    up to _MAX_COMMIT_ATTEMPTS, re-staging before each attempt.
+    """
+    (tmp_path / ".rrt.toml").write_text(
+        """\
+[tool.rrt]
+release_branch = "release/v{version}"
+lock_command = []
+
+[[tool.rrt.version_targets]]
+path = "package.json"
+kind = "package_json"
+""",
+        encoding="utf-8",
+    )
+    (tmp_path / "package.json").write_text(
+        '{\n  "name": "example",\n  "version": "0.1.0"\n}\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "CHANGELOG.md").write_text("# Changelog\n", encoding="utf-8")
+
+    calls: list[list[str]] = []
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.working_tree_clean",
+        lambda root: True,
+    )
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.git.branch_exists",
+        lambda root, branch: False,
+    )
+    monkeypatch.setattr("repo_release_tools.commands.bump.git.current_branch", lambda root: "main")
+    monkeypatch.setattr(
+        "repo_release_tools.commands.bump.replace_all_versions_atomic",
+        lambda *a, **k: [],
+    )
+    monkeypatch.setattr("repo_release_tools.commands.bump.update_changelog", lambda *a, **k: None)
+
+    commit_attempts = 0
+
+    def fake_run(
+        cmd: list[str],
+        root: Path,
+        *,
+        dry_run: bool,
+        label: str,
+        suppress_announce: bool = False,
+    ) -> str:
+        nonlocal commit_attempts
+        calls.append(cmd)
+        if cmd[:2] == ["git", "commit"]:
+            commit_attempts += 1
+            if commit_attempts == 1:
+                raise RuntimeError(
+                    "git commit failed (exit 1): rrt cli docs - files were modified by this hook"
+                )
+            if commit_attempts == 2:
+                raise RuntimeError(
+                    "git commit failed (exit 1): rrt tree auto-update - "
+                    "files were modified by this hook"
+                )
+        return ""
+
+    monkeypatch.setattr("repo_release_tools.commands.bump.git.run", fake_run)
+
+    result = cmd_bump(
+        Namespace(
+            bump="minor",
+            dry_run=False,
+            no_commit=False,
+            no_changelog=False,
+            no_update=True,
+            include_maintenance=False,
+            base_branch=None,
+            group=None,
+        ),
+    )
+
+    assert result == 0
+    assert commit_attempts == 3
+    commit_calls = [c for c in calls if c[:2] == ["git", "commit"]]
+    assert commit_calls == [["git", "commit", "-m", "chore: bump version to v0.2.0"]] * 3
+    assert calls.count(["git", "add", "-u"]) >= 3
+
+
 def test_cmd_bump_does_not_retry_unrelated_commit_failure(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- `finalize_bump_git` retried a failed `git commit` only once when a pre-commit hook auto-regenerated tracked files (e.g. `rrt-cli-docs`). If a *second*, different auto-fixing hook (`rrt-tree-auto-update`, `rrt-doctor-auto-update`, `rrt-config-reference-auto-update`, ...) tripped on that retry, bump gave up and surfaced the failure, forcing a manual re-stage-and-squash workflow.
- Turn the single retry into a bounded loop (`_MAX_COMMIT_ATTEMPTS = 3`) so multiple auto-fixing hooks can cascade across successive commit attempts before bump gives up.
- Non-retryable-failure behavior and `__cause__` chaining to the original hook error are unchanged (covered by existing tests).

Related: a separate, already-fixed bug (issue #182, shipped in v1.14.1) caused a *different* symptom — a passing hook's `...Passed` status line getting mistaken for the failure reason. That was a stale global `rrt` install issue, not a code change in this PR.

## Test plan
- [x] `uv run pytest tests/commands/test_bump.py -k "retries_commit_once_after_hook_auto_fix or retries_commit_twice_for_cascading or unrelated_commit_failure or retry_failure_chains"` — new + existing retry tests pass
- [x] `uv run pytest -q -m "not runtime"` — full fast suite, 3297 passed, 100% coverage
- [x] `uv run ruff check` / `uv run ruff format --check` / `uv run ty check` on changed files — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)