### PR TITLE
fix(branch): allow rename to rebuild a non-conventional branch name

### DIFF
--- a/src/repo_release_tools/commands/branch.py
+++ b/src/repo_release_tools/commands/branch.py
@@ -354,23 +354,43 @@ def cmd_rename(args: argparse.Namespace) -> int:
 
     current_branch = git.current_branch(root)
 
+    parse_error: str | None = None
     try:
         current_type, current_slug = _parse_current_branch(current_branch)
     except ValueError as exc:
-        VerbosePrinter(verbose=verbose).line(str(exc), ok=False, stream=sys.stderr)
-        return 1
-
-    new_type = new_type_arg or current_type
+        current_type = current_slug = None
+        parse_error = str(exc)
 
     if description_words:
-        # Full rebuild: type + scope + new description
+        # Full rebuild: type + scope + new description. A supplied --type
+        # means we never need the old name to have parsed at all, since
+        # nothing is being preserved from it (this is what lets `rename`
+        # bring a non-conventional branch into compliance).
+        if new_type_arg:
+            new_type = new_type_arg
+        elif parse_error is None:
+            assert current_type is not None
+            new_type = current_type
+        else:
+            VerbosePrinter(verbose=verbose).line(parse_error, ok=False, stream=sys.stderr)
+            return 1
+
         description = join_description(description_words)
         effective_scope = None if no_scope else scope
         branch = BranchName(type=new_type, description=description, scope=effective_scope)
         new_name = branch.slug()
         commit_title = branch.commit_title()
     else:
-        # Slug-preserving rename: only type and/or scope prefix changes
+        # Slug-preserving rename: only type and/or scope prefix changes.
+        # This always needs the old name to have parsed, since the slug is
+        # carried over from it.
+        if parse_error is not None:
+            VerbosePrinter(verbose=verbose).line(parse_error, ok=False, stream=sys.stderr)
+            return 1
+        assert current_type is not None
+        assert current_slug is not None
+        new_type = new_type_arg or current_type
+
         if scope:
             scope_slug = re.sub(r"[^a-z0-9]+", "-", scope.lower()).strip("-")
             new_slug = f"{scope_slug}-{current_slug}"

--- a/tests/commands/test_branch.py
+++ b/tests/commands/test_branch.py
@@ -496,6 +496,32 @@ def test_cmd_rename_full_rebuild_dry_run(
     assert "feat/introduce-v2" in out
 
 
+def test_cmd_rename_full_rebuild_preserves_type_without_type_flag(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Description words without --type reuse the type parsed from a conventional branch."""
+    from repo_release_tools.commands.branch import cmd_rename
+
+    monkeypatch.setattr(
+        "repo_release_tools.commands.branch.git.current_branch",
+        lambda root: "feat/add-login",
+    )
+
+    args = argparse.Namespace(
+        type=None,
+        scope=None,
+        no_scope=False,
+        description=["update", "login", "flow"],
+        dry_run=True,
+    )
+    result = cmd_rename(args)
+
+    assert result == 0
+    out = capsys.readouterr().out
+    assert "feat/update-login-flow" in out
+
+
 def test_cmd_rename_no_change_returns_error(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -665,6 +691,57 @@ def test_cmd_rename_non_conventional_branch_errors(
     assert result == 1
     err = capsys.readouterr().err
     assert "convention" in err
+
+
+def test_cmd_rename_non_conventional_branch_with_type_and_description_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--type + description can rebuild a non-conventional branch from scratch (issue #196)."""
+    from repo_release_tools.commands.branch import cmd_rename
+
+    monkeypatch.setattr(
+        "repo_release_tools.commands.branch.git.current_branch",
+        lambda root: "add-rrt-for-conventianl-branching-name",
+    )
+
+    args = argparse.Namespace(
+        type="feat",
+        scope=None,
+        no_scope=False,
+        description=["rrt", "conventional", "branch", "naming", "enforcement"],
+        dry_run=True,
+    )
+    result = cmd_rename(args)
+
+    assert result == 0
+    out = capsys.readouterr().out
+    assert "feat/rrt-conventional-branch-naming-enforcement" in out
+
+
+def test_cmd_rename_non_conventional_branch_without_type_still_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Description words alone (no --type) against a non-conventional branch still fails."""
+    from repo_release_tools.commands.branch import cmd_rename
+
+    monkeypatch.setattr(
+        "repo_release_tools.commands.branch.git.current_branch",
+        lambda root: "add-rrt-for-conventianl-branching-name",
+    )
+
+    args = argparse.Namespace(
+        type=None,
+        scope=None,
+        no_scope=False,
+        description=["rrt", "conventional", "branch", "naming", "enforcement"],
+        dry_run=True,
+    )
+    result = cmd_rename(args)
+
+    assert result == 1
+    assert "convention" in capsys.readouterr().err
 
 
 def test_cmd_rename_branch_already_exists_returns_error(


### PR DESCRIPTION
## Summary
- `rrt branch rename` no longer refuses to run just because the *current* branch doesn't already match `<type>/<slug>` — if `--type` plus description words are supplied, it now rebuilds the name from scratch the same way `rrt branch new` would, instead of requiring something to preserve from the old name.
- The no-`--type` case against a non-conventional branch still fails with the original "does not follow the convention" error, since there's genuinely nothing to fall back to for the type.

Fixes #196.

## Test plan
- [x] `uv run pytest tests/commands/test_branch.py -q --no-cov` — 35 passed
- [x] `uv run pytest -q -m "not runtime"` — full suite, 3300 passed, 100.00% coverage
- [x] `uv run ruff check` / `ruff format --check` — clean
- [x] Manually reproduced the issue's exact repro in a scratch git repo: a non-conventionally-named branch + `rrt branch rename --type feat --dry-run "..."` now succeeds; the same command without `--type` still fails with the original error
- [x] Dogfooded the fix on this very PR's working branch, which was itself non-conventionally named by the originating tooling — used `rrt branch rename --type fix "..."` to bring it into compliance before committing