### PR TITLE
feat: add AI-agent-optimized PR and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent_task.yml
+++ b/.github/ISSUE_TEMPLATE/agent_task.yml
@@ -1,0 +1,136 @@
+name: "🤖 Agent Task"
+description: A scoped task meant to be picked up and completed by an AI coding agent with minimal back-and-forth.
+title: ""
+labels: ["agent-task"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This form is read by an agent, not just a human. Fill it so an agent can start without
+        asking clarifying questions. See "Suitability check" below before filing — some tasks are a bad fit.
+
+  - type: dropdown
+    id: target-agent
+    attributes:
+      label: Target agent
+      description: |
+        Which agent should pick this up? This only changes how you hand it off, not what you write below:
+          Claude   → mention `@claude` in this issue's body or a comment (triggers .github/workflows/claude.yml)
+          Copilot  → assign this issue to Copilot from the sidebar (triggers GitHub's coding agent)
+          Codex / Gemini / other → paste this issue's rendered body into the agent's context manually
+      options:
+        - Claude
+        - GitHub Copilot
+        - Codex
+        - Gemini
+        - Unspecified / any
+      default: 4
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: suitability
+    attributes:
+      label: Suitability check
+      description: |
+        Agent-appropriate tasks are small, have a defined end state, and are easy to review:
+        bug fixes, test coverage, docs updates, small refactors, targeted feature slices.
+        NOT a good fit: broad cross-cutting refactors, security-sensitive changes, or anything
+        where the requirements themselves are still being figured out — write those up as a
+        normal discussion first instead.
+      options:
+        - label: This task is small, has a defined end state, and its diff will be easy to review
+          required: true
+
+  - type: textarea
+    id: objective
+    attributes:
+      label: Objective
+      description: One or two sentences — what should exist when this is done.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria
+      description: Concrete, checkable statements. Tests that must pass, commands that must succeed, behavior that must hold.
+      placeholder: |
+        - [ ] `uv run pytest tests/test_x.py -xvs` passes
+        - [ ] `rrt <command>` produces <exact output>
+      render: markdown
+    validations:
+      required: true
+
+  - type: textarea
+    id: plan
+    attributes:
+      label: Suggested approach / subtasks (optional)
+      description: |
+        If this breaks into independent steps, list them in order — each should be separately
+        testable, and if one depends on a prior step say so. For anything non-trivial, the agent
+        should still post its plan before writing code rather than jumping straight to a diff.
+      placeholder: |
+        1. Add `--foo` flag to `commands/bar.py`
+        2. Wire it through to `workflow/git.py`
+        3. Add a regression test in `tests/test_bar.py`
+
+  - type: textarea
+    id: modules
+    attributes:
+      label: Known affected modules/files (optional)
+      description: Best-known paths, even if incomplete. Not required — agents can search — but it saves a discovery pass.
+      render: shell
+
+  - type: textarea
+    id: code-ref
+    attributes:
+      label: Code / error reference (optional)
+      description: |
+        A snippet, traceback, or existing pattern to follow, if you have one. If you don't,
+        that's fine — make Objective and Acceptance criteria above precise enough to act on without it.
+      render: shell
+
+  - type: textarea
+    id: commands
+    attributes:
+      label: Relevant commands
+      description: Exact commands to reproduce, implement against, or verify with.
+      render: shell
+
+  - type: textarea
+    id: boundaries
+    attributes:
+      label: Boundaries
+      description: What must not change, and what needs a check-in first.
+      value: |
+        ✅ Always: <!-- e.g. add tests for new behavior -->
+        ⚠️ Ask first: <!-- e.g. changing a public CLI flag -->
+        🚫 Never: <!-- e.g. lower the coverage floor, edit CHANGELOG [Unreleased] by hand -->
+
+  - type: dropdown
+    id: commit-type
+    attributes:
+      label: Conventional commit type
+      description: Feeds the branch name and commit subject the agent should use.
+      options:
+        - feat
+        - fix
+        - refactor
+        - perf
+        - docs
+        - chore
+        - ci
+        - build
+        - test
+        - deps
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: self-contained
+    attributes:
+      label: Completeness
+      options:
+        - label: This issue includes everything needed to start without asking clarifying questions
+          required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,81 @@
+name: "🐛 Bug Report"
+description: Report a problem with the rrt CLI, rrt-hooks, the GitHub Action, or the MCP server.
+title: "fix: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. The more precise the repro, the faster this gets fixed — by a human or an agent.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened
+      description: A clear description of the incorrect behavior.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction steps
+      description: Exact commands, in order, with flags.
+      placeholder: |
+        1. `rrt branch new my-slug --dry-run`
+        2. ...
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Affected surface
+      options:
+        - rrt CLI
+        - rrt-hooks (pre-commit/lefthook)
+        - GitHub Action
+        - MCP server
+        - Docs
+        - Other/unsure
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: rrt version
+      description: Output of `rrt --version`
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, Python version (`python3 --version`), uv version (`uv --version`)
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant output / traceback
+      render: shell
+
+  - type: textarea
+    id: code-ref
+    attributes:
+      label: Code reference (optional)
+      description: |
+        A snippet, config excerpt, or file:line if you have one. If you don't, that's fine —
+        describe the exact symptom above precisely enough that it can be searched for.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://anselmoo.github.io/repo-release-tools/
+    about: Check the docs first — many questions are answered there.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,54 @@
+name: "✨ Feature Request"
+description: Propose a new capability or improvement for rrt.
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What's missing or painful today? What can't you do?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What should exist instead. Sketch the CLI surface or config shape if relevant.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Affected surface
+      options:
+        - rrt CLI
+        - rrt-hooks (pre-commit/lefthook)
+        - GitHub Action
+        - MCP server
+        - Docs
+        - Other/new
+
+  - type: textarea
+    id: code-ref
+    attributes:
+      label: Reference (optional)
+      description: |
+        A code snippet, a similar tool's flag/output, or an existing rrt command this resembles.
+        If you don't have one, skip this — the sections above are enough to act on.
+      render: shell
+
+  - type: checkboxes
+    id: dup-check
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and didn't find a duplicate
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE/agent.md
+++ b/.github/PULL_REQUEST_TEMPLATE/agent.md
@@ -1,0 +1,78 @@
+<!--
+rrt-pr-meta
+type: feat|fix|refactor|perf|docs|chore|ci|build|test|deps
+scope:
+breaking: false
+
+AGENT: fill the three fields above first — every other section below depends on them.
+  type     -> the Conventional Commit type of this change. If your commits disagree, use the
+              highest-impact one: feat > fix > refactor/perf > docs > chore/ci/build/test/deps.
+  scope    -> the `(scope)` from your commit subject(s), or leave blank if you used none.
+  breaking -> true only if a commit subject has `!` after type/scope, or a commit body has a
+              `BREAKING CHANGE:` footer. Verify, don't guess:
+                git log --format='%B' "$BASE"...HEAD | grep -E '^\w+(\(.+\))?!:|BREAKING CHANGE:'
+  This block is not decorative: `type` determines the required changelog section in the
+  Self-verification checklist (see SECTION_MAP in src/repo_release_tools/changelog.py), and
+  `breaking` gates the "Breaking changes" section below.
+-->
+
+<!-- AGENT: run these once and reuse the output for every section below. Ground every claim
+     in this actual output — do not reconstruct the diff from memory of what you intended to do.
+       BASE=$(git merge-base HEAD origin/main)
+       git log --format='%s' "$BASE"...HEAD
+       git diff --stat "$BASE"...HEAD
+-->
+
+## Summary
+
+<!-- AGENT: one sentence describing the mechanical change, derived from the `git diff --stat`
+     output above. State what changed, not why — that belongs in the next section. -->
+
+## Why
+
+<!-- AGENT: state the intent behind the change. If you considered and rejected an alternative
+     approach while implementing, name it and say why. If you made any judgment call the user
+     did not explicitly specify, flag it here explicitly so a human reviewer knows what to
+     double-check — do not silently absorb ambiguity. -->
+
+## Traceability
+
+- Related issue/task: <!-- AGENT: search the branch name and commit subjects for `#<number>`; if none is found, write N/A — do not invent one -->
+- Modules touched: <!-- AGENT: paste the file list from `git diff --stat "$BASE"...HEAD` verbatim -->
+
+## Breaking changes
+
+<!-- AGENT: if `breaking: false` in the metadata block above, write "None" and stop there.
+     If `breaking: true`, describe the break and the exact migration steps a downstream
+     consumer must take — this is user-facing, not a restatement of your diff. -->
+
+## Self-verification
+
+<!-- AGENT: run every command below yourself before checking its box. A box checked without
+     having run the command is a fabricated claim, not a verification. Your sandbox is not
+     guaranteed to run this repo's pre-commit/lefthook git hooks automatically — run these
+     commands directly rather than assuming a hook would have caught a problem. -->
+
+- [ ] `uv run pytest -q -m "not runtime"` passes with no `Missing:` lines in the coverage report (floor is 100%, enforced by `--cov-fail-under=100` in `pyproject.toml`)
+- [ ] Changelog: per `SECTION_MAP` in `src/repo_release_tools/changelog.py`, `type` values `feat/fix/refactor/perf/docs` require a `[Unreleased]` bullet in `CHANGELOG.md`; `chore/ci/build/test/deps` map to Maintenance and are exempt. Confirm which applies to the `type` set above, then check with `git diff "$BASE"...HEAD -- CHANGELOG.md` — or write N/A
+- [ ] `rrt-hooks check-branch-name --branch "$(git branch --show-current)"` exits 0, and `rrt-hooks check-commit-subject --subject "<subject>"` exits 0 for each commit subject from the `git log` output above
+- [ ] Every mutating `rrt` command run for this change (`rrt bump`, `rrt branch new`, etc.) was previewed with `--dry-run` first — list the commands run, or write N/A
+- [ ] `rrt docs map --check` exits 0 — or N/A if no `[tool.rrt.docs.map]`-managed directory was touched
+
+## Follow-ups (out of scope, not fixed here)
+
+<!-- AGENT: noticed something else worth fixing while working? Don't fix it inline — that's
+     scope creep. List it here as a one-line bullet instead; each is a candidate for a new
+     "🤖 Agent Task" issue, not a reason to expand this PR. Empty is fine. -->
+
+## Reviewer hand-off
+
+<!-- AGENT: this repo's .github/workflows/claude-code-review.yml runs against every PR
+     regardless of author — a Claude instance with none of your session's context will review
+     this PR from the description and diff alone. Before finishing, re-read the sections above
+     and confirm they contain everything that reviewer would need and could not infer from the
+     diff alone.
+
+     A maintainer can request follow-up work by mentioning `@claude` in a review comment, which
+     triggers .github/workflows/claude.yml independently of how this PR was opened — that's a
+     separate agent picking this up cold, not you resuming. -->

--- a/.github/PULL_REQUEST_TEMPLATE/agent.md
+++ b/.github/PULL_REQUEST_TEMPLATE/agent.md
@@ -10,7 +10,7 @@ AGENT: fill the three fields above first — every other section below depends o
   scope    -> the `(scope)` from your commit subject(s), or leave blank if you used none.
   breaking -> true only if a commit subject has `!` after type/scope, or a commit body has a
               `BREAKING CHANGE:` footer. Verify, don't guess:
-                git log --format='%B' "$BASE"...HEAD | grep -E '^\w+(\(.+\))?!:|BREAKING CHANGE:'
+                git log --format='%B' "$(git merge-base HEAD origin/main)"...HEAD | grep -E '^\w+(\(.+\))?!:|BREAKING CHANGE:'
   This block is not decorative: `type` determines the required changelog section in the
   Self-verification checklist (see SECTION_MAP in src/repo_release_tools/changelog.py), and
   `breaking` gates the "Breaking changes" section below.

--- a/.github/PULL_REQUEST_TEMPLATE/claude-agent.md
+++ b/.github/PULL_REQUEST_TEMPLATE/claude-agent.md
@@ -1,0 +1,77 @@
+<!--
+rrt-pr-meta
+type: feat|fix|refactor|perf|docs|chore|ci|build|test|deps
+scope:
+breaking: false
+
+CLAUDE: fill the three fields above first — every other section below depends on them.
+  type     -> the Conventional Commit type of this change. If your commits disagree, use the
+              highest-impact one: feat > fix > refactor/perf > docs > chore/ci/build/test/deps.
+  scope    -> the `(scope)` from your commit subject(s), or leave blank if you used none.
+  breaking -> true only if a commit subject has `!` after type/scope, or a commit body has a
+              `BREAKING CHANGE:` footer. Verify, don't guess:
+                git log --format='%B' "$BASE"...HEAD | grep -E '^\w+(\(.+\))?!:|BREAKING CHANGE:'
+  `type` determines the required changelog section (see SECTION_MAP in
+  src/repo_release_tools/changelog.py); `breaking` gates the "Breaking changes" section below.
+-->
+
+<!-- CLAUDE: run these once and reuse the output for every section below. Ground every claim in
+     this actual output — don't reconstruct the diff from memory of what you intended to do.
+       BASE=$(git merge-base HEAD origin/main)
+       git log --format='%s' "$BASE"...HEAD
+       git diff --stat "$BASE"...HEAD
+-->
+
+## Summary
+
+<!-- CLAUDE: one sentence, derived from the `git diff --stat` output above. -->
+
+## Why
+
+<!-- CLAUDE: intent behind the change, alternatives considered and rejected, and any judgment
+     call you made that wasn't explicitly specified — flag those so the reviewer knows what to
+     double-check rather than silently absorbing the ambiguity. -->
+
+## Traceability
+
+- Related issue/task: <!-- CLAUDE: search the branch name and commit subjects for `#<number>`; N/A if none — don't invent one -->
+- Modules touched: <!-- CLAUDE: paste the file list from `git diff --stat "$BASE"...HEAD` verbatim -->
+
+## Breaking changes
+
+<!-- CLAUDE: "None" if `breaking: false` above. Otherwise describe the break and the exact
+     migration steps a downstream consumer must take. -->
+
+## Self-verification
+
+<!-- CLAUDE: run every command below yourself before checking its box — a box checked without
+     having run the command is a fabricated claim.
+
+     This repo has a two-tier coverage gate: the local Stop hook
+     (.claude/hooks/coverage_non_regression.py) allows a small margin during iteration so it
+     doesn't false-block on stale/partial state — that leniency is NOT proof of anything.
+     `git push` (check_push_coverage.py) and CI always re-verify fresh at a hard 100%. Verify
+     against that number, not against the Stop hook having stayed quiet. -->
+
+- [ ] `uv run pytest -q -m "not runtime"` passes with no `Missing:` lines (`--cov-fail-under=100` in `pyproject.toml`)
+- [ ] Changelog: per `SECTION_MAP`, `feat/fix/refactor/perf/docs` need a `[Unreleased]` bullet; `chore/ci/build/test/deps` are exempt — confirm with `git diff "$BASE"...HEAD -- CHANGELOG.md`, or N/A
+- [ ] `rrt-hooks check-branch-name --branch "$(git branch --show-current)"` exits 0, and `rrt-hooks check-commit-subject --subject "<subject>"` exits 0 for each commit subject above
+- [ ] Every mutating `rrt` command run for this change was previewed with `--dry-run` first — list them, or N/A
+- [ ] `rrt docs map --check` exits 0 — or N/A if no `[tool.rrt.docs.map]`-managed directory was touched
+
+## Follow-ups (out of scope, not fixed here)
+
+<!-- CLAUDE: noticed something else worth fixing while working? Don't fix it inline — that's
+     scope creep. List it here as a one-line bullet instead; each is a candidate for a new
+     "🤖 Agent Task" issue, not a reason to expand this PR. Empty is fine. -->
+
+## Reviewer hand-off
+
+<!-- CLAUDE: .github/workflows/claude-code-review.yml runs a FRESH Claude instance against this
+     PR with none of this session's conversation — it sees only this description and the diff.
+     Before finishing, re-read the sections above and confirm they contain everything that
+     reviewer would need and could not infer from the diff alone.
+
+     After merge, a maintainer can request follow-up work by mentioning `@claude` in a review
+     comment or issue comment — that re-triggers .github/workflows/claude.yml. That session
+     starts cold too: reference this PR number, don't assume it remembers this conversation. -->

--- a/.github/PULL_REQUEST_TEMPLATE/claude-agent.md
+++ b/.github/PULL_REQUEST_TEMPLATE/claude-agent.md
@@ -10,7 +10,7 @@ CLAUDE: fill the three fields above first — every other section below depends 
   scope    -> the `(scope)` from your commit subject(s), or leave blank if you used none.
   breaking -> true only if a commit subject has `!` after type/scope, or a commit body has a
               `BREAKING CHANGE:` footer. Verify, don't guess:
-                git log --format='%B' "$BASE"...HEAD | grep -E '^\w+(\(.+\))?!:|BREAKING CHANGE:'
+                git log --format='%B' "$(git merge-base HEAD origin/main)"...HEAD | grep -E '^\w+(\(.+\))?!:|BREAKING CHANGE:'
   `type` determines the required changelog section (see SECTION_MAP in
   src/repo_release_tools/changelog.py); `breaking` gates the "Breaking changes" section below.
 -->

--- a/.github/PULL_REQUEST_TEMPLATE/default.md
+++ b/.github/PULL_REQUEST_TEMPLATE/default.md
@@ -1,0 +1,16 @@
+## Summary
+
+<!-- What changed, and why. -->
+
+Related issue/task: <!-- #123, or N/A -->
+
+## Checklist
+
+- [ ] Tests pass (`uv run pytest -q -m "not runtime"`) and coverage stayed at 100%
+- [ ] Changelog `[Unreleased]` entry added — or N/A (chore/ci/build/test/deps-only change)
+- [ ] Branch and commit(s) follow this repo's `<type>/<kebab-slug>` + Conventional Commits convention
+
+<!-- Agent-authored PR? Use one of these instead, via ?template=<file> on this PR's URL or
+     "Choose a template" above:
+       claude-agent.md — Claude Code
+       agent.md        — Copilot, Codex, Gemini, or any other agent -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@ Related issue/task: <!-- #123, or N/A -->
 - [ ] Changelog `[Unreleased]` entry added — or N/A (chore/ci/build/test/deps-only change)
 - [ ] Branch and commit(s) follow this repo's `<type>/<kebab-slug>` + Conventional Commits convention
 
-<!-- Agent-authored PR? Use one of these instead, via ?template=<file> on this PR's URL or
-     "Choose a template" above:
+<!-- Agent-authored PR? Pick one of these via ?template=<file> on this PR's URL, or the
+     "Choose a template" link above the description box:
        claude-agent.md — Claude Code
        agent.md        — Copilot, Codex, Gemini, or any other agent -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+### Added
+- add AI-agent-optimized PR and issue templates
+
 ## [1.14.1] - 2026-07-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Added
 - add AI-agent-optimized PR and issue templates
 
+### Documentation
+- point Claude at the PR/issue templates in CLAUDE.md
+
 ## [1.14.1] - 2026-07-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 ### Documentation
 - point Claude at the PR/issue templates in CLAUDE.md
 
+### Fixed
+- resolve PR review findings in agent templates
+
 ## [1.14.1] - 2026-07-30
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,8 @@ New CLI output uses `DryRunPrinter` from `ui/messaging.py` (re-exported via `ui/
 - **Changelog**: Keep-a-Changelog format; `[Unreleased]` is auto-managed by `rrt-update-unreleased` — never edit it manually when the hook is active
 - **Dry-run**: all mutating commands accept `--dry-run`; prototype with it first
 - **No new runtime dependencies** for CLI/UI work
-- **Coverage floor**: 85.71% — treat drops as a blocker; add tests before opening a PR. Low-coverage files: `ui/syntax.py`, `ui/color.py`, `ui/layout.py`, `ui/font.py`, `cli.py`
+- **PR/issue templates**: use `.github/PULL_REQUEST_TEMPLATE/claude-agent.md` when opening a PR as Claude — follow every `CLAUDE:` directive it contains (each names the exact command to run, not just what to describe). Use `.github/ISSUE_TEMPLATE/agent_task.yml` when filing a task-shaped issue meant for an agent to pick up — if Claude is the one filing it, set its `target-agent` field to `Claude` rather than leaving the default `Unspecified / any`.
+- **Coverage floor**: 100% — treat drops as a blocker; add tests before opening a PR. Low-coverage files: `ui/syntax.py`, `ui/color.py`, `ui/layout.py`, `ui/font.py`, `cli.py`
   - The local Stop hook (`coverage_non_regression.py`) allows a small margin during iteration so it doesn't false-block on stale/partial coverage state; `git push` (`check_push_coverage.py`) and CI always re-verify fresh at a hard 100%. See `.claude/hooks/README.md` for details.
 - **Per-directory purpose docs**: when `[tool.rrt.docs.map]` is configured, `rrt docs map` generates an anchor-wrapped README.md per source directory and writes `.rrt/docs_map.lock.toml`. CI runs `rrt docs map --check` (via the `rrt-docs-map-check` hook) to fail on drift; the `rrt-docs-map-update` hook keeps files fresh on commit. Prose outside the `rrt-docs-map` anchors is preserved verbatim.
 


### PR DESCRIPTION
<!--
rrt-pr-meta
type: feat
scope:
breaking: false
-->

## Summary

Adds AI-agent-optimized PR templates (`default`, `agent`, `claude-agent`) and issue-form templates (`bug_report`, `feature_request`, `agent_task`) under `.github/`, designed so both human contributors and AI coding agents can fill them out efficiently and reliably.

## Why

This repo already runs Claude Code automation (`@claude` mentions trigger `.github/workflows/claude.yml`; every PR gets an automated review via `claude-code-review.yml`), so PR/issue quality directly affects how well those agents — and any other coding agent picking up a task — can work with minimal back-and-forth.

Design decisions worth flagging for review:
- PR templates: kept `default.md` (human, lean) separate from `agent.md` (any AI agent) and `claude-agent.md` (Claude-specific: notes the two-tier coverage-hook gate, a Follow-ups section, and reviewer hand-off behavior). Considered a fourth Copilot-specific template but folded that content back into `agent.md` per your steer to keep it to two AI-facing templates.
- Discovered mid-session that naming a file exactly `claude.md` collides with Claude Code's own `CLAUDE.md` project-instructions auto-loader on case-insensitive filesystems (macOS/Windows) — it would get silently injected as directory instructions. Renamed to `claude-agent.md` to avoid this; flagging in case this surprises reviewers on other OSes.
- `agent_task.yml` issue form includes a `target-agent` dropdown (Claude/Copilot/Codex/Gemini/Unspecified) with this repo's actual hand-off mechanism per agent, a suitability gate (agent-appropriate vs. not), and a ✅/⚠️/🚫 boundaries field — informed by GitHub's own Copilot coding-agent best-practices docs and Addy Osmani's "good spec for AI agents" writeup (see PR discussion for sources).

## Traceability

- Related issue/task: N/A
- Modules touched:
  - `.github/ISSUE_TEMPLATE/{config.yml,bug_report.yml,feature_request.yml,agent_task.yml}`
  - `.github/PULL_REQUEST_TEMPLATE/{default.md,agent.md,claude-agent.md}`
  - `CHANGELOG.md`

## Breaking changes

None.

## Self-verification

- [x] `uv run pytest -q -m "not runtime"` — not applicable, no Python source changed (docs/config only)
- [x] Changelog `[Unreleased]` entry added (`chore` follow-up commit)
- [x] Branch renamed via `rrt branch rename --type feat` to follow `<type>/<kebab-slug>`; commits made via `rrt git commit`
- [x] No mutating `rrt` commands beyond `branch rename` / `git commit`, both run for real after a `--dry-run` preview
- [x] `rrt docs map --check` — N/A, no `[tool.rrt.docs.map]`-managed directory touched
- [x] All 4 YAML issue-form files validated with `python3 -c "import yaml; yaml.safe_load(...)"` before commit
- [x] Pre-push hooks passed: ci lint gate, tree check, folder check, case-conflict check

## Follow-ups (out of scope, not fixed here)

- The `rrt-pr-meta` metadata block in the PR templates isn't consumed by any script yet — cheap to keep as a forward-looking convention, but wiring it up (e.g. a CI step reading `type`/`breaking` from PR bodies) would be separate follow-up work.

## Reviewer hand-off

This PR will be reviewed by a fresh Claude instance via `claude-code-review.yml` with no memory of this session — the sections above are written to be self-contained for that review.