### PR TITLE
fix: rrt_init_run blocks event loop and hooks use cwd-relative paths

### DIFF
--- a/.claude/hooks/completeness_guard.py
+++ b/.claude/hooks/completeness_guard.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -56,7 +57,7 @@ def main() -> int:
     """Block when required shipped agent surfaces are missing."""
     _ = sys.stdin.read()
 
-    root = Path.cwd()
+    root = Path(os.environ.get("CLAUDE_PROJECT_DIR") or Path.cwd())
     if missing := [str(path) for path in REQUIRED_PATHS if not (root / path).exists()]:
         joined = ", ".join(missing)
         return _block(f"Missing required agent surfaces: {joined}")

--- a/.claude/hooks/coverage_non_regression.py
+++ b/.claude/hooks/coverage_non_regression.py
@@ -51,7 +51,7 @@ def main() -> int:
     # Ignore stdin payload (event JSON) for this deterministic check.
     _ = sys.stdin.read()
 
-    repo_root = Path.cwd()
+    repo_root = Path(os.environ.get("CLAUDE_PROJECT_DIR") or Path.cwd())
     coverage_xml = Path(os.getenv("COVERAGE_XML_PATH", str(repo_root / "coverage.xml")))
     baseline_file = Path(
         os.getenv("COVERAGE_BASELINE_FILE", str(repo_root / ".claude" / "coverage-baseline.json")),

--- a/.claude/hooks/drift_guard.py
+++ b/.claude/hooks/drift_guard.py
@@ -26,7 +26,7 @@ def main() -> int:
     """Run the canonical drift check and block if lockfile surfaces are stale."""
     _ = sys.stdin.read()
 
-    repo_root = Path.cwd()
+    repo_root = Path(os.environ.get("CLAUDE_PROJECT_DIR") or Path.cwd())
     command = os.getenv("RRT_DRIFT_CHECK_COMMAND", "uv run rrt drift check")
 
     env = os.environ.copy()

--- a/.claude/hooks/refresh_coverage_baseline.py
+++ b/.claude/hooks/refresh_coverage_baseline.py
@@ -134,7 +134,7 @@ def main() -> int:
     if not _extract_success(payload):
         return 0
 
-    repo_root = Path.cwd()
+    repo_root = Path(os.environ.get("CLAUDE_PROJECT_DIR") or Path.cwd())
     coverage_xml = repo_root / "coverage.xml"
     if not coverage_xml.exists():
         return 0

--- a/.claude/hooks/rrt_ux_guard.py
+++ b/.claude/hooks/rrt_ux_guard.py
@@ -18,6 +18,7 @@ Exit codes:
 from __future__ import annotations
 
 import json
+import os
 import re
 import sys
 from pathlib import Path
@@ -97,7 +98,7 @@ def _extract_paths(prompt: str) -> list[Path]:
     """Return existing Python files mentioned in the prompt."""
     raw = _PY_PATH.findall(prompt)
     found: list[Path] = []
-    root = Path.cwd()
+    root = Path(os.environ.get("CLAUDE_PROJECT_DIR") or Path.cwd())
     for p in raw:
         candidate = root / p
         if candidate.exists():

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 .claude/hooks/rrt_ux_guard.py",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/rrt_ux_guard.py\"",
             "timeout": 5
           }
         ]
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 .claude/hooks/check_push_coverage.py",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/check_push_coverage.py\"",
             "timeout": 900
           }
         ]
@@ -28,7 +28,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 .claude/hooks/rrt_ux_write_guard.py",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/rrt_ux_write_guard.py\"",
             "timeout": 5
           }
         ]
@@ -40,7 +40,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 .claude/hooks/refresh_coverage_baseline.py",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/refresh_coverage_baseline.py\"",
             "timeout": 60
           }
         ]
@@ -52,17 +52,17 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 .claude/hooks/completeness_guard.py",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/completeness_guard.py\"",
             "timeout": 60
           },
           {
             "type": "command",
-            "command": "python3 .claude/hooks/drift_guard.py",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/drift_guard.py\"",
             "timeout": 120
           },
           {
             "type": "command",
-            "command": "TARGET_COVERAGE_PCT=90 MAX_ABSOLUTE_DROP_PCT=10 MAX_RELATIVE_DROP_PCT=10 python3 .claude/hooks/coverage_non_regression.py",
+            "command": "TARGET_COVERAGE_PCT=90 MAX_ABSOLUTE_DROP_PCT=10 MAX_RELATIVE_DROP_PCT=10 python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/coverage_non_regression.py\"",
             "timeout": 60
           }
         ]

--- a/.rrt/drift.lock.toml
+++ b/.rrt/drift.lock.toml
@@ -1,237 +1,237 @@
 [meta]
-generated_at = "2026-07-12T07:17:01+00:00"
-rrt_version = "1.12.0"
+generated_at = "2026-08-11T05:06:39+00:00"
+rrt_version = "1.14.1"
 
 [sources.".claude/hooks/check_push_coverage.py"]
 hash = "sha256:d924f61fd56de0425b6cf14e5e4b9cf80f709bb95ffda1f7997fcb5b420a0aba"
 symbols = []
 lang = "text"
-updated_at = "2026-07-12T07:17:01+00:00"
+updated_at = "2026-08-11T05:06:39+00:00"
 
 [sources.".claude/hooks/completeness_guard.py"]
-hash = "sha256:915f26d0af9448dd4b50790112a7cabe0c4217000a07c3b49f2fde80bd352885"
+hash = "sha256:659e67419b6afcb97a5f30d8573d70a54809f71e7b06cf87c8b2b6512fc739aa"
 symbols = []
 lang = "text"
-updated_at = "2026-07-12T07:17:01+00:00"
+updated_at = "2026-08-11T05:06:39+00:00"
 
 [sources.".claude/hooks/coverage_non_regression.py"]
-hash = "sha256:c02b0d68676225a8f11a8a7e54bf4cd9da7ba212bab4150a5bc40f17045ed1c6"
+hash = "sha256:a7b7b00ea43fb7c7ea67846496710b9e523e4adcdfc5479d3f15c4c9e9d97811"
 symbols = []
 lang = "text"
-updated_at = "2026-07-12T07:17:01+00:00"
+updated_at = "2026-08-11T05:06:39+00:00"
 
 [sources.".claude/hooks/drift_guard.py"]
-hash = "sha256:a7a87a6925369f31638f6186dc280cec1dd9349baaded86256a7dca78bec47da"
+hash = "sha256:dd69d73e660df74527e4db300f9ff0b15ecbd02872208d8c1c4b2f4d88d145c7"
 symbols = []
 lang = "text"
-updated_at = "2026-07-12T07:17:01+00:00"
+updated_at = "2026-08-11T05:06:39+00:00"
 
 [sources.".claude/hooks/refresh_coverage_baseline.py"]
-hash = "sha256:3d829384f8449863d2068abd5456b10f21163768b33ec82ae8b0b333ee2d5016"
+hash = "sha256:1a6c483759483a2865d362e4212f673eb7ebf913e6341c10687fd54f88de1ff2"
 symbols = []
 lang = "text"
-updated_at = "2026-07-12T07:17:01+00:00"
+updated_at = "2026-08-11T05:06:39+00:00"
 
 [sources.".claude/hooks/rrt_ux_guard.py"]
-hash = "sha256:e0173dce9372fe79e658e108a71186e629b295851b521e06312a9411139fab91"
+hash = "sha256:ff91b196edbee9608bfce9a450681306e3322d09c1e4958b825d40936c185235"
 symbols = []
 lang = "text"
-updated_at = "2026-07-12T07:17:01+00:00"
+updated_at = "2026-08-11T05:06:39+00:00"
 
 [sources.".claude/hooks/rrt_ux_write_guard.py"]
 hash = "sha256:143ece27f1412dd4311a5358146b44da4a80b72d1eb4b6921f859e1c64f19ec0"
 symbols = []
 lang = "text"
-updated_at = "2026-07-12T07:17:01+00:00"
+updated_at = "2026-08-11T05:06:39+00:00"
 
 [sources.".claude/settings.json"]
-hash = "sha256:9daf7e934a24c3efd9c41903ba64a26592fa05b5d258080da575965c17343dd0"
+hash = "sha256:e76af9f5e9a491e9cfc23e122d0df9b0abe616cba2044b96208fbfcfd8463aa4"
 symbols = []
 lang = "text"
-updated_at = "2026-07-12T07:17:01+00:00"
+updated_at = "2026-08-11T05:06:39+00:00"
 
 [sources.".github/agents/artifact-router.agent.md"]
 hash = "sha256:0730aa06096c4c75e280ec36f1bd818c1e98a1ef65b550a216290998743146d7"
 symbols = []
 lang = "text"
-updated_at = "2026-07-12T07:17:01+00:00"
+updated_at = "2026-08-11T05:06:39+00:00"
 
 [sources.".github/agents/prompt-strategist.agent.md"]
 hash = "sha256:13eb4ea91cbae6e643f6d01b91de1c295c70b7fdd41712bf0ae647530329b4aa"
 symbols = []
 lang = "text"
-updated_at = "2026-07-12T07:17:01+00:00"
+updated_at = "2026-08-11T05:06:39+00:00"
 
 [sources.".github/agents/rrt-user-bootstrap.agent.md"]
 hash = "sha256:0b8e83de4267c18417b4e8f8b25e2fc54a51d084872436ace4aad7a1cde315c9"
 symbols = []
 lang = "text"
-updated_at = "2026-07-12T07:17:01+00:00"
+updated_at = "2026-08-11T05:06:39+00:00"
 
 [sources.".github/agents/rrt-user-branch-guard.agent.md"]
 hash = "sha256:72f9d5d622ed3b2a6f5813e7bcd37f35ac7be781b9b534af923b17c37049a2b9"
 symbols = []
 lang = "text"
-updated_at = "2026-07-12T07:17:01+00:00"
+updated_at = "2026-08-11T05:06:39+00:00"
 
 [sources.".github/agents/rrt-user-changelog-curator.agent.md"]
 hash = "sha256:f5f5a86f85334092e3c2059e511c072c40d7bddd41199d598f20bee701ac2d8c"
 symbols = []
 lang = "text"
-updated_at = "2026-07-12T07:17:01+00:00"
+updated_at = "2026-08-11T05:06:39+00:00"
 
 [sources.".github/agents/rrt-user-ci-failure-triage.agent.md"]
 hash = "sha256:ac0d5b2ec95b4256eac9746699647eafdd892da21e5cfd01122511530d09b889"
 symbols = []
 lang = "text"
-updated_at = "2026-07-12T07:17:01+00:00"
+updated_at = "2026-08-11T05:06:39+00:00"
 
 [sources.".github/agents/rrt-user-commit-lint-triage.agent.md"]
 hash = "sha256:9599fcf1e4f89d6191d9be3db934974d965aa51ada5e93913b6a46b0f5d0cbad"
 symbols = []
 lang = "text"
-updated_at = "2026-07-12T07:17:01+00:00"
+updated_at = "2026-08-11T05:06:39+00:00"
 
 [sources.".github/agents/rrt-user-config-validator.agent.md"]
 hash = "sha256:4a11815a420d2851c79624b56ca17887f8fa05c9dc999cfede47cd5c8c97a1d0"
 symbols = []
 lang = "text"
-updated_at = "2026-07-12T07:17:01+00:00"
+updated_at = "2026-08-11T05:06:39+00:00"
 
 [sources.".github/agents/rrt-user-docs-sync-auditor.agent.md"]
 hash = "sha256:36d0fa4b6c60d6f292b82a0940cec510d288d15c3b010ab5ffdfbc606fe70e1d"
 symbols = []
 lang = "text"
-updated_at = "2026-07-12T07:17:01+00:00"
+updated_at = "2026-08-11T05:06:39+00:00"
 
 [sources.".github/agents/rrt-user-release-readiness.agent.md"]
 hash = "sha256:b9ba2bea51f8fecbd84be64b807f5ee3e9a1c87e182b97710cf16d9218bb6e30"
 symbols = []
 lang = "text"
-updated_at = "2026-07-12T07:17:01+00:00"
+updated_at = "2026-08-11T05:06:39+00:00"
 
 [sources.".github/agents/rrt-user-upgrade-assistant.agent.md"]
 hash = "sha256:da6533455d4355c20b0861e5da050f25dae9b2a9027009470fc01c804e5504ec"
 symbols = []
 lang = "text"
-updated_at = "2026-07-12T07:17:01+00:00"
+updated_at = "2026-08-11T05:06:39+00:00"
 
 [sources.".github/agents/rrt-user-version-planner.agent.md"]
 hash = "sha256:bb7321dfc921421ca21656ded8aee1ed61e70add3259503b31f462ed80c7f98d"
 symbols = []
 lang = "text"
-updated_at = "2026-07-12T07:17:01+00:00"
+updated_at = "2026-08-11T05:06:39+00:00"
 
 [sources.".github/agents/universal-explore.agent.md"]
 hash = "sha256:9f6281b8d58430614f5ebc79699714790217021c95869f066e17cd142a6afe75"
 symbols = []
 lang = "text"
-updated_at = "2026-07-12T07:17:01+00:00"
+updated_at = "2026-08-11T05:06:39+00:00"
 
 [sources.".github/agents/universal-plan.agent.md"]
 hash = "sha256:832c4803a053f34600d3015163d5c4f7be6d05a29b1fe1884c763012bf15097e"
 symbols = []
 lang = "text"
-updated_at = "2026-07-12T07:17:01+00:00"
+updated_at = "2026-08-11T05:06:39+00:00"
 
 [sources.".github/agents/validation-reviewer.agent.md"]
 hash = "sha256:c8e7812143ba73b09a4b33e3255011b1ce70e95b7b864ce7f6a7957e7a0df870"
 symbols = []
 lang = "text"
-updated_at = "2026-07-12T07:17:01+00:00"
+updated_at = "2026-08-11T05:06:39+00:00"
 
 [sources.".github/copilot-instructions.md"]
 hash = "sha256:d9ca097acc9cebd234ef91b03bd6e4116bda9d1edc3254d484c96546830eb286"
 symbols = []
 lang = "text"
-updated_at = "2026-07-12T07:17:01+00:00"
+updated_at = "2026-08-11T05:06:39+00:00"
 
 [sources.".github/instructions/coverage-tests.instructions.md"]
 hash = "sha256:f7f78ed649f3b5e50b19ff28dc71a870b9314ca72e1d941a66895090ade6baef"
 symbols = []
 lang = "text"
-updated_at = "2026-07-12T07:17:01+00:00"
+updated_at = "2026-08-11T05:06:39+00:00"
 
 [sources.".github/instructions/repo-release-tools.instructions.md"]
 hash = "sha256:023fa5d870f88e91be714b97c107702c31d06ce90e159173a714bbdd74721ed8"
 symbols = []
 lang = "text"
-updated_at = "2026-07-12T07:17:01+00:00"
+updated_at = "2026-08-11T05:06:39+00:00"
 
 [sources.".github/instructions/self-correction.instructions.md"]
 hash = "sha256:e33656aa408c1c038a05e9056f6071d81696ff258815a191456e5001fc1cb864"
 symbols = []
 lang = "text"
-updated_at = "2026-07-12T07:17:01+00:00"
+updated_at = "2026-08-11T05:06:39+00:00"
 
 [sources.".github/instructions/tox-uv.instructions.md"]
 hash = "sha256:06a9d3f4576c66171f3278ca7b4a674e04ad02e99c0ff802752351607deb5a02"
 symbols = []
 lang = "text"
-updated_at = "2026-07-12T07:17:01+00:00"
+updated_at = "2026-08-11T05:06:39+00:00"
 
 [sources.".github/skills/rrt-user-bootstrap/SKILL.md"]
 hash = "sha256:5ad1f0eaafc241b64183ba92174274fb2971bad8c88e5515835db3942c4c5ea9"
 symbols = []
 lang = "text"
-updated_at = "2026-07-12T07:17:01+00:00"
+updated_at = "2026-08-11T05:06:39+00:00"
 
 [sources.".github/skills/rrt-user-branch-strategy/SKILL.md"]
 hash = "sha256:db8b0f0985cf9d38dff2832814ccfc5633ea6b6c21127c122cf61f30744f94d0"
 symbols = []
 lang = "text"
-updated_at = "2026-07-12T07:17:01+00:00"
+updated_at = "2026-08-11T05:06:39+00:00"
 
 [sources.".github/skills/rrt-user-changelog-automation/SKILL.md"]
 hash = "sha256:a8cb226d025addc58c86ab31507e8a59f3c337ddc9ea0acc710cf5c52575c50e"
 symbols = []
 lang = "text"
-updated_at = "2026-07-12T07:17:01+00:00"
+updated_at = "2026-08-11T05:06:39+00:00"
 
 [sources.".github/skills/rrt-user-ci-readiness/SKILL.md"]
 hash = "sha256:d164a0eebe1ea0e1a9540d54d63c1c8d13fa440751765d3b826c468169af8a74"
 symbols = []
 lang = "text"
-updated_at = "2026-07-12T07:17:01+00:00"
+updated_at = "2026-08-11T05:06:39+00:00"
 
 [sources.".github/skills/rrt-user-commit-quality/SKILL.md"]
 hash = "sha256:82b1261423641c5aa3de4fac56edc05ae0de71a67fde8bee392d9396a9b8c4eb"
 symbols = []
 lang = "text"
-updated_at = "2026-07-12T07:17:01+00:00"
+updated_at = "2026-08-11T05:06:39+00:00"
 
 [sources.".github/skills/rrt-user-config-safety/SKILL.md"]
 hash = "sha256:196b11ad0657a6524287e2b3f87e18f8737c6f6a6438b252a86081ad48d75806"
 symbols = []
 lang = "text"
-updated_at = "2026-07-12T07:17:01+00:00"
+updated_at = "2026-08-11T05:06:39+00:00"
 
 [sources.".github/skills/rrt-user-docs-consistency/SKILL.md"]
 hash = "sha256:bba5f6a7f90a2617366156d52697fb39d35cfa7d0bd843b1921bb14097cf642c"
 symbols = []
 lang = "text"
-updated_at = "2026-07-12T07:17:01+00:00"
+updated_at = "2026-08-11T05:06:39+00:00"
 
 [sources.".github/skills/rrt-user-mcp-server/SKILL.md"]
 hash = "sha256:6e36eec838008dd8aa49ec15c681f5e9b107002483b2d9c328b2405593c01c28"
 symbols = []
 lang = "text"
-updated_at = "2026-07-12T07:17:01+00:00"
+updated_at = "2026-08-11T05:06:39+00:00"
 
 [sources.".github/skills/rrt-user-migration-uvx-to-installed/SKILL.md"]
 hash = "sha256:c2aa81c0c3947034b653339df669006bd803530203c911bbf28e67daf535ea37"
 symbols = []
 lang = "text"
-updated_at = "2026-07-12T07:17:01+00:00"
+updated_at = "2026-08-11T05:06:39+00:00"
 
 [sources.".github/skills/rrt-user-release-flow/SKILL.md"]
 hash = "sha256:5d409a2ee9fb7b4c4e55d8c4dd7d9be7f11f5a21c89e3c1dbd7c53b1fd78cdd6"
 symbols = []
 lang = "text"
-updated_at = "2026-07-12T07:17:01+00:00"
+updated_at = "2026-08-11T05:06:39+00:00"
 
 [sources.".github/skills/rrt-user-versioning/SKILL.md"]
 hash = "sha256:5201a14259964a62b08acac3e440315529b4afe558b49e426a5a13e9aaf22395"
 symbols = []
 lang = "text"
-updated_at = "2026-07-12T07:17:01+00:00"
+updated_at = "2026-08-11T05:06:39+00:00"

--- a/src/repo_release_tools/mcp/apps.py
+++ b/src/repo_release_tools/mcp/apps.py
@@ -618,12 +618,13 @@ def register_apps(mcp: FastMCP) -> None:
             await proc.wait()
             return "[error]: rrt init timed out after 20 seconds"
 
-        output = stdout_bytes.decode()
-        stderr = stderr_bytes.decode()
+        stdout = stdout_bytes.decode(errors="replace")
+        stderr = stderr_bytes.decode(errors="replace")
+        output = stdout
         if stderr:
             output += f"\n[stderr]: {stderr}"
         if proc.returncode != 0:
-            details = (stderr or stdout_bytes.decode()).strip()
+            details = (stderr or stdout).strip()
             if details:
                 return f"[error]: rrt init exited with code {proc.returncode}: {details}"
             return f"[error]: rrt init exited with code {proc.returncode}"

--- a/src/repo_release_tools/mcp/apps.py
+++ b/src/repo_release_tools/mcp/apps.py
@@ -590,7 +590,7 @@ def register_apps(mcp: FastMCP) -> None:
         force: bool = False,
     ) -> str:
         """Run rrt init with the given target format. Defaults to dry_run=True for safety."""
-        import subprocess
+        import asyncio
         import sys
         from pathlib import Path
 
@@ -604,20 +604,29 @@ def register_apps(mcp: FastMCP) -> None:
             cmd.append("--dry-run")
         if force:
             cmd.append("--force")
+
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            cwd=str(root),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
         try:
-            result = subprocess.run(
-                cmd, cwd=str(root), capture_output=True, text=True, timeout=20.0
-            )
-        except subprocess.TimeoutExpired:
+            stdout_bytes, stderr_bytes = await asyncio.wait_for(proc.communicate(), timeout=20.0)
+        except TimeoutError:
+            proc.kill()
+            await proc.wait()
             return "[error]: rrt init timed out after 20 seconds"
-        output = result.stdout
-        if result.stderr:
-            output += f"\n[stderr]: {result.stderr}"
-        if result.returncode != 0:
-            details = (result.stderr or result.stdout).strip()
+
+        output = stdout_bytes.decode()
+        stderr = stderr_bytes.decode()
+        if stderr:
+            output += f"\n[stderr]: {stderr}"
+        if proc.returncode != 0:
+            details = (stderr or stdout_bytes.decode()).strip()
             if details:
-                return f"[error]: rrt init exited with code {result.returncode}: {details}"
-            return f"[error]: rrt init exited with code {result.returncode}"
+                return f"[error]: rrt init exited with code {proc.returncode}: {details}"
+            return f"[error]: rrt init exited with code {proc.returncode}"
         return output.strip() or "Init complete."
 
     @mcp.tool(

--- a/tests/mcp/test_apps.py
+++ b/tests/mcp/test_apps.py
@@ -357,20 +357,26 @@ def test_rrt_init(tmp_path: Path) -> None:
 # ── rrt_init_run ──────────────────────────────────────────────────────────────
 
 
+def _mock_proc(stdout: bytes = b"", stderr: bytes = b"", returncode: int = 0) -> AsyncMock:
+    proc = AsyncMock()
+    proc.communicate.return_value = (stdout, stderr)
+    proc.returncode = returncode
+    return proc
+
+
 def test_rrt_init_run_dry_run(tmp_path: Path) -> None:
     tools = _registered(tmp_path)
     ctx = _ctx(tmp_path)
-    fake_proc = MagicMock(stdout="Would write .rrt.toml", stderr="", returncode=0)
-    mock_run = MagicMock(return_value=fake_proc)
+    proc = _mock_proc(stdout=b"Would write .rrt.toml")
+    mock_exec = AsyncMock(return_value=proc)
 
     async def _run() -> str:
-        with patch("subprocess.run", mock_run):
+        with patch("asyncio.create_subprocess_exec", mock_exec):
             return await tools["rrt_init_run"](ctx)
 
     result = asyncio.run(_run())
     assert "Would write" in result
-    mock_run.assert_called_once()
-    assert mock_run.call_args.kwargs["timeout"] == 20.0
+    mock_exec.assert_called_once()
 
 
 def test_rrt_init_run_rejects_unknown_target_without_invoking_subprocess(
@@ -379,25 +385,25 @@ def test_rrt_init_run_rejects_unknown_target_without_invoking_subprocess(
     """SEC-007: an unallowlisted `target` must never reach subprocess argv."""
     tools = _registered(tmp_path)
     ctx = _ctx(tmp_path)
-    mock_run = MagicMock()
+    mock_exec = AsyncMock()
 
     async def _run() -> str:
-        with patch("subprocess.run", mock_run):
+        with patch("asyncio.create_subprocess_exec", mock_exec):
             return await tools["rrt_init_run"](ctx, target="rrt-toml; rm -rf /")
 
     result = asyncio.run(_run())
     assert "[error]" in result
     assert "Invalid target" in result
-    mock_run.assert_not_called()
+    mock_exec.assert_not_called()
 
 
 def test_rrt_init_run_apply(tmp_path: Path) -> None:
     tools = _registered(tmp_path)
     ctx = _ctx(tmp_path)
-    fake_proc = MagicMock(stdout="Wrote .rrt.toml", stderr="", returncode=0)
+    proc = _mock_proc(stdout=b"Wrote .rrt.toml")
 
     async def _run() -> str:
-        with patch("subprocess.run", return_value=fake_proc):
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
             return await tools["rrt_init_run"](ctx, target="rrt-toml", dry_run=False, force=False)
 
     result = asyncio.run(_run())
@@ -407,10 +413,10 @@ def test_rrt_init_run_apply(tmp_path: Path) -> None:
 def test_rrt_init_run_with_stderr(tmp_path: Path) -> None:
     tools = _registered(tmp_path)
     ctx = _ctx(tmp_path)
-    fake_proc = MagicMock(stdout="", stderr="some warning", returncode=1)
+    proc = _mock_proc(stderr=b"some warning", returncode=1)
 
     async def _run() -> str:
-        with patch("subprocess.run", return_value=fake_proc):
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
             return await tools["rrt_init_run"](ctx)
 
     result = asyncio.run(_run())
@@ -421,10 +427,10 @@ def test_rrt_init_run_with_stderr(tmp_path: Path) -> None:
 def test_rrt_init_run_empty_output(tmp_path: Path) -> None:
     tools = _registered(tmp_path)
     ctx = _ctx(tmp_path)
-    fake_proc = MagicMock(stdout="", stderr="", returncode=0)
+    proc = _mock_proc()
 
     async def _run() -> str:
-        with patch("subprocess.run", return_value=fake_proc):
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
             return await tools["rrt_init_run"](ctx, force=True)
 
     result = asyncio.run(_run())
@@ -434,10 +440,10 @@ def test_rrt_init_run_empty_output(tmp_path: Path) -> None:
 def test_rrt_init_run_nonzero_no_output(tmp_path: Path) -> None:
     tools = _registered(tmp_path)
     ctx = _ctx(tmp_path)
-    fake_proc = MagicMock(stdout="", stderr="", returncode=1)
+    proc = _mock_proc(returncode=1)
 
     async def _run() -> str:
-        with patch("subprocess.run", return_value=fake_proc):
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
             return await tools["rrt_init_run"](ctx)
 
     result = asyncio.run(_run())
@@ -448,18 +454,22 @@ def test_rrt_init_run_nonzero_no_output(tmp_path: Path) -> None:
 def test_rrt_init_run_timeout(tmp_path: Path) -> None:
     tools = _registered(tmp_path)
     ctx = _ctx(tmp_path)
+    proc = AsyncMock()
+    proc.communicate.return_value = (b"", b"")
+    proc.kill = MagicMock()
+    proc.wait = AsyncMock()
 
     async def _run() -> str:
-        with patch(
-            "subprocess.run",
-            side_effect=subprocess.TimeoutExpired(
-                cmd=["python", "-m", "repo_release_tools.cli"], timeout=20
-            ),
+        with (
+            patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)),
+            patch("asyncio.wait_for", AsyncMock(side_effect=TimeoutError)),
         ):
             return await tools["rrt_init_run"](ctx)
 
     result = asyncio.run(_run())
     assert result == "[error]: rrt init timed out after 20 seconds"
+    proc.kill.assert_called_once()
+    proc.wait.assert_awaited_once()
 
 
 # ── rrt_locks_overview ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **#204**: `rrt_init_run` now uses `asyncio.create_subprocess_exec` + `asyncio.wait_for` instead of blocking `subprocess.run`, so a slow `rrt init` no longer stalls the FastMCP event loop for other concurrent MCP requests. On timeout, the child process is now explicitly killed and reaped instead of left orphaned.
- **#205**: `.claude/settings.json` hook commands now resolve their script path via `$CLAUDE_PROJECT_DIR` instead of a bare relative path, so a single `cd` mid-session can no longer make every subsequent tool call fail its hook and brick the session. The five hook scripts that computed repo root via `Path.cwd()` (`completeness_guard.py`, `coverage_non_regression.py`, `drift_guard.py`, `refresh_coverage_baseline.py`, `rrt_ux_guard.py`) now prefer `$CLAUDE_PROJECT_DIR` too, so they act on the correct directory even when invoked after a cwd drift — not just get found, but behave correctly.
- `.rrt/drift.lock.toml` regenerated to match the edited hook/settings files.

Closes #204, closes #205.

## Test plan

- [x] `uv run pytest tests/mcp/test_apps.py -k init_run -xvs` — all 7 `rrt_init_run` tests pass against the new `asyncio.create_subprocess_exec` implementation
- [x] `uv run pytest -q -m "not runtime"` — full unit suite, 3300 passed, 100.00% coverage
- [x] `python3 -m json.tool .claude/settings.json` — valid JSON
- [x] Manually ran all 5 edited hook scripts from `/tmp` with `CLAUDE_PROJECT_DIR` set, confirmed correct repo-root resolution despite the drifted cwd
- [x] `uv run rrt drift check` — lockfile current
- [x] `uvx pre-commit run --all-files` — all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
