### PR TITLE
refactor: consolidate command declaration into a single registry

### DIFF
--- a/.rrt/tree.lock.toml
+++ b/.rrt/tree.lock.toml
@@ -1,10 +1,10 @@
 [meta]
-generated_at = "2026-07-30T05:03:14+00:00"
-rrt_version = "1.14.0"
+generated_at = "2026-08-11T06:37:06+00:00"
+rrt_version = "1.14.1"
 
 [snapshot]
-entry_count = 417
-tree_hash = "sha256:968a0224c04c06903cf5b87824519313aece4b030658a772b63d0bf7403ff269"
-updated_at = "2026-07-30T05:03:14+00:00"
+entry_count = 419
+tree_hash = "sha256:2dc327811c46089db1080042105860f06c6730150cbe69e985382869f956344a"
+updated_at = "2026-08-11T06:37:06+00:00"
 ignored_count = 34
 phantom_empty_dirs = []

--- a/docs/src/content/docs/commands/repo-health.mdx
+++ b/docs/src/content/docs/commands/repo-health.mdx
@@ -8,74 +8,29 @@ description: "Generated command reference for the Repository Health command grou
 {/* Auto-generated from repo_release_tools.cli.build_parser(); run `rrt docs publish` to refresh. */}
 
 {/* rrt:auto:start:toc */}
-- [`rrt doctor`](#rrt-doctor)
-  - [Overview](#overview)
-  - [What it checks](#what-it-checks)
-  - [Output and severity](#output-and-severity)
-  - [Config discovery behavior](#config-discovery-behavior)
-  - [Examples](#examples)
-  - [Caveats](#caveats)
-  - [Related docs](#related-docs)
 - [`rrt artifacts`](#rrt-artifacts)
-  - [Overview](#overview-1)
+  - [Overview](#overview)
   - [Configuration](#configuration)
   - [Subcommands](#subcommands)
-  - [Examples](#examples-1)
-- [`rrt fields`](#rrt-fields)
-  - [Overview](#overview-2)
-  - [Configuration](#configuration-1)
-  - [Subcommands](#subcommands-1)
-  - [Examples](#examples-2)
-  - [Caveats](#caveats-1)
+  - [Examples](#examples)
 - [`rrt config`](#rrt-config)
-  - [Overview](#overview-3)
+  - [Overview](#overview-1)
   - [What the command reports](#what-the-command-reports)
   - [Raw mode](#raw-mode)
   - [Validate mode](#validate-mode)
   - [Schema mode](#schema-mode)
   - [Failure behavior](#failure-behavior)
-  - [Examples](#examples-3)
-  - [Caveats](#caveats-2)
-- [`rrt env`](#rrt-env)
-  - [Overview](#overview-4)
-  - [What it reports](#what-it-reports)
-  - [JSON mode](#json-mode)
-  - [Examples](#examples-4)
-  - [Caveats](#caveats-3)
-  - [`rrt env check`](#rrt-env-check)
-- [`rrt eol`](#rrt-eol)
-  - [Overview](#overview-5)
-  - [What the command checks](#what-the-command-checks)
-  - [Data sources](#data-sources)
-  - [Policy behavior](#policy-behavior)
-  - [Output](#output)
-  - [Examples](#examples-5)
-  - [Caveats](#caveats-4)
-  - [`rrt eol check`](#rrt-eol-check)
-- [`rrt toc`](#rrt-toc)
-  - [Overview](#overview-6)
-  - [Usage](#usage)
-  - [Anchors](#anchors)
-  - [Options](#options)
-- [`rrt tree`](#rrt-tree)
-  - [Overview](#overview-7)
-  - [Ignore behavior](#ignore-behavior)
-  - [Output formats](#output-formats)
-  - [Common options](#common-options)
-  - [Failure behavior](#failure-behavior-1)
-  - [Examples](#examples-6)
-  - [Embedding a tree into a Markdown file](#embedding-a-tree-into-a-markdown-file)
-  - [Caveats](#caveats-5)
-  - [Related docs](#related-docs-1)
+  - [Examples](#examples-1)
+  - [Caveats](#caveats)
 - [`rrt docs`](#rrt-docs)
-  - [Overview](#overview-8)
+  - [Overview](#overview-2)
   - [Responsibilities](#responsibilities)
   - [Sub-actions](#sub-actions)
   - [Extraction modes](#extraction-modes)
   - [Supported languages](#supported-languages)
   - [Lockfile](#lockfile)
-  - [Examples](#examples-7)
-  - [Related docs](#related-docs-2)
+  - [Examples](#examples-2)
+  - [Related docs](#related-docs)
   - [`rrt docs generate`](#rrt-docs-generate)
   - [`rrt docs check`](#rrt-docs-check)
   - [`rrt docs publish`](#rrt-docs-publish)
@@ -84,119 +39,65 @@ description: "Generated command reference for the Repository Health command grou
   - [`rrt docs badges`](#rrt-docs-badges)
   - [`rrt docs api`](#rrt-docs-api)
   - [`rrt docs map`](#rrt-docs-map)
+- [`rrt doctor`](#rrt-doctor)
+  - [Overview](#overview-3)
+  - [What it checks](#what-it-checks)
+  - [Output and severity](#output-and-severity)
+  - [Config discovery behavior](#config-discovery-behavior)
+  - [Examples](#examples-3)
+  - [Caveats](#caveats-1)
+  - [Related docs](#related-docs-1)
 - [`rrt drift`](#rrt-drift)
-  - [Overview](#overview-9)
+  - [Overview](#overview-4)
   - [Responsibilities](#responsibilities-1)
   - [Tracked Surfaces](#tracked-surfaces)
   - [Behavior](#behavior)
-  - [Examples](#examples-8)
-  - [Caveats](#caveats-6)
+  - [Examples](#examples-4)
+  - [Caveats](#caveats-2)
   - [`rrt drift generate`](#rrt-drift-generate)
   - [`rrt drift check`](#rrt-drift-check)
+- [`rrt env`](#rrt-env)
+  - [Overview](#overview-5)
+  - [What it reports](#what-it-reports)
+  - [JSON mode](#json-mode)
+  - [Examples](#examples-5)
+  - [Caveats](#caveats-3)
+  - [`rrt env check`](#rrt-env-check)
+- [`rrt eol`](#rrt-eol)
+  - [Overview](#overview-6)
+  - [What the command checks](#what-the-command-checks)
+  - [Data sources](#data-sources)
+  - [Policy behavior](#policy-behavior)
+  - [Output](#output)
+  - [Examples](#examples-6)
+  - [Caveats](#caveats-4)
+  - [`rrt eol check`](#rrt-eol-check)
+- [`rrt fields`](#rrt-fields)
+  - [Overview](#overview-7)
+  - [Configuration](#configuration-1)
+  - [Subcommands](#subcommands-1)
+  - [Examples](#examples-7)
+  - [Caveats](#caveats-5)
 - [`rrt folder`](#rrt-folder)
   - [`rrt folder check`](#rrt-folder-check)
   - [`rrt folder scaffold`](#rrt-folder-scaffold)
   - [`rrt folder design`](#rrt-folder-design)
+- [`rrt tree`](#rrt-tree)
+  - [Overview](#overview-8)
+  - [Ignore behavior](#ignore-behavior)
+  - [Output formats](#output-formats)
+  - [Common options](#common-options)
+  - [Failure behavior](#failure-behavior-1)
+  - [Examples](#examples-8)
+  - [Embedding a tree into a Markdown file](#embedding-a-tree-into-a-markdown-file)
+  - [Caveats](#caveats-6)
+  - [Related docs](#related-docs-2)
+- [`rrt toc`](#rrt-toc)
+  - [Overview](#overview-9)
+  - [Usage](#usage)
+  - [Anchors](#anchors)
+  - [Options](#options)
 {/* rrt:auto:end:toc */}
-
-## `rrt doctor`
-
-Validate the core automation health of the resolved rrt configuration.
-
-### Overview
-
-`rrt doctor` is the basics-first repository health check. It focuses on the
-shared automation wiring around the resolved configuration — local hooks, CI
-workflows, and guidance to the feature-specific checks that own deeper policy
-validation.
-
-### What it checks
-
-The command checks the automation surfaces that tell you whether repository
-basics are wired correctly:
-
-- `.pre-commit-config.yaml` when present
-- `lefthook.yml` when present
-- `.husky/*` hook scripts when present
-- `.github/workflows/*.yml` / `.yaml` when present
-
-The checks are intentionally light-touch: they verify presence, readability,
-and whether the file appears to reference repo-release-tools policy checks.
-They do **not** replace the deeper feature validators.
-
-### Output and severity
-
-The command prints one grouped report for the core automation surfaces and an
-overall status at the end.
-
-- unreadable automation files are errors
-- missing hook-manager surfaces are obsolete when another hook manager is active
-- missing optional integration surfaces are warnings when no equivalent surface is active
-- surfaces that exist but do not appear to reference repo-release-tools are warnings
-- readable, recognized surfaces are reported as OK
-
-At the end, `rrt doctor` also points you to the feature-specific commands that
-own deeper validation, such as `rrt release check`, `rrt docs check`, and
-`rrt eol`.
-
-### Config discovery behavior
-
-If no config file can be found, the command prints repository guidance and
-exits with an error.
-
-If a config is auto-detected, the command emits a notice on stderr before the
-main report so you can tell that rrt did not use an explicitly selected file.
-
-### Examples
-
-```bash
-rrt doctor
-```
-
-### Caveats
-
-- The command reports core automation health for the resolved configuration,
-    not just the visible file in the current directory.
-- Feature-specific checks belong to their own surfaces: `rrt release check`,
-    `rrt docs check`, and `rrt eol`.
-- A warning does not fail the command; only error-level findings do.
-
-### Related docs
-
-- [Runtime EOL tracking](/repo-release-tools/commands/eol_check/)
-- [rrt eol (CLI)](/repo-release-tools/commands/rrt-cli/)
-- [rrt release check](/repo-release-tools/commands/rrt-cli/)
-- [pre-commit / lefthook / husky](/repo-release-tools/commands/hooks/)
-- [GitHub Action](/repo-release-tools/action/)
-
-```text
-Usage:  rrt doctor [OPTIONS]
-
-Validate the core automation wiring for the current repository.
-
-Use `rrt doctor` for repository basics, then run feature-specific checks like `rrt release check`, `rrt docs check`, or `rrt eol` for deeper validation.
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Arguments
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Options
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  -h, --help     Show this message and exit.
-  --fix          Auto-repair fixable issues (e.g. missing [Unreleased] changelog section).
-  --fix-dry-run  Preview what --fix would change without writing files.
-  --snapshot     Write current health check results to .rrt/health.lock.toml as a baseline.
-  --check        Compare current health against .rrt/health.lock.toml and report regressions.
-  --strict       With --check: exit 1 on any regression (default: advisory, exit 0).
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Examples
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  $ rrt doctor
-  $ rrt release check
-  $ rrt docs check
-```
 
 ## `rrt artifacts`
 
@@ -271,127 +172,6 @@ Examples
   $ rrt artifacts --snapshot
   $ rrt artifacts --check --strict
   $ rrt artifacts --list
-```
-
-## `rrt fields`
-
-Field-level manifest sync for values duplicated across independent JSON files.
-
-### Overview
-
-`rrt fields` keeps a single logical fact — a value embedded in more than one
-JSON manifest — from silently drifting. The motivating case: a Claude Code
-plugin marketplace's root `.claude-plugin/marketplace.json` lists each
-plugin's `description`, copied by hand from that plugin's own
-`plugin.json`. Nothing catches it when the two copies diverge.
-
-This is the same shape of problem `rrt artifacts` and `rrt drift` already
-solve — a sensitive value silently drifting from its source of truth — but
-at individual JSON field granularity rather than whole-file content hash.
-
-Unlike `rrt artifacts`, **there is no lockfile**. The source of truth is
-itself a git-tracked file, so `--check` always compares the live source
-field against each live target field directly, on every run.
-
-### Configuration
-
-Add `[[tool.rrt.field_targets]]` entries to `pyproject.toml` (or `.rrt.toml`):
-
-```toml
-[[tool.rrt.field_targets]]
-source = "plugins/self-assess/.claude-plugin/plugin.json"
-source_field = "description"
-targets = [
-  { path = ".claude-plugin/marketplace.json", field = "plugins[name=self-assess].description" },
-  { path = "README.md", anchor = "self-assess-description" },
-]
-```
-
-- `source` — relative path to the source-of-truth JSON file.
-- `source_field` — a path into the parsed source JSON (see "Field path
-  syntax" below).
-- `targets` — a list of write destinations, each setting exactly one of:
-  - `field` — a JSON target. `path` is the target JSON file; `field` uses
-    the same path syntax as `source_field`.
-  - `anchor` — a Markdown/MDX/RST target. `path` is the prose file; `anchor`
-    is the anchor id of an `<!-- rrt:auto:start:<id> -->` /
-    `{/* rrt:auto:start:<id> */}` / `.. rrt:auto:start:<id>` block already
-    present in that file (format auto-detected from the file extension, the
-    same primitive used by `rrt docs publish`/`inject` and `rrt tree
-    --inject`). A target file missing the anchor markers fails loudly
-    (exit 1) rather than being silently skipped.
-
-#### Field path syntax
-
-Only two forms are supported, deliberately — this is a hand-rolled stdlib
-resolver, not a general JSONPath/JMESPath engine (no new runtime
-dependency is taken on for it):
-
-- Dotted keys for nested objects: `author.name`
-- One bracket-filter form, for selecting an array element by a matching
-  field: `arrayKey[matchField=matchValue]` — selects the element of the
-  array at `arrayKey` whose `matchField` equals `matchValue`. Chainable
-  with further dotted segments, e.g. `plugins[name=self-assess].description`.
-
-### Subcommands
-
-- `--check` — resolve the source field and each target field, compare.
-  Advisory by default (warns on mismatch, exits 0); `--strict` makes any
-  mismatch exit 1 (for CI gates).
-- `--sync` — overwrite each target field with the current source field
-  value, in place, preserving the target file's existing key order and
-  formatting (a value-only edit). Supports `--dry-run`.
-- `--list` — show every configured `(source_field -> target.field)`
-  mapping with its current match/mismatch status.
-
-### Examples
-
-```bash
-rrt fields --check
-rrt fields --check --strict
-rrt fields --sync --dry-run
-rrt fields --sync
-rrt fields --list
-```
-
-### Caveats
-
-- Only JSON source files are supported in this first pass (TOML/YAML sources
-  are not handled). Targets may be JSON (`field`) or Markdown/MDX/RST
-  (`anchor`).
-- A `field` target path must resolve to an existing key on an existing
-  object — `--sync` will not create new keys.
-- An `anchor` target file must already contain the matching anchor marker
-  pair; `--sync`/`--check` fail loudly rather than creating or skipping it.
-
-```text
-Usage:  rrt fields [OPTIONS]
-
-Check or sync a JSON field value that's duplicated as a copy across
-one or more other JSON files. No lockfile — the source file is the
-source of truth, compared live on every run.
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Arguments
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Options
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  -h, --help  Show this message and exit.
-  --check     Compare each target field against its source field. Advisory by default.
-  --sync      Write each target field to match its current source field value.
-  --list      Display all configured field mappings and their current match status.
-  --dry-run   Show what --sync would do without writing any files.
-  --strict    With --check: exit 1 on any field mismatch (for CI gates).
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Examples
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  $ rrt fields --check
-  $ rrt fields --check --strict
-  $ rrt fields --sync --dry-run
-  $ rrt fields --list
 ```
 
 ## `rrt config`
@@ -508,462 +288,6 @@ Examples
   $ rrt config --reference
   $ rrt config --reference --check
   $ rrt config --reference --dry-run
-```
-
-## `rrt env`
-
-Inspect the process environment and runtime context used by rrt.
-
-### Overview
-
-This command is a compact diagnostics tool for answering "what environment am
-I running in?" It does not read repository configuration. Instead, it reports
-the interpreter and terminal-related values that can affect rrt output.
-
-### What it reports
-
-The standard text view prints:
-
-- platform
-- Python version
-- Python executable path
-- `TERM`
-- `COLORTERM`
-- whether `NO_COLOR` is enabled
-- `RRT_COLOR`
-
-The `NO_COLOR` field is normalized to a friendly enabled/disabled value rather
-than echoing the raw environment variable.
-
-### JSON mode
-
-Use `--json` to emit the same fields as a JSON object. This is useful for
-automation, debugging, and documentation tooling that prefers structured
-output.
-
-### Examples
-
-```bash
-rrt env
-rrt env --json
-```
-
-### Caveats
-
-- This command reports only a small set of environment values that are most
-  relevant to rrt behavior.
-- It is a snapshot of the current process, not a probe of the wider shell or
-  login environment.
-
-```text
-Usage:  rrt env [OPTIONS] <env_action>
-
-Show environment variables and interpreter details that affect rrt behavior.
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Arguments
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  check       Run environment sanity checks (duplicates in PATH/PYTHONPATH).
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Options
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  -h, --help  Show this message and exit.
-  --json      Output the environment as JSON.
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Examples
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  $ rrt env
-  $ rrt env --json
-```
-
-### `rrt env check`
-
-```text
-Usage:  rrt env check [OPTIONS]
-
-Run a small set of environment sanity checks and exit non-zero on failure.
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Arguments
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Options
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  -h, --help  Show this message and exit.
-  --json      (Ignored) kept for interface parity with `rrt env`.
-```
-
-## `rrt eol`
-
-Check detected runtimes and project minimum versions against end-of-life policy.
-
-### Overview
-
-`rrt eol` helps you answer two questions for one or more languages:
-
-- Is the current host runtime still supported?
-- Is the repository's declared minimum version still supported?
-
-It is designed for release pipelines and maintenance workflows where runtime
-support windows matter.
-
-### What the command checks
-
-For each requested language, the command checks:
-
-- the host runtime detected on the current machine
-- the project minimum version detected from the repository
-
-Each version is compared against EOL records and classified as:
-
-- supported
-- expiring soon
-- end-of-life
-- unknown
-
-When the runtime cannot be detected, the command prints `not detected` instead
-of failing that check.
-
-### Data sources
-
-By default, rrt uses bundled EOL data. With `--fetch-live`, it refreshes the
-records from endoflife.date for the current run.
-
-Language selection comes from the resolved configuration when available. If no
-EOL config is present, the command defaults to Python.
-
-### Policy behavior
-
-The effective thresholds come from `[tool.rrt.eol]` when configured, with CLI
-flags applied on top for the current invocation.
-
-Important policy switches:
-
-- `--warn-days` sets the warning window
-- `--error-days` sets the failure window
-- `--allow-eol` downgrades EOL failures to warnings
-- `--language` limits the check to one language
-
-### Output
-
-The command prints a small summary first, then one section per language with
-host runtime and project minimum results. If all checks pass it ends with a
-success line; otherwise it prints a failure line and returns a non-zero exit
-code.
-
-### Examples
-
-```bash
-rrt eol
-rrt eol --language node --fetch-live
-rrt eol --warn-days 90 --error-days 30
-```
-
-### Caveats
-
-- Supported languages are limited to the values exposed by rrt's EOL helpers.
-- Configured EOL overrides apply per language and version cycle.
-- `--allow-eol` changes exit-code behavior, not the underlying status labels.
-
-```text
-Usage:  rrt eol [OPTIONS] <eol_action>
-
-Check detected host runtimes and project minimum versions against end-of-life dates.
-
-Uses bundled EOL data by default and can refresh from endoflife.date on demand. When [tool.rrt.eol] is configured, CLI flags override the configured thresholds for this invocation.
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Arguments
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  check            Exit non-zero when any EOL check fails.
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Options
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  -h, --help       Show this message and exit.
-  --language LANG  Check one language only (go, node, nodejs, python, rust). Default: from config or python.
-  --fetch-live     Fetch fresh EOL data from endoflife.date instead of using bundled snapshot.
-  --warn-days N    Warn when EOL is within N days (default: 180 or from config).
-  --error-days N   Error when EOL is within N days (default: 0 or from config = only on actual EOL).
-  --allow-eol      Downgrade errors to warnings (useful during migration grace periods).
-  --host-only      Only check the host runtime; skip project minimum checks.
-  --project-only   Only check the project minimum version; skip host runtime checks.
-  --snapshot       Merge EOL check results into .rrt/health.lock.toml after running.
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Examples
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  $ rrt eol
-  $ rrt eol --language node --fetch-live
-  $ rrt eol --warn-days 90 --error-days 30
-```
-
-### `rrt eol check`
-
-```text
-Usage:  rrt eol check [OPTIONS]
-
-Run the configured EOL checks for the current repository and exit non-zero when any failure is detected.
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Arguments
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Options
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  -h, --help       Show this message and exit.
-  --language LANG  Check one language only (go, node, nodejs, python, rust). Default: from config or python.
-  --fetch-live     Fetch fresh EOL data from endoflife.date instead of using bundled snapshot.
-  --warn-days N    Warn when EOL is within N days (default: 180 or from config).
-  --error-days N   Error when EOL is within N days (default: 0 or from config = only on actual EOL).
-  --allow-eol      Downgrade errors to warnings (useful during migration grace periods).
-  --host-only      Only check the host runtime; skip project minimum checks.
-  --project-only   Only check the project minimum version; skip host runtime checks.
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Examples
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  $ rrt eol
-  $ rrt eol --language node --fetch-live
-  $ rrt eol --warn-days 90 --error-days 30
-```
-
-## `rrt toc`
-
-``rrt toc`` — generate and inject a Markdown table of contents.
-
-### Overview
-
-``rrt toc FILE`` reads a Markdown file and prints a nested bullet list of its
-headings to stdout.  With ``--inject`` and ``--anchor``, the generated TOC is
-written in-place inside a marked anchor block in a target file.
-
-### Usage
-
-```
-rrt toc FILE [--min-level N] [--max-level N]
-rrt toc FILE --inject TARGET --anchor ID [--min-level N] [--max-level N] [--dry-run]
-```
-
-### Anchors
-
-Place a pair of HTML comments in the target file to mark where the TOC
-should live:
-
-```markdown
-<!-- rrt:auto:start:toc -->
-<!-- rrt:auto:end:toc -->
-```
-
-The content between the markers is replaced on every ``rrt toc --inject`` run.
-Everything outside the markers is preserved unchanged.
-
-### Options
-
-| Flag | Default | Description |
-|---|---|---|
-| ``FILE`` | — | Markdown file to parse for headings |
-| ``--inject FILE`` | — | Target file to update in-place |
-| ``--anchor ID`` | — | Anchor ID inside the inject target |
-| ``--min-level N`` | 1 | Shallowest heading level to include (1 = ``#``) |
-| ``--max-level N`` | 6 | Deepest heading level to include (6 = ``######``) |
-| ``--dry-run`` | — | Print result instead of writing (requires ``--inject``) |
-
-``--inject`` and ``--anchor`` must always be used together.
-
-```text
-Usage:  rrt toc [OPTIONS] FILE
-
-Read a Markdown file and print a nested bullet-list TOC to stdout.
-
-With --inject and --anchor the generated TOC is written in-place inside
-an anchor block in a target file.  Markers delimit the block:
-
-  <!-- rrt:auto:start:ID -->
-  <!-- rrt:auto:end:ID -->
-
-Everything outside the markers is preserved unchanged.
---inject and --anchor must always be used together.
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Arguments
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  FILE           Markdown file to parse for headings.
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Options
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  -h, --help     Show this message and exit.
-  --inject FILE  Markdown file to update in-place. Requires --anchor. The anchored block is replaced; all other content is preserved.
-  --anchor ID    Anchor ID to replace inside the --inject file. Place <!-- rrt:auto:start:<ID> --> and <!-- rrt:auto:end:<ID> --> markers in the target file.
-  --min-level N  Shallowest heading level to include (default: 1 = #).
-  --max-level N  Deepest heading level to include (default: 6 = ######).
-  --dry-run      Print the result instead of writing (only effective with --inject).
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Examples
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  $ rrt toc README.md
-  $ rrt toc README.md --min-level 2 --max-level 3
-  $ rrt toc README.md --inject README.md --anchor toc
-  $ rrt toc README.md --inject README.md --anchor toc --dry-run
-```
-
-## `rrt tree`
-
-Render a project tree with gitignore-aware filtering.
-
-### Overview
-
-`rrt tree` prints a repository or directory tree suitable for terminal review,
-docs snippets, and quick project orientation.
-
-The command is read-only and intentionally deterministic:
-
-- stable ordering (directories first, then files)
-- optional depth limiting for large repositories
-- optional hidden-file inclusion
-- optional directories-only mode
-
-### Ignore behavior
-
-When the selected root is inside a Git repository, ignore checks use Git's own
-exclude engine via `git check-ignore`, so matching follows active repository
-rules and precedence semantics.
-
-When the root is not in a Git worktree, the command falls back to a conservative
-local skip list for well-known transient directories (for example `.git`,
-`node_modules`, `.venv`) while still honoring explicit CLI flags.
-
-### Output formats
-
-- `classic` (default): platform-aware tree connectors through `GLYPHS.tree`
-- `ascii`: forced ASCII connectors for paste-safe logs or legacy terminals
-- `markdown`: nested bullet output for Markdown docs and issue comments
-- `rich`: Rich tree rendering when the optional package is installed; falls
-    back to `classic` with a warning when Rich is unavailable
-
-### Common options
-
-- `--root PATH` selects the traversal root
-- `--max-depth N` limits recursion depth (unlimited by default)
-- `--dirs-only` suppresses files
-- `--show-hidden` includes dotfiles and dot-directories
-
-### Failure behavior
-
-The command exits non-zero when:
-
-- the root path does not exist
-- the root path is not a directory
-
-Unreadable subdirectories are reported as warnings and do not fail the command.
-
-### Examples
-
-```bash
-rrt tree
-rrt tree --format ascii
-rrt tree --format markdown --max-depth 3
-rrt tree --root src/repo_release_tools --dirs-only
-rrt tree --format markdown --inject README.md --anchor project-tree
-rrt tree --format markdown --inject README.md --anchor project-tree --dry-run
-```
-
-### Embedding a tree into a Markdown file
-
-Use `--inject` and `--anchor` to automatically update a block inside any
-Markdown document without touching the surrounding prose.
-
-**Step 1 — add anchor markers once** (HTML comments, invisible when rendered):
-
-```markdown
-## Project layout
-
-Some intro text above — preserved on every run.
-
-<!-- rrt:auto:start:project-tree -->
-<!-- rrt:auto:end:project-tree -->
-
-Some text below — also preserved.
-```
-
-**Step 2 — run `rrt tree` with `--inject`**:
-
-```bash
-rrt tree --format markdown --inject README.md --anchor project-tree
-```
-
-Only the content between the markers is replaced; everything else in the file
-stays untouched.
-
-#### Anchor ID rules
-
-An anchor ID must start with an ASCII letter or digit followed by any
-combination of ASCII letters, digits, dots, underscores, or hyphens.
-
-Valid examples: `project-tree`, `src.layout`, `tree_v2`
-
-### Caveats
-
-- Symlinked directories are listed but not recursively traversed.
-- The root itself is not printed as a tree node; output begins with its
-    children.
-- Rich formatting is optional and never required for baseline output.
-
-### Related docs
-
-- [Generated CLI reference](/repo-release-tools/commands/rrt-cli/)
-- [rrt git](/repo-release-tools/commands/git_cmd/)
-
-```text
-Usage:  rrt tree [OPTIONS] PATH
-
-Render a directory tree from the selected root while respecting gitignore rules.
-
-Formats: classic, ascii, markdown, rich, json, flat. Rich output falls back to classic if the optional rich package is unavailable. json/flat emit machine-consumable output (a nested document or one path per line, respectively).
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Arguments
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  PATH                   Root directory to render. Equivalent to --root and takes precedence when both are supplied.
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Options
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  -h, --help             Show this message and exit.
-  --format               Output format. Defaults to classic.
-  --max-depth N          Maximum recursion depth (default: unlimited).
-  --dirs-only            Show directories only.
-  --show-hidden          Include dotfiles and dot-directories.
-  --root PATH            Root directory to render (default: current directory).
-  --inject FILE          Markdown file to update in-place. Requires --anchor. The anchored block is replaced; all other content is preserved.
-  --anchor ID            Anchor ID to replace inside the --inject file. Place <!-- rrt:auto:start:<ID> --> and <!-- rrt:auto:end:<ID> --> markers in the target file.
-  --dry-run              Print planned actions instead of writing (with --inject or --fix-empty-dirs).
-  --snapshot             Write a tree structure snapshot to .rrt/tree.lock.toml as a baseline.
-  --check                Compare current tree against .rrt/tree.lock.toml and report structural drift.
-  --manifest             Write a machine-readable manifest to .rrt/tree.manifest.json containing per-file metadata (size, mtime, sha256, mode, uid, gid, symlink_target). This enables deterministic, atomic manifest generation and implies hashing of file contents.
-  --compressed           Write the manifest as a compressed gzip file (.rrt/tree.manifest.json.gz). Implied: --manifest.
-  --strict               With --check: exit 1 on structural drift (default: advisory, exit 0).
-  --strict-empty-dirs    Exit 1 when truly-empty (non-.gitkept) directories are present. Such directories cannot be tracked by git and cause local/CI manifest drift. Use --fix-empty-dirs to resolve interactively.
-  --fix-empty-dirs       Interactively resolve truly-empty directories by adding a .gitkeep placeholder or removing the directory. Honors --dry-run and --yes.
-  --yes, -y              With --fix-empty-dirs: assume yes (add .gitkeep) for every prompt.
-  --auto-resolve ACTION  With --fix-empty-dirs: apply ACTION to every phantom directory without prompting. 'git-rm' stages the removal via `git rm -rf`.
-  --absolute             Emit absolute paths in the json and flat formats (and in the manifest). Default: paths are relative to the scan root.
-  --output PATH          Write the rendered tree to PATH instead of stdout. Honors --format. Ignored when --inject, --snapshot, --check, or --fix-empty-dirs is used (those have their own targets).
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Examples
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  $ rrt tree
-  $ rrt tree --format ascii
-  $ rrt tree --format markdown --max-depth 3
-  $ rrt tree --root src/repo_release_tools --dirs-only
-  $ rrt tree --format markdown --inject README.md --anchor project-tree
 ```
 
 ## `rrt docs`
@@ -1241,6 +565,105 @@ Options
   --dry-run    Preview changes without writing files or the lockfile.
 ```
 
+## `rrt doctor`
+
+Validate the core automation health of the resolved rrt configuration.
+
+### Overview
+
+`rrt doctor` is the basics-first repository health check. It focuses on the
+shared automation wiring around the resolved configuration — local hooks, CI
+workflows, and guidance to the feature-specific checks that own deeper policy
+validation.
+
+### What it checks
+
+The command checks the automation surfaces that tell you whether repository
+basics are wired correctly:
+
+- `.pre-commit-config.yaml` when present
+- `lefthook.yml` when present
+- `.husky/*` hook scripts when present
+- `.github/workflows/*.yml` / `.yaml` when present
+
+The checks are intentionally light-touch: they verify presence, readability,
+and whether the file appears to reference repo-release-tools policy checks.
+They do **not** replace the deeper feature validators.
+
+### Output and severity
+
+The command prints one grouped report for the core automation surfaces and an
+overall status at the end.
+
+- unreadable automation files are errors
+- missing hook-manager surfaces are obsolete when another hook manager is active
+- missing optional integration surfaces are warnings when no equivalent surface is active
+- surfaces that exist but do not appear to reference repo-release-tools are warnings
+- readable, recognized surfaces are reported as OK
+
+At the end, `rrt doctor` also points you to the feature-specific commands that
+own deeper validation, such as `rrt release check`, `rrt docs check`, and
+`rrt eol`.
+
+### Config discovery behavior
+
+If no config file can be found, the command prints repository guidance and
+exits with an error.
+
+If a config is auto-detected, the command emits a notice on stderr before the
+main report so you can tell that rrt did not use an explicitly selected file.
+
+### Examples
+
+```bash
+rrt doctor
+```
+
+### Caveats
+
+- The command reports core automation health for the resolved configuration,
+    not just the visible file in the current directory.
+- Feature-specific checks belong to their own surfaces: `rrt release check`,
+    `rrt docs check`, and `rrt eol`.
+- A warning does not fail the command; only error-level findings do.
+
+### Related docs
+
+- [Runtime EOL tracking](/repo-release-tools/commands/eol_check/)
+- [rrt eol (CLI)](/repo-release-tools/commands/rrt-cli/)
+- [rrt release check](/repo-release-tools/commands/rrt-cli/)
+- [pre-commit / lefthook / husky](/repo-release-tools/commands/hooks/)
+- [GitHub Action](/repo-release-tools/action/)
+
+```text
+Usage:  rrt doctor [OPTIONS]
+
+Validate the core automation wiring for the current repository.
+
+Use `rrt doctor` for repository basics, then run feature-specific checks like `rrt release check`, `rrt docs check`, or `rrt eol` for deeper validation.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Arguments
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  -h, --help     Show this message and exit.
+  --fix          Auto-repair fixable issues (e.g. missing [Unreleased] changelog section).
+  --fix-dry-run  Preview what --fix would change without writing files.
+  --snapshot     Write current health check results to .rrt/health.lock.toml as a baseline.
+  --check        Compare current health against .rrt/health.lock.toml and report regressions.
+  --strict       With --check: exit 1 on any regression (default: advisory, exit 0).
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Examples
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  $ rrt doctor
+  $ rrt release check
+  $ rrt docs check
+```
+
 ## `rrt drift`
 
 Lock and check agent-surface drift for repo-release-tools.
@@ -1374,6 +797,349 @@ Examples
   $ rrt drift check
 ```
 
+## `rrt env`
+
+Inspect the process environment and runtime context used by rrt.
+
+### Overview
+
+This command is a compact diagnostics tool for answering "what environment am
+I running in?" It does not read repository configuration. Instead, it reports
+the interpreter and terminal-related values that can affect rrt output.
+
+### What it reports
+
+The standard text view prints:
+
+- platform
+- Python version
+- Python executable path
+- `TERM`
+- `COLORTERM`
+- whether `NO_COLOR` is enabled
+- `RRT_COLOR`
+
+The `NO_COLOR` field is normalized to a friendly enabled/disabled value rather
+than echoing the raw environment variable.
+
+### JSON mode
+
+Use `--json` to emit the same fields as a JSON object. This is useful for
+automation, debugging, and documentation tooling that prefers structured
+output.
+
+### Examples
+
+```bash
+rrt env
+rrt env --json
+```
+
+### Caveats
+
+- This command reports only a small set of environment values that are most
+  relevant to rrt behavior.
+- It is a snapshot of the current process, not a probe of the wider shell or
+  login environment.
+
+```text
+Usage:  rrt env [OPTIONS] <env_action>
+
+Show environment variables and interpreter details that affect rrt behavior.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Arguments
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  check       Run environment sanity checks (duplicates in PATH/PYTHONPATH).
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  -h, --help  Show this message and exit.
+  --json      Output the environment as JSON.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Examples
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  $ rrt env
+  $ rrt env --json
+```
+
+### `rrt env check`
+
+```text
+Usage:  rrt env check [OPTIONS]
+
+Run a small set of environment sanity checks and exit non-zero on failure.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Arguments
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  -h, --help  Show this message and exit.
+  --json      (Ignored) kept for interface parity with `rrt env`.
+```
+
+## `rrt eol`
+
+Check detected runtimes and project minimum versions against end-of-life policy.
+
+### Overview
+
+`rrt eol` helps you answer two questions for one or more languages:
+
+- Is the current host runtime still supported?
+- Is the repository's declared minimum version still supported?
+
+It is designed for release pipelines and maintenance workflows where runtime
+support windows matter.
+
+### What the command checks
+
+For each requested language, the command checks:
+
+- the host runtime detected on the current machine
+- the project minimum version detected from the repository
+
+Each version is compared against EOL records and classified as:
+
+- supported
+- expiring soon
+- end-of-life
+- unknown
+
+When the runtime cannot be detected, the command prints `not detected` instead
+of failing that check.
+
+### Data sources
+
+By default, rrt uses bundled EOL data. With `--fetch-live`, it refreshes the
+records from endoflife.date for the current run.
+
+Language selection comes from the resolved configuration when available. If no
+EOL config is present, the command defaults to Python.
+
+### Policy behavior
+
+The effective thresholds come from `[tool.rrt.eol]` when configured, with CLI
+flags applied on top for the current invocation.
+
+Important policy switches:
+
+- `--warn-days` sets the warning window
+- `--error-days` sets the failure window
+- `--allow-eol` downgrades EOL failures to warnings
+- `--language` limits the check to one language
+
+### Output
+
+The command prints a small summary first, then one section per language with
+host runtime and project minimum results. If all checks pass it ends with a
+success line; otherwise it prints a failure line and returns a non-zero exit
+code.
+
+### Examples
+
+```bash
+rrt eol
+rrt eol --language node --fetch-live
+rrt eol --warn-days 90 --error-days 30
+```
+
+### Caveats
+
+- Supported languages are limited to the values exposed by rrt's EOL helpers.
+- Configured EOL overrides apply per language and version cycle.
+- `--allow-eol` changes exit-code behavior, not the underlying status labels.
+
+```text
+Usage:  rrt eol [OPTIONS] <eol_action>
+
+Check detected host runtimes and project minimum versions against end-of-life dates.
+
+Uses bundled EOL data by default and can refresh from endoflife.date on demand. When [tool.rrt.eol] is configured, CLI flags override the configured thresholds for this invocation.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Arguments
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  check            Exit non-zero when any EOL check fails.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  -h, --help       Show this message and exit.
+  --language LANG  Check one language only (go, node, nodejs, python, rust). Default: from config or python.
+  --fetch-live     Fetch fresh EOL data from endoflife.date instead of using bundled snapshot.
+  --warn-days N    Warn when EOL is within N days (default: 180 or from config).
+  --error-days N   Error when EOL is within N days (default: 0 or from config = only on actual EOL).
+  --allow-eol      Downgrade errors to warnings (useful during migration grace periods).
+  --host-only      Only check the host runtime; skip project minimum checks.
+  --project-only   Only check the project minimum version; skip host runtime checks.
+  --snapshot       Merge EOL check results into .rrt/health.lock.toml after running.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Examples
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  $ rrt eol
+  $ rrt eol --language node --fetch-live
+  $ rrt eol --warn-days 90 --error-days 30
+```
+
+### `rrt eol check`
+
+```text
+Usage:  rrt eol check [OPTIONS]
+
+Run the configured EOL checks for the current repository and exit non-zero when any failure is detected.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Arguments
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  -h, --help       Show this message and exit.
+  --language LANG  Check one language only (go, node, nodejs, python, rust). Default: from config or python.
+  --fetch-live     Fetch fresh EOL data from endoflife.date instead of using bundled snapshot.
+  --warn-days N    Warn when EOL is within N days (default: 180 or from config).
+  --error-days N   Error when EOL is within N days (default: 0 or from config = only on actual EOL).
+  --allow-eol      Downgrade errors to warnings (useful during migration grace periods).
+  --host-only      Only check the host runtime; skip project minimum checks.
+  --project-only   Only check the project minimum version; skip host runtime checks.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Examples
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  $ rrt eol
+  $ rrt eol --language node --fetch-live
+  $ rrt eol --warn-days 90 --error-days 30
+```
+
+## `rrt fields`
+
+Field-level manifest sync for values duplicated across independent JSON files.
+
+### Overview
+
+`rrt fields` keeps a single logical fact — a value embedded in more than one
+JSON manifest — from silently drifting. The motivating case: a Claude Code
+plugin marketplace's root `.claude-plugin/marketplace.json` lists each
+plugin's `description`, copied by hand from that plugin's own
+`plugin.json`. Nothing catches it when the two copies diverge.
+
+This is the same shape of problem `rrt artifacts` and `rrt drift` already
+solve — a sensitive value silently drifting from its source of truth — but
+at individual JSON field granularity rather than whole-file content hash.
+
+Unlike `rrt artifacts`, **there is no lockfile**. The source of truth is
+itself a git-tracked file, so `--check` always compares the live source
+field against each live target field directly, on every run.
+
+### Configuration
+
+Add `[[tool.rrt.field_targets]]` entries to `pyproject.toml` (or `.rrt.toml`):
+
+```toml
+[[tool.rrt.field_targets]]
+source = "plugins/self-assess/.claude-plugin/plugin.json"
+source_field = "description"
+targets = [
+  { path = ".claude-plugin/marketplace.json", field = "plugins[name=self-assess].description" },
+  { path = "README.md", anchor = "self-assess-description" },
+]
+```
+
+- `source` — relative path to the source-of-truth JSON file.
+- `source_field` — a path into the parsed source JSON (see "Field path
+  syntax" below).
+- `targets` — a list of write destinations, each setting exactly one of:
+  - `field` — a JSON target. `path` is the target JSON file; `field` uses
+    the same path syntax as `source_field`.
+  - `anchor` — a Markdown/MDX/RST target. `path` is the prose file; `anchor`
+    is the anchor id of an `<!-- rrt:auto:start:<id> -->` /
+    `{/* rrt:auto:start:<id> */}` / `.. rrt:auto:start:<id>` block already
+    present in that file (format auto-detected from the file extension, the
+    same primitive used by `rrt docs publish`/`inject` and `rrt tree
+    --inject`). A target file missing the anchor markers fails loudly
+    (exit 1) rather than being silently skipped.
+
+#### Field path syntax
+
+Only two forms are supported, deliberately — this is a hand-rolled stdlib
+resolver, not a general JSONPath/JMESPath engine (no new runtime
+dependency is taken on for it):
+
+- Dotted keys for nested objects: `author.name`
+- One bracket-filter form, for selecting an array element by a matching
+  field: `arrayKey[matchField=matchValue]` — selects the element of the
+  array at `arrayKey` whose `matchField` equals `matchValue`. Chainable
+  with further dotted segments, e.g. `plugins[name=self-assess].description`.
+
+### Subcommands
+
+- `--check` — resolve the source field and each target field, compare.
+  Advisory by default (warns on mismatch, exits 0); `--strict` makes any
+  mismatch exit 1 (for CI gates).
+- `--sync` — overwrite each target field with the current source field
+  value, in place, preserving the target file's existing key order and
+  formatting (a value-only edit). Supports `--dry-run`.
+- `--list` — show every configured `(source_field -> target.field)`
+  mapping with its current match/mismatch status.
+
+### Examples
+
+```bash
+rrt fields --check
+rrt fields --check --strict
+rrt fields --sync --dry-run
+rrt fields --sync
+rrt fields --list
+```
+
+### Caveats
+
+- Only JSON source files are supported in this first pass (TOML/YAML sources
+  are not handled). Targets may be JSON (`field`) or Markdown/MDX/RST
+  (`anchor`).
+- A `field` target path must resolve to an existing key on an existing
+  object — `--sync` will not create new keys.
+- An `anchor` target file must already contain the matching anchor marker
+  pair; `--sync`/`--check` fail loudly rather than creating or skipping it.
+
+```text
+Usage:  rrt fields [OPTIONS]
+
+Check or sync a JSON field value that's duplicated as a copy across
+one or more other JSON files. No lockfile — the source file is the
+source of truth, compared live on every run.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Arguments
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  -h, --help  Show this message and exit.
+  --check     Compare each target field against its source field. Advisory by default.
+  --sync      Write each target field to match its current source field value.
+  --list      Display all configured field mappings and their current match status.
+  --dry-run   Show what --sync would do without writing any files.
+  --strict    With --check: exit 1 on any field mismatch (for CI gates).
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Examples
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  $ rrt fields --check
+  $ rrt fields --check --strict
+  $ rrt fields --sync --dry-run
+  $ rrt fields --list
+```
+
 ## `rrt folder`
 
 Folder supervision and scaffolding command family.
@@ -1480,4 +1246,238 @@ Options
   --name NAME      Template name to emit.
   --selector GLOB  Selector to pair with the emitted rule snippet.
   --loose          Emit a permissive loose template instead of an exact one.
+```
+
+## `rrt tree`
+
+Render a project tree with gitignore-aware filtering.
+
+### Overview
+
+`rrt tree` prints a repository or directory tree suitable for terminal review,
+docs snippets, and quick project orientation.
+
+The command is read-only and intentionally deterministic:
+
+- stable ordering (directories first, then files)
+- optional depth limiting for large repositories
+- optional hidden-file inclusion
+- optional directories-only mode
+
+### Ignore behavior
+
+When the selected root is inside a Git repository, ignore checks use Git's own
+exclude engine via `git check-ignore`, so matching follows active repository
+rules and precedence semantics.
+
+When the root is not in a Git worktree, the command falls back to a conservative
+local skip list for well-known transient directories (for example `.git`,
+`node_modules`, `.venv`) while still honoring explicit CLI flags.
+
+### Output formats
+
+- `classic` (default): platform-aware tree connectors through `GLYPHS.tree`
+- `ascii`: forced ASCII connectors for paste-safe logs or legacy terminals
+- `markdown`: nested bullet output for Markdown docs and issue comments
+- `rich`: Rich tree rendering when the optional package is installed; falls
+    back to `classic` with a warning when Rich is unavailable
+
+### Common options
+
+- `--root PATH` selects the traversal root
+- `--max-depth N` limits recursion depth (unlimited by default)
+- `--dirs-only` suppresses files
+- `--show-hidden` includes dotfiles and dot-directories
+
+### Failure behavior
+
+The command exits non-zero when:
+
+- the root path does not exist
+- the root path is not a directory
+
+Unreadable subdirectories are reported as warnings and do not fail the command.
+
+### Examples
+
+```bash
+rrt tree
+rrt tree --format ascii
+rrt tree --format markdown --max-depth 3
+rrt tree --root src/repo_release_tools --dirs-only
+rrt tree --format markdown --inject README.md --anchor project-tree
+rrt tree --format markdown --inject README.md --anchor project-tree --dry-run
+```
+
+### Embedding a tree into a Markdown file
+
+Use `--inject` and `--anchor` to automatically update a block inside any
+Markdown document without touching the surrounding prose.
+
+**Step 1 — add anchor markers once** (HTML comments, invisible when rendered):
+
+```markdown
+## Project layout
+
+Some intro text above — preserved on every run.
+
+<!-- rrt:auto:start:project-tree -->
+<!-- rrt:auto:end:project-tree -->
+
+Some text below — also preserved.
+```
+
+**Step 2 — run `rrt tree` with `--inject`**:
+
+```bash
+rrt tree --format markdown --inject README.md --anchor project-tree
+```
+
+Only the content between the markers is replaced; everything else in the file
+stays untouched.
+
+#### Anchor ID rules
+
+An anchor ID must start with an ASCII letter or digit followed by any
+combination of ASCII letters, digits, dots, underscores, or hyphens.
+
+Valid examples: `project-tree`, `src.layout`, `tree_v2`
+
+### Caveats
+
+- Symlinked directories are listed but not recursively traversed.
+- The root itself is not printed as a tree node; output begins with its
+    children.
+- Rich formatting is optional and never required for baseline output.
+
+### Related docs
+
+- [Generated CLI reference](/repo-release-tools/commands/rrt-cli/)
+- [rrt git](/repo-release-tools/commands/git_cmd/)
+
+```text
+Usage:  rrt tree [OPTIONS] PATH
+
+Render a directory tree from the selected root while respecting gitignore rules.
+
+Formats: classic, ascii, markdown, rich, json, flat. Rich output falls back to classic if the optional rich package is unavailable. json/flat emit machine-consumable output (a nested document or one path per line, respectively).
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Arguments
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  PATH                   Root directory to render. Equivalent to --root and takes precedence when both are supplied.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  -h, --help             Show this message and exit.
+  --format               Output format. Defaults to classic.
+  --max-depth N          Maximum recursion depth (default: unlimited).
+  --dirs-only            Show directories only.
+  --show-hidden          Include dotfiles and dot-directories.
+  --root PATH            Root directory to render (default: current directory).
+  --inject FILE          Markdown file to update in-place. Requires --anchor. The anchored block is replaced; all other content is preserved.
+  --anchor ID            Anchor ID to replace inside the --inject file. Place <!-- rrt:auto:start:<ID> --> and <!-- rrt:auto:end:<ID> --> markers in the target file.
+  --dry-run              Print planned actions instead of writing (with --inject or --fix-empty-dirs).
+  --snapshot             Write a tree structure snapshot to .rrt/tree.lock.toml as a baseline.
+  --check                Compare current tree against .rrt/tree.lock.toml and report structural drift.
+  --manifest             Write a machine-readable manifest to .rrt/tree.manifest.json containing per-file metadata (size, mtime, sha256, mode, uid, gid, symlink_target). This enables deterministic, atomic manifest generation and implies hashing of file contents.
+  --compressed           Write the manifest as a compressed gzip file (.rrt/tree.manifest.json.gz). Implied: --manifest.
+  --strict               With --check: exit 1 on structural drift (default: advisory, exit 0).
+  --strict-empty-dirs    Exit 1 when truly-empty (non-.gitkept) directories are present. Such directories cannot be tracked by git and cause local/CI manifest drift. Use --fix-empty-dirs to resolve interactively.
+  --fix-empty-dirs       Interactively resolve truly-empty directories by adding a .gitkeep placeholder or removing the directory. Honors --dry-run and --yes.
+  --yes, -y              With --fix-empty-dirs: assume yes (add .gitkeep) for every prompt.
+  --auto-resolve ACTION  With --fix-empty-dirs: apply ACTION to every phantom directory without prompting. 'git-rm' stages the removal via `git rm -rf`.
+  --absolute             Emit absolute paths in the json and flat formats (and in the manifest). Default: paths are relative to the scan root.
+  --output PATH          Write the rendered tree to PATH instead of stdout. Honors --format. Ignored when --inject, --snapshot, --check, or --fix-empty-dirs is used (those have their own targets).
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Examples
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  $ rrt tree
+  $ rrt tree --format ascii
+  $ rrt tree --format markdown --max-depth 3
+  $ rrt tree --root src/repo_release_tools --dirs-only
+  $ rrt tree --format markdown --inject README.md --anchor project-tree
+```
+
+## `rrt toc`
+
+``rrt toc`` — generate and inject a Markdown table of contents.
+
+### Overview
+
+``rrt toc FILE`` reads a Markdown file and prints a nested bullet list of its
+headings to stdout.  With ``--inject`` and ``--anchor``, the generated TOC is
+written in-place inside a marked anchor block in a target file.
+
+### Usage
+
+```
+rrt toc FILE [--min-level N] [--max-level N]
+rrt toc FILE --inject TARGET --anchor ID [--min-level N] [--max-level N] [--dry-run]
+```
+
+### Anchors
+
+Place a pair of HTML comments in the target file to mark where the TOC
+should live:
+
+```markdown
+<!-- rrt:auto:start:toc -->
+<!-- rrt:auto:end:toc -->
+```
+
+The content between the markers is replaced on every ``rrt toc --inject`` run.
+Everything outside the markers is preserved unchanged.
+
+### Options
+
+| Flag | Default | Description |
+|---|---|---|
+| ``FILE`` | — | Markdown file to parse for headings |
+| ``--inject FILE`` | — | Target file to update in-place |
+| ``--anchor ID`` | — | Anchor ID inside the inject target |
+| ``--min-level N`` | 1 | Shallowest heading level to include (1 = ``#``) |
+| ``--max-level N`` | 6 | Deepest heading level to include (6 = ``######``) |
+| ``--dry-run`` | — | Print result instead of writing (requires ``--inject``) |
+
+``--inject`` and ``--anchor`` must always be used together.
+
+```text
+Usage:  rrt toc [OPTIONS] FILE
+
+Read a Markdown file and print a nested bullet-list TOC to stdout.
+
+With --inject and --anchor the generated TOC is written in-place inside
+an anchor block in a target file.  Markers delimit the block:
+
+  <!-- rrt:auto:start:ID -->
+  <!-- rrt:auto:end:ID -->
+
+Everything outside the markers is preserved unchanged.
+--inject and --anchor must always be used together.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Arguments
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  FILE           Markdown file to parse for headings.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  -h, --help     Show this message and exit.
+  --inject FILE  Markdown file to update in-place. Requires --anchor. The anchored block is replaced; all other content is preserved.
+  --anchor ID    Anchor ID to replace inside the --inject file. Place <!-- rrt:auto:start:<ID> --> and <!-- rrt:auto:end:<ID> --> markers in the target file.
+  --min-level N  Shallowest heading level to include (default: 1 = #).
+  --max-level N  Deepest heading level to include (default: 6 = ######).
+  --dry-run      Print the result instead of writing (only effective with --inject).
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Examples
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  $ rrt toc README.md
+  $ rrt toc README.md --min-level 2 --max-level 3
+  $ rrt toc README.md --inject README.md --anchor toc
+  $ rrt toc README.md --inject README.md --anchor toc --dry-run
 ```

--- a/docs/src/content/docs/commands/repo-health.mdx
+++ b/docs/src/content/docs/commands/repo-health.mdx
@@ -82,21 +82,24 @@ description: "Generated command reference for the Repository Health command grou
   - [`rrt folder check`](#rrt-folder-check)
   - [`rrt folder scaffold`](#rrt-folder-scaffold)
   - [`rrt folder design`](#rrt-folder-design)
-- [`rrt tree`](#rrt-tree)
+- [`rrt project`](#rrt-project)
+  - [Examples](#examples-8)
+  - [`rrt project info`](#rrt-project-info)
+- [`rrt toc`](#rrt-toc)
   - [Overview](#overview-8)
+  - [Usage](#usage)
+  - [Anchors](#anchors)
+  - [Options](#options)
+- [`rrt tree`](#rrt-tree)
+  - [Overview](#overview-9)
   - [Ignore behavior](#ignore-behavior)
   - [Output formats](#output-formats)
   - [Common options](#common-options)
   - [Failure behavior](#failure-behavior-1)
-  - [Examples](#examples-8)
+  - [Examples](#examples-9)
   - [Embedding a tree into a Markdown file](#embedding-a-tree-into-a-markdown-file)
   - [Caveats](#caveats-6)
   - [Related docs](#related-docs-2)
-- [`rrt toc`](#rrt-toc)
-  - [Overview](#overview-9)
-  - [Usage](#usage)
-  - [Anchors](#anchors)
-  - [Options](#options)
 {/* rrt:auto:end:toc */}
 
 ## `rrt artifacts`
@@ -1248,6 +1251,141 @@ Options
   --loose          Emit a permissive loose template instead of an exact one.
 ```
 
+## `rrt project`
+
+`rrt project info` — surface project metadata from the project manifest.
+
+Reads ``pyproject.toml`` / ``Cargo.toml`` / ``package.json`` and emits
+``name``, ``description``, ``version``, ``authors``, ``license``, and
+``urls`` as text (default) or JSON. Useful for generating README headers,
+populating release-body templates, or scripting CI tasks that need a
+single field via ``--key``.
+
+### Examples
+
+- ``rrt project info``
+- ``rrt project info --format json``
+- ``rrt project info --key description``
+- ``rrt project info --format json --output project-info.json``
+
+```text
+Usage:  rrt project [OPTIONS] <project_command>
+
+Read project metadata (name, description, version, authors, license, urls) from the appropriate manifest in the current repository.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Arguments
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  info        Print project metadata as text (default) or JSON.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  -h, --help  Show this message and exit.
+```
+
+### `rrt project info`
+
+```text
+Usage:  rrt project info [OPTIONS]
+
+Resolve the project manifest (pyproject.toml, Cargo.toml, or package.json) and emit name, version, description, authors, license, and URLs.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Arguments
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  -h, --help       Show this message and exit.
+  --root PATH      Project root to read (default: current directory).
+  --format FORMAT  Output format: text (default) or json.
+  --key KEY        Emit only one field. Valid keys: name, version, description, authors, license, urls, source.
+  --output PATH    Write the output to PATH instead of stdout.
+```
+
+## `rrt toc`
+
+``rrt toc`` — generate and inject a Markdown table of contents.
+
+### Overview
+
+``rrt toc FILE`` reads a Markdown file and prints a nested bullet list of its
+headings to stdout.  With ``--inject`` and ``--anchor``, the generated TOC is
+written in-place inside a marked anchor block in a target file.
+
+### Usage
+
+```
+rrt toc FILE [--min-level N] [--max-level N]
+rrt toc FILE --inject TARGET --anchor ID [--min-level N] [--max-level N] [--dry-run]
+```
+
+### Anchors
+
+Place a pair of HTML comments in the target file to mark where the TOC
+should live:
+
+```markdown
+<!-- rrt:auto:start:toc -->
+<!-- rrt:auto:end:toc -->
+```
+
+The content between the markers is replaced on every ``rrt toc --inject`` run.
+Everything outside the markers is preserved unchanged.
+
+### Options
+
+| Flag | Default | Description |
+|---|---|---|
+| ``FILE`` | — | Markdown file to parse for headings |
+| ``--inject FILE`` | — | Target file to update in-place |
+| ``--anchor ID`` | — | Anchor ID inside the inject target |
+| ``--min-level N`` | 1 | Shallowest heading level to include (1 = ``#``) |
+| ``--max-level N`` | 6 | Deepest heading level to include (6 = ``######``) |
+| ``--dry-run`` | — | Print result instead of writing (requires ``--inject``) |
+
+``--inject`` and ``--anchor`` must always be used together.
+
+```text
+Usage:  rrt toc [OPTIONS] FILE
+
+Read a Markdown file and print a nested bullet-list TOC to stdout.
+
+With --inject and --anchor the generated TOC is written in-place inside
+an anchor block in a target file.  Markers delimit the block:
+
+  <!-- rrt:auto:start:ID -->
+  <!-- rrt:auto:end:ID -->
+
+Everything outside the markers is preserved unchanged.
+--inject and --anchor must always be used together.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Arguments
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  FILE           Markdown file to parse for headings.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  -h, --help     Show this message and exit.
+  --inject FILE  Markdown file to update in-place. Requires --anchor. The anchored block is replaced; all other content is preserved.
+  --anchor ID    Anchor ID to replace inside the --inject file. Place <!-- rrt:auto:start:<ID> --> and <!-- rrt:auto:end:<ID> --> markers in the target file.
+  --min-level N  Shallowest heading level to include (default: 1 = #).
+  --max-level N  Deepest heading level to include (default: 6 = ######).
+  --dry-run      Print the result instead of writing (only effective with --inject).
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Examples
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  $ rrt toc README.md
+  $ rrt toc README.md --min-level 2 --max-level 3
+  $ rrt toc README.md --inject README.md --anchor toc
+  $ rrt toc README.md --inject README.md --anchor toc --dry-run
+```
+
 ## `rrt tree`
 
 Render a project tree with gitignore-aware filtering.
@@ -1399,85 +1537,4 @@ Examples
   $ rrt tree --format markdown --max-depth 3
   $ rrt tree --root src/repo_release_tools --dirs-only
   $ rrt tree --format markdown --inject README.md --anchor project-tree
-```
-
-## `rrt toc`
-
-``rrt toc`` — generate and inject a Markdown table of contents.
-
-### Overview
-
-``rrt toc FILE`` reads a Markdown file and prints a nested bullet list of its
-headings to stdout.  With ``--inject`` and ``--anchor``, the generated TOC is
-written in-place inside a marked anchor block in a target file.
-
-### Usage
-
-```
-rrt toc FILE [--min-level N] [--max-level N]
-rrt toc FILE --inject TARGET --anchor ID [--min-level N] [--max-level N] [--dry-run]
-```
-
-### Anchors
-
-Place a pair of HTML comments in the target file to mark where the TOC
-should live:
-
-```markdown
-<!-- rrt:auto:start:toc -->
-<!-- rrt:auto:end:toc -->
-```
-
-The content between the markers is replaced on every ``rrt toc --inject`` run.
-Everything outside the markers is preserved unchanged.
-
-### Options
-
-| Flag | Default | Description |
-|---|---|---|
-| ``FILE`` | — | Markdown file to parse for headings |
-| ``--inject FILE`` | — | Target file to update in-place |
-| ``--anchor ID`` | — | Anchor ID inside the inject target |
-| ``--min-level N`` | 1 | Shallowest heading level to include (1 = ``#``) |
-| ``--max-level N`` | 6 | Deepest heading level to include (6 = ``######``) |
-| ``--dry-run`` | — | Print result instead of writing (requires ``--inject``) |
-
-``--inject`` and ``--anchor`` must always be used together.
-
-```text
-Usage:  rrt toc [OPTIONS] FILE
-
-Read a Markdown file and print a nested bullet-list TOC to stdout.
-
-With --inject and --anchor the generated TOC is written in-place inside
-an anchor block in a target file.  Markers delimit the block:
-
-  <!-- rrt:auto:start:ID -->
-  <!-- rrt:auto:end:ID -->
-
-Everything outside the markers is preserved unchanged.
---inject and --anchor must always be used together.
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Arguments
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  FILE           Markdown file to parse for headings.
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Options
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  -h, --help     Show this message and exit.
-  --inject FILE  Markdown file to update in-place. Requires --anchor. The anchored block is replaced; all other content is preserved.
-  --anchor ID    Anchor ID to replace inside the --inject file. Place <!-- rrt:auto:start:<ID> --> and <!-- rrt:auto:end:<ID> --> markers in the target file.
-  --min-level N  Shallowest heading level to include (default: 1 = #).
-  --max-level N  Deepest heading level to include (default: 6 = ######).
-  --dry-run      Print the result instead of writing (only effective with --inject).
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Examples
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  $ rrt toc README.md
-  $ rrt toc README.md --min-level 2 --max-level 3
-  $ rrt toc README.md --inject README.md --anchor toc
-  $ rrt toc README.md --inject README.md --anchor toc --dry-run
 ```

--- a/docs/src/content/docs/commands/rrt-cli.mdx
+++ b/docs/src/content/docs/commands/rrt-cli.mdx
@@ -40,35 +40,33 @@ Options
   --generate-completion SHELL  Print shell completion script for SHELL and exit.
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Version & Release
+CI & Automation
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  bump        Bump project version using [tool.rrt] config.
-  changelog   Commands for working with the project changelog.
-  ci-version  Compute and apply CI pre-release versions (PEP 440 / SemVer).
-  release     Release-specific workflows and checks.
-  sync        Fetch all released versions of the configured upstream package and print those that are strictly newer than the current project version.  With --bump, apply each newer version in ascending order, optionally committing and tagging each one.
-  workspace   Apply a unified version bump to every listed package.
-  tag         Create annotated git tags from the current configured version, or check that existing tags follow the naming convention.
+  action  Scaffold a starter GitHub Actions workflow that runs repo-release-tools checks.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Setup & Tooling
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  agents   Install bundled rrt user agents into one or more local or global agent directories.
+  hooks    Install bundled rrt user workflow hook scripts into one or more local hook directories and update the surface's hook registration JSON.
+  init     Generate a starter rrt configuration for the current repository or manifest.
+  skill    Install the bundled rrt user workflow skills.
+  install  Install one or more bundled rrt agent surfaces (skill, agents, hooks) into one or more local/global targets.
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Repository Health
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  doctor     Validate the core automation wiring for the current repository.
   artifacts  Hash and verify generated files against a committed fingerprint lock.
-  fields     Check or sync a JSON field value that's duplicated as a copy across
   config     Inspect the resolved rrt configuration after discovery and auto-detection.
+  docs       Scan source files and extract inline documentation blocks
+  doctor     Validate the core automation wiring for the current repository.
+  drift      Lock and check the repo's agent-facing surfaces, such as Claude hooks, agent prompts, and shared skill docs.
   env        Show environment variables and interpreter details that affect rrt behavior.
   eol        Check detected host runtimes and project minimum versions against end-of-life dates.
-  toc        Read a Markdown file and print a nested bullet-list TOC to stdout.
-  tree       Render a directory tree from the selected root while respecting gitignore rules.
-  docs       Scan source files and extract inline documentation blocks
-  drift      Lock and check the repo's agent-facing surfaces, such as Claude hooks, agent prompts, and shared skill docs.
+  fields     Check or sync a JSON field value that's duplicated as a copy across
   folder     Supervise folder structures against config-defined rules or built-in templates, scaffold missing structure, and infer new templates from existing trees.
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-CI & Automation
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  action  Scaffold a starter GitHub Actions workflow that runs repo-release-tools checks.
+  tree       Render a directory tree from the selected root while respecting gitignore rules.
+  toc        Read a Markdown file and print a nested bullet-list TOC to stdout.
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Git Workflow
@@ -77,13 +75,15 @@ Git Workflow
   git     Git workflow helpers for repository status, commit, sync, and history operations.
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Setup & Tooling
+Version & Release
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  install  Install one or more bundled rrt agent surfaces (skill, agents, hooks) into one or more local/global targets.
-  init     Generate a starter rrt configuration for the current repository or manifest.
-  skill    Install the bundled rrt user workflow skills.
-  agents   Install bundled rrt user agents into one or more local or global agent directories.
-  hooks    Install bundled rrt user workflow hook scripts into one or more local hook directories and update the surface's hook registration JSON.
+  bump        Bump project version using [tool.rrt] config.
+  changelog   Commands for working with the project changelog.
+  ci-version  Compute and apply CI pre-release versions (PEP 440 / SemVer).
+  release     Release-specific workflows and checks.
+  tag         Create annotated git tags from the current configured version, or check that existing tags follow the naming convention.
+  sync        Fetch all released versions of the configured upstream package and print those that are strictly newer than the current project version.  With --bump, apply each newer version in ascending order, optionally committing and tagging each one.
+  workspace   Apply a unified version bump to every listed package.
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Examples
@@ -107,8 +107,8 @@ Each command group has its own reference page with the full argparse help.
 
 | Group | Commands | Reference |
 |---|---|---|
-| **Version & Release** | `bump`, `changelog`, `ci-version`, `release`, `sync`, `workspace`, `tag` | [Version & Release](/repo-release-tools/commands/version-release/) |
-| **Repository Health** | `doctor`, `artifacts`, `fields`, `config`, `env`, `eol`, `toc`, `tree`, `docs`, `drift`, `folder` | [Repository Health](/repo-release-tools/commands/repo-health/) |
-| **Git Workflow** | `branch`, `git` | [Git Workflow](/repo-release-tools/commands/git-workflow/) |
 | **CI & Automation** | `action` | [CI & Automation](/repo-release-tools/commands/ci-automation/) |
-| **Setup & Tooling** | `install`, `init`, `skill`, `agents`, `hooks` | [Setup & Tooling](/repo-release-tools/commands/setup-tooling/) |
+| **Setup & Tooling** | `agents`, `hooks`, `init`, `skill`, `install` | [Setup & Tooling](/repo-release-tools/commands/setup-tooling/) |
+| **Repository Health** | `artifacts`, `config`, `docs`, `doctor`, `drift`, `env`, `eol`, `fields`, `folder`, `tree`, `toc` | [Repository Health](/repo-release-tools/commands/repo-health/) |
+| **Git Workflow** | `branch`, `git` | [Git Workflow](/repo-release-tools/commands/git-workflow/) |
+| **Version & Release** | `bump`, `changelog`, `ci-version`, `release`, `tag`, `sync`, `workspace` | [Version & Release](/repo-release-tools/commands/version-release/) |

--- a/docs/src/content/docs/commands/rrt-cli.mdx
+++ b/docs/src/content/docs/commands/rrt-cli.mdx
@@ -40,18 +40,15 @@ Options
   --generate-completion SHELL  Print shell completion script for SHELL and exit.
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-CI & Automation
+Version & Release
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  action  Scaffold a starter GitHub Actions workflow that runs repo-release-tools checks.
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Setup & Tooling
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  agents   Install bundled rrt user agents into one or more local or global agent directories.
-  hooks    Install bundled rrt user workflow hook scripts into one or more local hook directories and update the surface's hook registration JSON.
-  init     Generate a starter rrt configuration for the current repository or manifest.
-  skill    Install the bundled rrt user workflow skills.
-  install  Install one or more bundled rrt agent surfaces (skill, agents, hooks) into one or more local/global targets.
+  bump        Bump project version using [tool.rrt] config.
+  changelog   Commands for working with the project changelog.
+  ci-version  Compute and apply CI pre-release versions (PEP 440 / SemVer).
+  release     Release-specific workflows and checks.
+  sync        Fetch all released versions of the configured upstream package and print those that are strictly newer than the current project version.  With --bump, apply each newer version in ascending order, optionally committing and tagging each one.
+  tag         Create annotated git tags from the current configured version, or check that existing tags follow the naming convention.
+  workspace   Apply a unified version bump to every listed package.
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Repository Health
@@ -65,8 +62,14 @@ Repository Health
   eol        Check detected host runtimes and project minimum versions against end-of-life dates.
   fields     Check or sync a JSON field value that's duplicated as a copy across
   folder     Supervise folder structures against config-defined rules or built-in templates, scaffold missing structure, and infer new templates from existing trees.
-  tree       Render a directory tree from the selected root while respecting gitignore rules.
+  project    Read project metadata (name, description, version, authors, license, urls) from the appropriate manifest in the current repository.
   toc        Read a Markdown file and print a nested bullet-list TOC to stdout.
+  tree       Render a directory tree from the selected root while respecting gitignore rules.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+CI & Automation
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  action  Scaffold a starter GitHub Actions workflow that runs repo-release-tools checks.
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Git Workflow
@@ -75,15 +78,14 @@ Git Workflow
   git     Git workflow helpers for repository status, commit, sync, and history operations.
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Version & Release
+Setup & Tooling
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  bump        Bump project version using [tool.rrt] config.
-  changelog   Commands for working with the project changelog.
-  ci-version  Compute and apply CI pre-release versions (PEP 440 / SemVer).
-  release     Release-specific workflows and checks.
-  tag         Create annotated git tags from the current configured version, or check that existing tags follow the naming convention.
-  sync        Fetch all released versions of the configured upstream package and print those that are strictly newer than the current project version.  With --bump, apply each newer version in ascending order, optionally committing and tagging each one.
-  workspace   Apply a unified version bump to every listed package.
+  agents   Install bundled rrt user agents into one or more local or global agent directories.
+  hooks    Install bundled rrt user workflow hook scripts into one or more local hook directories and update the surface's hook registration JSON.
+  init     Generate a starter rrt configuration for the current repository or manifest.
+  install  Install one or more bundled rrt agent surfaces (skill, agents, hooks) into one or more local/global targets.
+  mcp      Scaffolders and utilities for the rrt MCP server. Currently exposes `mcp tool new` to generate a starter MCP tool module.
+  skill    Install the bundled rrt user workflow skills.
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Examples
@@ -107,8 +109,8 @@ Each command group has its own reference page with the full argparse help.
 
 | Group | Commands | Reference |
 |---|---|---|
+| **Version & Release** | `bump`, `changelog`, `ci-version`, `release`, `sync`, `tag`, `workspace` | [Version & Release](/repo-release-tools/commands/version-release/) |
+| **Repository Health** | `artifacts`, `config`, `docs`, `doctor`, `drift`, `env`, `eol`, `fields`, `folder`, `project`, `toc`, `tree` | [Repository Health](/repo-release-tools/commands/repo-health/) |
 | **CI & Automation** | `action` | [CI & Automation](/repo-release-tools/commands/ci-automation/) |
-| **Setup & Tooling** | `agents`, `hooks`, `init`, `skill`, `install` | [Setup & Tooling](/repo-release-tools/commands/setup-tooling/) |
-| **Repository Health** | `artifacts`, `config`, `docs`, `doctor`, `drift`, `env`, `eol`, `fields`, `folder`, `tree`, `toc` | [Repository Health](/repo-release-tools/commands/repo-health/) |
 | **Git Workflow** | `branch`, `git` | [Git Workflow](/repo-release-tools/commands/git-workflow/) |
-| **Version & Release** | `bump`, `changelog`, `ci-version`, `release`, `tag`, `sync`, `workspace` | [Version & Release](/repo-release-tools/commands/version-release/) |
+| **Setup & Tooling** | `agents`, `hooks`, `init`, `install`, `mcp`, `skill` | [Setup & Tooling](/repo-release-tools/commands/setup-tooling/) |

--- a/docs/src/content/docs/commands/setup-tooling.mdx
+++ b/docs/src/content/docs/commands/setup-tooling.mdx
@@ -29,20 +29,23 @@ description: "Generated command reference for the Setup & Tooling command group.
   - [Behavior](#behavior-2)
   - [Examples](#examples-2)
   - [Caveats](#caveats-2)
-- [`rrt skill`](#rrt-skill)
+- [`rrt install`](#rrt-install)
   - [Overview](#overview-3)
-  - [Target surfaces](#target-surfaces-3)
+  - [Responsibilities](#responsibilities-1)
+  - [Target roots](#target-roots)
   - [Behavior](#behavior-3)
   - [Examples](#examples-3)
   - [Caveats](#caveats-3)
-  - [`rrt skill install`](#rrt-skill-install)
-- [`rrt install`](#rrt-install)
-  - [Overview](#overview-4)
-  - [Responsibilities](#responsibilities-1)
-  - [Target roots](#target-roots)
-  - [Behavior](#behavior-4)
+- [`rrt mcp`](#rrt-mcp)
   - [Examples](#examples-4)
+  - [`rrt mcp tool`](#rrt-mcp-tool)
+- [`rrt skill`](#rrt-skill)
+  - [Overview](#overview-4)
+  - [Target surfaces](#target-surfaces-3)
+  - [Behavior](#behavior-4)
+  - [Examples](#examples-5)
   - [Caveats](#caveats-4)
+  - [`rrt skill install`](#rrt-skill-install)
 {/* rrt:auto:end:toc */}
 
 ## `rrt agents`
@@ -331,6 +334,170 @@ Examples
   $ rrt init --target go
 ```
 
+## `rrt install`
+
+Install bundled rrt user workflow surfaces into local/global tool roots.
+
+### Overview
+
+`rrt install` provides a unified, top-level entrypoint for the existing
+specialized installer surfaces:
+
+- `skill install`
+- `agents install`
+- `hooks install`
+
+It is designed to simplify the initial setup and maintenance of the agentic
+workflow tools by allowing users to install all (or a subset of) surfaces
+into one or more target destinations in a single operation.
+
+### Responsibilities
+
+- coordinate the installation of multiple surface types (skills, agents, hooks)
+- validate target compatibility across all requested surfaces
+- provide a consistent dry-run experience for multi-surface installation
+- manage local and global tool root discovery
+
+### Target roots
+
+Supported local/global roots include:
+
+- **Claude**: `./.claude` (local) and `~/.claude` (global)
+- **Codex**: `./.codex` (local) and `~/.codex` (global)
+- **Copilot**: `./.github` (local) and `~/.copilot` (global)
+- **Gemini**: `./.gemini` (local) and `~/.gemini` (global)
+
+Each surface appends its own standardized subdirectory (e.g., `skills`,
+`agents`, or `hooks`) using the internal per-surface logic.
+
+### Behavior
+
+- If `--surface` is omitted, all bundled surfaces are installed.
+- Accepts multiple `--target` values to support parallel installation into
+  different tools or both local and global roots.
+- Respects `--force` to overwrite existing files across all selected surfaces.
+- Supports `--dry-run` to preview the entire installation plan without modifying
+  any files.
+- Exits with an error if any requested target is unsupported by a selected
+  surface.
+
+### Examples
+
+- `rrt install --target claude-local`
+- `rrt install --surface skill --target copilot-local`
+- `rrt install --surface agents --surface hooks --target codex-global --dry-run`
+- `rrt install --target gemini-local --target gemini-global --force`
+
+### Caveats
+
+- Without `--target`, the command prints available destinations in dry-run
+  mode and otherwise fails.
+- The installation is additive by default; existing files are only replaced
+  when `--force` is explicitly passed.
+
+```text
+Usage:  rrt install [OPTIONS]
+
+Install one or more bundled rrt agent surfaces (skill, agents, hooks) into one or more local/global targets.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Arguments
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  -h, --help         Show this message and exit.
+  --surface SURFACE  Surface to install. Repeat for multiple values. Defaults to all: skill, agents, hooks.
+  --target DEST      Install target. Repeat to install into multiple locations. Use --dry-run with no targets to inspect supported values.
+  --dry-run          Preview without writing files.
+  --force            Overwrite existing installed files.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Examples
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  $ rrt install --target claude-local
+  $ rrt install --surface skill --target copilot-local
+  $ rrt install --surface agents --surface hooks --target codex-global --dry-run
+```
+
+## `rrt mcp`
+
+`rrt mcp tool new <name>` — scaffold a starter MCP tool module.
+
+Emits a new file under ``src/repo_release_tools/mcp/tools/<name>_tools.py``
+mirroring the pattern already used by the other modules in that directory:
+a ``register(mcp: FastMCP)`` function plus one ``@mcp.tool`` body with a
+typed Pydantic response model. Tool authors fill in the ``# TODO`` block.
+
+The scaffolder is intentionally minimal — it does not edit
+``mcp/tools/__init__.py``; the printed reminder tells the user to add the
+new ``register()`` call there. Keeping the edits separate makes the
+generated file reviewable on its own.
+
+### Examples
+
+- ``rrt mcp tool new sample``
+- ``rrt mcp tool new sample --title "Sample" --description "demo" --dry-run``
+- ``rrt mcp tool new sample --into custom/path.py --force``
+
+```text
+Usage:  rrt mcp [OPTIONS] <mcp_command>
+
+Scaffolders and utilities for the rrt MCP server. Currently exposes `mcp tool new` to generate a starter MCP tool module.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Arguments
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  tool        Manage MCP tool scaffolds.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  -h, --help  Show this message and exit.
+```
+
+### `rrt mcp tool`
+
+```text
+Usage:  rrt mcp tool [OPTIONS] <tool_command>
+
+Operations on MCP tool modules under mcp/tools/.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Arguments
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  new         Scaffold a new MCP tool module.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  -h, --help  Show this message and exit.
+```
+
+#### `rrt mcp tool new`
+
+```text
+Usage:  rrt mcp tool new [OPTIONS] <name>
+
+Emit a starter `mcp/tools/<name>_tools.py` with one @mcp.tool body, a Pydantic response model, and a register(mcp) function ready to wire into mcp/tools/__init__.py:register_tools().
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Arguments
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  <name>              Snake_case tool name (e.g. project_metadata).
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  -h, --help          Show this message and exit.
+  --title TITLE       Human-readable title (default: derived from name).
+  --description TEXT  Short description used in the docstring and tool body.
+  --into PATH         Target path for the new module (default: src/repo_release_tools/mcp/tools/<name>_tools.py).
+  --dry-run           Print the scaffold to stdout instead of writing the file.
+  --force             Overwrite the target file if it already exists.
+```
+
 ## `rrt skill`
 
 Install bundled rrt user workflow skills.
@@ -437,91 +604,4 @@ Examples
   $ rrt skill install --target claude-local --target codex-local
   $ rrt skill install --target copilot-global --force --dry-run
   $ rrt skill install --target gemini-global
-```
-
-## `rrt install`
-
-Install bundled rrt user workflow surfaces into local/global tool roots.
-
-### Overview
-
-`rrt install` provides a unified, top-level entrypoint for the existing
-specialized installer surfaces:
-
-- `skill install`
-- `agents install`
-- `hooks install`
-
-It is designed to simplify the initial setup and maintenance of the agentic
-workflow tools by allowing users to install all (or a subset of) surfaces
-into one or more target destinations in a single operation.
-
-### Responsibilities
-
-- coordinate the installation of multiple surface types (skills, agents, hooks)
-- validate target compatibility across all requested surfaces
-- provide a consistent dry-run experience for multi-surface installation
-- manage local and global tool root discovery
-
-### Target roots
-
-Supported local/global roots include:
-
-- **Claude**: `./.claude` (local) and `~/.claude` (global)
-- **Codex**: `./.codex` (local) and `~/.codex` (global)
-- **Copilot**: `./.github` (local) and `~/.copilot` (global)
-- **Gemini**: `./.gemini` (local) and `~/.gemini` (global)
-
-Each surface appends its own standardized subdirectory (e.g., `skills`,
-`agents`, or `hooks`) using the internal per-surface logic.
-
-### Behavior
-
-- If `--surface` is omitted, all bundled surfaces are installed.
-- Accepts multiple `--target` values to support parallel installation into
-  different tools or both local and global roots.
-- Respects `--force` to overwrite existing files across all selected surfaces.
-- Supports `--dry-run` to preview the entire installation plan without modifying
-  any files.
-- Exits with an error if any requested target is unsupported by a selected
-  surface.
-
-### Examples
-
-- `rrt install --target claude-local`
-- `rrt install --surface skill --target copilot-local`
-- `rrt install --surface agents --surface hooks --target codex-global --dry-run`
-- `rrt install --target gemini-local --target gemini-global --force`
-
-### Caveats
-
-- Without `--target`, the command prints available destinations in dry-run
-  mode and otherwise fails.
-- The installation is additive by default; existing files are only replaced
-  when `--force` is explicitly passed.
-
-```text
-Usage:  rrt install [OPTIONS]
-
-Install one or more bundled rrt agent surfaces (skill, agents, hooks) into one or more local/global targets.
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Arguments
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Options
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  -h, --help         Show this message and exit.
-  --surface SURFACE  Surface to install. Repeat for multiple values. Defaults to all: skill, agents, hooks.
-  --target DEST      Install target. Repeat to install into multiple locations. Use --dry-run with no targets to inspect supported values.
-  --dry-run          Preview without writing files.
-  --force            Overwrite existing installed files.
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Examples
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  $ rrt install --target claude-local
-  $ rrt install --surface skill --target copilot-local
-  $ rrt install --surface agents --surface hooks --target codex-global --dry-run
 ```

--- a/docs/src/content/docs/commands/setup-tooling.mdx
+++ b/docs/src/content/docs/commands/setup-tooling.mdx
@@ -8,108 +8,116 @@ description: "Generated command reference for the Setup & Tooling command group.
 {/* Auto-generated from repo_release_tools.cli.build_parser(); run `rrt docs publish` to refresh. */}
 
 {/* rrt:auto:start:toc */}
-- [`rrt install`](#rrt-install)
+- [`rrt agents`](#rrt-agents)
   - [Overview](#overview)
-  - [Responsibilities](#responsibilities)
-  - [Target roots](#target-roots)
+  - [Target surfaces](#target-surfaces)
   - [Behavior](#behavior)
   - [Examples](#examples)
   - [Caveats](#caveats)
-- [`rrt init`](#rrt-init)
+  - [`rrt agents install`](#rrt-agents-install)
+- [`rrt hooks`](#rrt-hooks)
   - [Overview](#overview-1)
-  - [Responsibilities](#responsibilities-1)
-  - [Target Surfaces](#target-surfaces)
+  - [Target surfaces](#target-surfaces-1)
   - [Behavior](#behavior-1)
   - [Examples](#examples-1)
   - [Caveats](#caveats-1)
-- [`rrt skill`](#rrt-skill)
+  - [`rrt hooks install`](#rrt-hooks-install)
+- [`rrt init`](#rrt-init)
   - [Overview](#overview-2)
-  - [Target surfaces](#target-surfaces-1)
+  - [Responsibilities](#responsibilities)
+  - [Target Surfaces](#target-surfaces-2)
   - [Behavior](#behavior-2)
   - [Examples](#examples-2)
   - [Caveats](#caveats-2)
-  - [`rrt skill install`](#rrt-skill-install)
-- [`rrt agents`](#rrt-agents)
+- [`rrt skill`](#rrt-skill)
   - [Overview](#overview-3)
-  - [Target surfaces](#target-surfaces-2)
+  - [Target surfaces](#target-surfaces-3)
   - [Behavior](#behavior-3)
   - [Examples](#examples-3)
   - [Caveats](#caveats-3)
-  - [`rrt agents install`](#rrt-agents-install)
-- [`rrt hooks`](#rrt-hooks)
+  - [`rrt skill install`](#rrt-skill-install)
+- [`rrt install`](#rrt-install)
   - [Overview](#overview-4)
-  - [Target surfaces](#target-surfaces-3)
+  - [Responsibilities](#responsibilities-1)
+  - [Target roots](#target-roots)
   - [Behavior](#behavior-4)
   - [Examples](#examples-4)
   - [Caveats](#caveats-4)
-  - [`rrt hooks install`](#rrt-hooks-install)
 {/* rrt:auto:end:toc */}
 
-## `rrt install`
+## `rrt agents`
 
-Install bundled rrt user workflow surfaces into local/global tool roots.
+Install bundled rrt user agent definitions (.agent.md files).
 
 ### Overview
 
-`rrt install` provides a unified, top-level entrypoint for the existing
-specialized installer surfaces:
+`rrt agents` manages installation of the packaged user-facing agent definitions
+into tool-specific agent directories. The only implemented subcommand is `install`.
 
-- `skill install`
-- `agents install`
-- `hooks install`
+### Target surfaces
 
-It is designed to simplify the initial setup and maintenance of the agentic
-workflow tools by allowing users to install all (or a subset of) surfaces
-into one or more target destinations in a single operation.
+The install command can write to local or global agent roots for:
 
-### Responsibilities
+- Claude: `.claude/agents`
+- Codex: `.codex/agents`
+- Copilot: `.github/agents` (local), `~/.copilot/agents` (global)
+- Gemini: `.gemini/agents`
 
-- coordinate the installation of multiple surface types (skills, agents, hooks)
-- validate target compatibility across all requested surfaces
-- provide a consistent dry-run experience for multi-surface installation
-- manage local and global tool root discovery
-
-### Target roots
-
-Supported local/global roots include:
-
-- **Claude**: `./.claude` (local) and `~/.claude` (global)
-- **Codex**: `./.codex` (local) and `~/.codex` (global)
-- **Copilot**: `./.github` (local) and `~/.copilot` (global)
-- **Gemini**: `./.gemini` (local) and `~/.gemini` (global)
-
-Each surface appends its own standardized subdirectory (e.g., `skills`,
-`agents`, or `hooks`) using the internal per-surface logic.
+Each target receives one flat `.agent.md` file per bundled user agent.
 
 ### Behavior
 
-- If `--surface` is omitted, all bundled surfaces are installed.
-- Accepts multiple `--target` values to support parallel installation into
-  different tools or both local and global roots.
-- Respects `--force` to overwrite existing files across all selected surfaces.
-- Supports `--dry-run` to preview the entire installation plan without modifying
-  any files.
-- Exits with an error if any requested target is unsupported by a selected
-  surface.
+- Accepts one or more `--target` values; duplicates are ignored after first use.
+- Resolves local targets relative to the current working directory and global
+  targets relative to the home directory.
+- Refuses to overwrite an existing file unless `--force` is provided.
+- Supports `--dry-run` previews that show the resolved destination paths
+  without writing files.
 
 ### Examples
 
-- `rrt install --target claude-local`
-- `rrt install --surface skill --target copilot-local`
-- `rrt install --surface agents --surface hooks --target codex-global --dry-run`
-- `rrt install --target gemini-local --target gemini-global --force`
+- `rrt agents install --target claude-local`
+- `rrt agents install --target claude-local --target codex-local`
+- `rrt agents install --target claude-global --force`
+- `rrt agents install --dry-run`
 
 ### Caveats
 
+- `rrt agents` requires a subcommand; use `rrt agents install ...`.
 - Without `--target`, the command prints available destinations in dry-run
   mode and otherwise fails.
-- The installation is additive by default; existing files are only replaced
-  when `--force` is explicitly passed.
+- Existing files at the destination are replaced only when `--force` is used.
 
 ```text
-Usage:  rrt install [OPTIONS]
+Usage:  rrt agents [OPTIONS] <agents_command>
 
-Install one or more bundled rrt agent surfaces (skill, agents, hooks) into one or more local/global targets.
+Install bundled rrt user agents into one or more local or global agent directories.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Arguments
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  install     Install bundled rrt user agents into agent directories.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  -h, --help  Show this message and exit.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Examples
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  $ rrt agents install --target claude-local
+  $ rrt agents install --target claude-local --target codex-local
+  $ rrt agents install --target copilot-local
+  $ rrt agents install --target claude-global --force
+```
+
+### `rrt agents install`
+
+```text
+Usage:  rrt agents install [OPTIONS]
+
+Install bundled .agent.md user agents into one or more local or global agent directories.
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Arguments
@@ -118,18 +126,117 @@ Arguments
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Options
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  -h, --help         Show this message and exit.
-  --surface SURFACE  Surface to install. Repeat for multiple values. Defaults to all: skill, agents, hooks.
-  --target DEST      Install target. Repeat to install into multiple locations. Use --dry-run with no targets to inspect supported values.
-  --dry-run          Preview without writing files.
-  --force            Overwrite existing installed files.
+  -h, --help     Show this message and exit.
+  --target DEST  Install target. Repeat to install into multiple locations: claude-local, claude-global, codex-local, codex-global, copilot-local, copilot-global, gemini-local, gemini-global.
+  --agent AGENT  Install a specific agent by name. When the agent declares a `family:` metadata, the entire family will be installed. Repeat for multiple agents.
+  --dry-run      Preview without writing files.
+  --force        Overwrite existing agent files.
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Examples
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  $ rrt install --target claude-local
-  $ rrt install --surface skill --target copilot-local
-  $ rrt install --surface agents --surface hooks --target codex-global --dry-run
+  $ rrt agents install --target claude-local
+  $ rrt agents install --target claude-local --target codex-local
+  $ rrt agents install --target gemini-local
+  $ rrt agents install --target claude-global --force --dry-run
+  $ rrt agents install --target copilot-global
+```
+
+## `rrt hooks`
+
+Install bundled rrt user workflow hook scripts and register them automatically.
+
+### Overview
+
+`rrt hooks` manages installation of the packaged user-facing hook scripts into
+tool-specific hook directories and writes managed hook-registration config for
+the selected surface. The only implemented subcommand is `install`.
+
+### Target surfaces
+
+The install command can write to local or global hook roots for:
+
+- Claude: `.claude/hooks`
+- Codex: `.codex/hooks`
+- Copilot: `.github/hooks` (local), `~/.copilot/hooks` (global)
+- Gemini: `.gemini/hooks`
+
+Each target receives the same bundled `.py` hook scripts for user-facing `rrt`
+workflow checks and a managed hook-registration file in the surface's native
+JSON format.
+
+### Behavior
+
+- Accepts one or more `--target` values; duplicates are ignored after first use.
+- Resolves local targets relative to the current working directory.
+- Refuses to overwrite an existing script file unless `--force` is provided.
+- Supports `--dry-run` previews that show the resolved destination paths
+    without writing files.
+- Merges managed hook registrations additively, preserving unrelated settings.
+
+### Examples
+
+- `rrt hooks install --target claude-local`
+- `rrt hooks install --target claude-local --force`
+- `rrt hooks install --dry-run`
+
+### Caveats
+
+- `rrt hooks` requires a subcommand; use `rrt hooks install ...`.
+- Without `--target`, the command prints available destinations in dry-run
+  mode and otherwise fails.
+- Hook registration happens automatically during installation.
+
+```text
+Usage:  rrt hooks [OPTIONS] <hooks_command>
+
+Install bundled rrt user workflow hook scripts into one or more local hook directories and update the surface's hook registration JSON.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Arguments
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  install     Install bundled rrt hook scripts into hook directories and register them.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  -h, --help  Show this message and exit.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Examples
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  $ rrt hooks install --target claude-local
+  $ rrt hooks install --target codex-local
+  $ rrt hooks install --target gemini-local
+  $ rrt hooks install --target claude-local --force
+```
+
+### `rrt hooks install`
+
+```text
+Usage:  rrt hooks install [OPTIONS]
+
+Install bundled rrt user workflow hook .py scripts into one or more local hook directories and update the native hook-registration JSON for that surface.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Arguments
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  -h, --help     Show this message and exit.
+  --target DEST  Install target. Repeat to install into multiple locations: claude-local, claude-global, codex-local, codex-global, copilot-local, copilot-global, gemini-local, gemini-global.
+  --dry-run      Preview without writing files.
+  --force        Overwrite existing hook files.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Examples
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  $ rrt hooks install --target claude-local
+  $ rrt hooks install --target claude-local --force --dry-run
+  $ rrt hooks install --target codex-global
+  $ rrt hooks install --target copilot-local
 ```
 
 ## `rrt init`
@@ -332,178 +439,71 @@ Examples
   $ rrt skill install --target gemini-global
 ```
 
-## `rrt agents`
+## `rrt install`
 
-Install bundled rrt user agent definitions (.agent.md files).
-
-### Overview
-
-`rrt agents` manages installation of the packaged user-facing agent definitions
-into tool-specific agent directories. The only implemented subcommand is `install`.
-
-### Target surfaces
-
-The install command can write to local or global agent roots for:
-
-- Claude: `.claude/agents`
-- Codex: `.codex/agents`
-- Copilot: `.github/agents` (local), `~/.copilot/agents` (global)
-- Gemini: `.gemini/agents`
-
-Each target receives one flat `.agent.md` file per bundled user agent.
-
-### Behavior
-
-- Accepts one or more `--target` values; duplicates are ignored after first use.
-- Resolves local targets relative to the current working directory and global
-  targets relative to the home directory.
-- Refuses to overwrite an existing file unless `--force` is provided.
-- Supports `--dry-run` previews that show the resolved destination paths
-  without writing files.
-
-### Examples
-
-- `rrt agents install --target claude-local`
-- `rrt agents install --target claude-local --target codex-local`
-- `rrt agents install --target claude-global --force`
-- `rrt agents install --dry-run`
-
-### Caveats
-
-- `rrt agents` requires a subcommand; use `rrt agents install ...`.
-- Without `--target`, the command prints available destinations in dry-run
-  mode and otherwise fails.
-- Existing files at the destination are replaced only when `--force` is used.
-
-```text
-Usage:  rrt agents [OPTIONS] <agents_command>
-
-Install bundled rrt user agents into one or more local or global agent directories.
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Arguments
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  install     Install bundled rrt user agents into agent directories.
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Options
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  -h, --help  Show this message and exit.
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Examples
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  $ rrt agents install --target claude-local
-  $ rrt agents install --target claude-local --target codex-local
-  $ rrt agents install --target copilot-local
-  $ rrt agents install --target claude-global --force
-```
-
-### `rrt agents install`
-
-```text
-Usage:  rrt agents install [OPTIONS]
-
-Install bundled .agent.md user agents into one or more local or global agent directories.
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Arguments
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Options
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  -h, --help     Show this message and exit.
-  --target DEST  Install target. Repeat to install into multiple locations: claude-local, claude-global, codex-local, codex-global, copilot-local, copilot-global, gemini-local, gemini-global.
-  --agent AGENT  Install a specific agent by name. When the agent declares a `family:` metadata, the entire family will be installed. Repeat for multiple agents.
-  --dry-run      Preview without writing files.
-  --force        Overwrite existing agent files.
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Examples
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  $ rrt agents install --target claude-local
-  $ rrt agents install --target claude-local --target codex-local
-  $ rrt agents install --target gemini-local
-  $ rrt agents install --target claude-global --force --dry-run
-  $ rrt agents install --target copilot-global
-```
-
-## `rrt hooks`
-
-Install bundled rrt user workflow hook scripts and register them automatically.
+Install bundled rrt user workflow surfaces into local/global tool roots.
 
 ### Overview
 
-`rrt hooks` manages installation of the packaged user-facing hook scripts into
-tool-specific hook directories and writes managed hook-registration config for
-the selected surface. The only implemented subcommand is `install`.
+`rrt install` provides a unified, top-level entrypoint for the existing
+specialized installer surfaces:
 
-### Target surfaces
+- `skill install`
+- `agents install`
+- `hooks install`
 
-The install command can write to local or global hook roots for:
+It is designed to simplify the initial setup and maintenance of the agentic
+workflow tools by allowing users to install all (or a subset of) surfaces
+into one or more target destinations in a single operation.
 
-- Claude: `.claude/hooks`
-- Codex: `.codex/hooks`
-- Copilot: `.github/hooks` (local), `~/.copilot/hooks` (global)
-- Gemini: `.gemini/hooks`
+### Responsibilities
 
-Each target receives the same bundled `.py` hook scripts for user-facing `rrt`
-workflow checks and a managed hook-registration file in the surface's native
-JSON format.
+- coordinate the installation of multiple surface types (skills, agents, hooks)
+- validate target compatibility across all requested surfaces
+- provide a consistent dry-run experience for multi-surface installation
+- manage local and global tool root discovery
+
+### Target roots
+
+Supported local/global roots include:
+
+- **Claude**: `./.claude` (local) and `~/.claude` (global)
+- **Codex**: `./.codex` (local) and `~/.codex` (global)
+- **Copilot**: `./.github` (local) and `~/.copilot` (global)
+- **Gemini**: `./.gemini` (local) and `~/.gemini` (global)
+
+Each surface appends its own standardized subdirectory (e.g., `skills`,
+`agents`, or `hooks`) using the internal per-surface logic.
 
 ### Behavior
 
-- Accepts one or more `--target` values; duplicates are ignored after first use.
-- Resolves local targets relative to the current working directory.
-- Refuses to overwrite an existing script file unless `--force` is provided.
-- Supports `--dry-run` previews that show the resolved destination paths
-    without writing files.
-- Merges managed hook registrations additively, preserving unrelated settings.
+- If `--surface` is omitted, all bundled surfaces are installed.
+- Accepts multiple `--target` values to support parallel installation into
+  different tools or both local and global roots.
+- Respects `--force` to overwrite existing files across all selected surfaces.
+- Supports `--dry-run` to preview the entire installation plan without modifying
+  any files.
+- Exits with an error if any requested target is unsupported by a selected
+  surface.
 
 ### Examples
 
-- `rrt hooks install --target claude-local`
-- `rrt hooks install --target claude-local --force`
-- `rrt hooks install --dry-run`
+- `rrt install --target claude-local`
+- `rrt install --surface skill --target copilot-local`
+- `rrt install --surface agents --surface hooks --target codex-global --dry-run`
+- `rrt install --target gemini-local --target gemini-global --force`
 
 ### Caveats
 
-- `rrt hooks` requires a subcommand; use `rrt hooks install ...`.
 - Without `--target`, the command prints available destinations in dry-run
   mode and otherwise fails.
-- Hook registration happens automatically during installation.
+- The installation is additive by default; existing files are only replaced
+  when `--force` is explicitly passed.
 
 ```text
-Usage:  rrt hooks [OPTIONS] <hooks_command>
+Usage:  rrt install [OPTIONS]
 
-Install bundled rrt user workflow hook scripts into one or more local hook directories and update the surface's hook registration JSON.
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Arguments
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  install     Install bundled rrt hook scripts into hook directories and register them.
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Options
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  -h, --help  Show this message and exit.
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Examples
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  $ rrt hooks install --target claude-local
-  $ rrt hooks install --target codex-local
-  $ rrt hooks install --target gemini-local
-  $ rrt hooks install --target claude-local --force
-```
-
-### `rrt hooks install`
-
-```text
-Usage:  rrt hooks install [OPTIONS]
-
-Install bundled rrt user workflow hook .py scripts into one or more local hook directories and update the native hook-registration JSON for that surface.
+Install one or more bundled rrt agent surfaces (skill, agents, hooks) into one or more local/global targets.
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Arguments
@@ -512,16 +512,16 @@ Arguments
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Options
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  -h, --help     Show this message and exit.
-  --target DEST  Install target. Repeat to install into multiple locations: claude-local, claude-global, codex-local, codex-global, copilot-local, copilot-global, gemini-local, gemini-global.
-  --dry-run      Preview without writing files.
-  --force        Overwrite existing hook files.
+  -h, --help         Show this message and exit.
+  --surface SURFACE  Surface to install. Repeat for multiple values. Defaults to all: skill, agents, hooks.
+  --target DEST      Install target. Repeat to install into multiple locations. Use --dry-run with no targets to inspect supported values.
+  --dry-run          Preview without writing files.
+  --force            Overwrite existing installed files.
 
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Examples
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  $ rrt hooks install --target claude-local
-  $ rrt hooks install --target claude-local --force --dry-run
-  $ rrt hooks install --target codex-global
-  $ rrt hooks install --target copilot-local
+  $ rrt install --target claude-local
+  $ rrt install --surface skill --target copilot-local
+  $ rrt install --surface agents --surface hooks --target codex-global --dry-run
 ```

--- a/docs/src/content/docs/commands/version-release.mdx
+++ b/docs/src/content/docs/commands/version-release.mdx
@@ -37,6 +37,15 @@ description: "Generated command reference for the Version & Release command grou
   - [`rrt release check`](#rrt-release-check)
   - [`rrt release notes`](#rrt-release-notes)
   - [`rrt release repair`](#rrt-release-repair)
+- [`rrt tag`](#rrt-tag)
+  - [Overview](#overview-2)
+  - [Responsibilities](#responsibilities-1)
+  - [Tag Format](#tag-format)
+  - [Behavior](#behavior-1)
+  - [Examples](#examples-2)
+  - [Caveats](#caveats)
+  - [`rrt tag create`](#rrt-tag-create)
+  - [`rrt tag check`](#rrt-tag-check)
 - [`rrt sync`](#rrt-sync)
   - [Configuration](#configuration)
   - [Supported providers](#supported-providers)
@@ -45,21 +54,12 @@ description: "Generated command reference for the Version & Release command grou
   - [CI mirror loop](#ci-mirror-loop)
   - [Hook](#hook)
 - [`rrt workspace`](#rrt-workspace)
-  - [Overview](#overview-2)
+  - [Overview](#overview-3)
   - [When to use this](#when-to-use-this)
   - [What it does](#what-it-does)
   - [Safety notes](#safety-notes)
-  - [Examples](#examples-2)
-  - [`rrt workspace bump`](#rrt-workspace-bump)
-- [`rrt tag`](#rrt-tag)
-  - [Overview](#overview-3)
-  - [Responsibilities](#responsibilities-1)
-  - [Tag Format](#tag-format)
-  - [Behavior](#behavior-1)
   - [Examples](#examples-3)
-  - [Caveats](#caveats)
-  - [`rrt tag create`](#rrt-tag-create)
-  - [`rrt tag check`](#rrt-tag-check)
+  - [`rrt workspace bump`](#rrt-workspace-bump)
 {/* rrt:auto:end:toc */}
 
 ## `rrt bump`
@@ -727,6 +727,149 @@ Examples
   $ rrt release repair --from main --hotfix
 ```
 
+## `rrt tag`
+
+Create and validate release tags for the current repository.
+
+### Overview
+
+`rrt tag` centralizes the management of Git release tags, ensuring that the
+repository's version history remains consistent with its configuration. It
+automates the creation of annotated tags and provides validation tools to
+verify that existing tags align with the project's versioning policy.
+
+The command supports both manual release tagging and automated verification in
+CI pipelines, helping to maintain a clean and reliable release record.
+
+### Responsibilities
+
+- create annotated Git tags matching the current configured version
+- support custom tag prefixes and annotation messages
+- validate that existing tags follow the expected naming convention
+- verify that the expected tag for the current version is present
+- optionally push newly created tags to the remote repository
+
+### Tag Format
+
+By default, tags are created with a `v` prefix (e.g., `v1.2.3`) as is standard
+for many version control and release automation tools.
+
+- The prefix can be customized using `--prefix <string>`.
+- The prefix can be removed entirely using `--prefix ""`.
+- Tag names are derived directly from the current version read from the
+  active `[tool.rrt]` configuration group.
+
+### Behavior
+
+- **create**: Reads the current version from config, builds the tag name and
+  message, and executes `git tag -a`. Refuses to overwrite existing tags
+  unless `--force` is used.
+- **check**: Scans all repository tags, identifies those that don't match the
+  requested prefix, and verifies the presence of the tag corresponding to the
+  current version.
+- **push**: When `--push` is used with `create`, the command executes
+  `git push origin <tag>` after a successful local tag creation.
+- **dry-run**: Previews the `git` commands that would be executed without
+  modifying the repository.
+
+### Examples
+
+- `rrt tag create`
+- `rrt tag create --push --message "Production release v1.5.0"`
+- `rrt tag create --prefix "" --force`
+- `rrt tag check`
+- `rrt tag check --strict --prefix "rel-"`
+
+### Caveats
+
+- Requires a valid Git repository and `repo-release-tools` configuration.
+- Annotated tags are used to ensure that metadata (author, date, message) is
+  correctly captured in the Git history.
+- The `check --strict` mode is recommended for CI pipelines to ensure that a
+  tag was correctly created before a release proceeds.
+
+```text
+Usage:  rrt tag [OPTIONS] <tag_command>
+
+Create annotated git tags from the current configured version, or check that existing tags follow the naming convention.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Arguments
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  create      Create an annotated git tag for the current version.
+  check       Validate existing tags against the configured version.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  -h, --help  Show this message and exit.
+```
+
+### `rrt tag create`
+
+```text
+Usage:  rrt tag create [OPTIONS]
+
+Create an annotated git tag matching the current configured version.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Arguments
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  -h, --help       Show this message and exit.
+  --prefix PREFIX  Tag prefix (default: 'v'). Pass empty string for no prefix. Include the '{group}' token to render each group's name when --group lists multiple groups (e.g. '{group}-v').
+  --message MSG    Annotation message. Defaults to 'Release <tag>'.
+  --push           Push the tag to origin after creating it.
+  --force          Delete and recreate the tag if it already exists.
+  --dry-run        Preview what would happen without making changes.
+  --group GROUP    Version group to read when multiple groups are configured. Pass a comma-separated list (e.g. 'a,b,c') to tag several groups in one invocation; --prefix must then include the '{group}' token.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Examples
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  $ rrt tag create
+  $ rrt tag create --push
+  $ rrt tag create --prefix '' --message 'Release 1.2.3'
+  $ rrt tag create --group backend,sdk --prefix '{group}-v'
+  $ rrt tag check
+  $ rrt tag check --strict
+  $ rrt tag check --group backend,sdk --prefix '{group}-v'
+```
+
+### `rrt tag check`
+
+```text
+Usage:  rrt tag check [OPTIONS]
+
+Check that existing git tags follow the naming convention.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Arguments
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  -h, --help       Show this message and exit.
+  --prefix PREFIX  Expected tag prefix (default: 'v'). Include the '{group}' token to render each group's name when --group lists multiple groups (e.g. '{group}-v').
+  --strict         Fail if the expected tag for the current version is missing.
+  --group GROUP    Version group to read when multiple groups are configured. Pass a comma-separated list (e.g. 'a,b,c') to check several groups in one invocation; --prefix must then include the '{group}' token.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Examples
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  $ rrt tag create
+  $ rrt tag create --push
+  $ rrt tag create --prefix '' --message 'Release 1.2.3'
+  $ rrt tag create --group backend,sdk --prefix '{group}-v'
+  $ rrt tag check
+  $ rrt tag check --strict
+  $ rrt tag check --group backend,sdk --prefix '{group}-v'
+```
+
 ## `rrt sync`
 
 ### Configuration
@@ -936,147 +1079,4 @@ Examples
   $ rrt workspace bump minor --packages api,sdk,docs
   $ rrt workspace bump 2.0.0 --packages ./packages/api,./packages/sdk
   $ rrt workspace bump patch --dry-run --packages api,sdk
-```
-
-## `rrt tag`
-
-Create and validate release tags for the current repository.
-
-### Overview
-
-`rrt tag` centralizes the management of Git release tags, ensuring that the
-repository's version history remains consistent with its configuration. It
-automates the creation of annotated tags and provides validation tools to
-verify that existing tags align with the project's versioning policy.
-
-The command supports both manual release tagging and automated verification in
-CI pipelines, helping to maintain a clean and reliable release record.
-
-### Responsibilities
-
-- create annotated Git tags matching the current configured version
-- support custom tag prefixes and annotation messages
-- validate that existing tags follow the expected naming convention
-- verify that the expected tag for the current version is present
-- optionally push newly created tags to the remote repository
-
-### Tag Format
-
-By default, tags are created with a `v` prefix (e.g., `v1.2.3`) as is standard
-for many version control and release automation tools.
-
-- The prefix can be customized using `--prefix <string>`.
-- The prefix can be removed entirely using `--prefix ""`.
-- Tag names are derived directly from the current version read from the
-  active `[tool.rrt]` configuration group.
-
-### Behavior
-
-- **create**: Reads the current version from config, builds the tag name and
-  message, and executes `git tag -a`. Refuses to overwrite existing tags
-  unless `--force` is used.
-- **check**: Scans all repository tags, identifies those that don't match the
-  requested prefix, and verifies the presence of the tag corresponding to the
-  current version.
-- **push**: When `--push` is used with `create`, the command executes
-  `git push origin <tag>` after a successful local tag creation.
-- **dry-run**: Previews the `git` commands that would be executed without
-  modifying the repository.
-
-### Examples
-
-- `rrt tag create`
-- `rrt tag create --push --message "Production release v1.5.0"`
-- `rrt tag create --prefix "" --force`
-- `rrt tag check`
-- `rrt tag check --strict --prefix "rel-"`
-
-### Caveats
-
-- Requires a valid Git repository and `repo-release-tools` configuration.
-- Annotated tags are used to ensure that metadata (author, date, message) is
-  correctly captured in the Git history.
-- The `check --strict` mode is recommended for CI pipelines to ensure that a
-  tag was correctly created before a release proceeds.
-
-```text
-Usage:  rrt tag [OPTIONS] <tag_command>
-
-Create annotated git tags from the current configured version, or check that existing tags follow the naming convention.
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Arguments
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  create      Create an annotated git tag for the current version.
-  check       Validate existing tags against the configured version.
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Options
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  -h, --help  Show this message and exit.
-```
-
-### `rrt tag create`
-
-```text
-Usage:  rrt tag create [OPTIONS]
-
-Create an annotated git tag matching the current configured version.
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Arguments
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Options
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  -h, --help       Show this message and exit.
-  --prefix PREFIX  Tag prefix (default: 'v'). Pass empty string for no prefix. Include the '{group}' token to render each group's name when --group lists multiple groups (e.g. '{group}-v').
-  --message MSG    Annotation message. Defaults to 'Release <tag>'.
-  --push           Push the tag to origin after creating it.
-  --force          Delete and recreate the tag if it already exists.
-  --dry-run        Preview what would happen without making changes.
-  --group GROUP    Version group to read when multiple groups are configured. Pass a comma-separated list (e.g. 'a,b,c') to tag several groups in one invocation; --prefix must then include the '{group}' token.
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Examples
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  $ rrt tag create
-  $ rrt tag create --push
-  $ rrt tag create --prefix '' --message 'Release 1.2.3'
-  $ rrt tag create --group backend,sdk --prefix '{group}-v'
-  $ rrt tag check
-  $ rrt tag check --strict
-  $ rrt tag check --group backend,sdk --prefix '{group}-v'
-```
-
-### `rrt tag check`
-
-```text
-Usage:  rrt tag check [OPTIONS]
-
-Check that existing git tags follow the naming convention.
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Arguments
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Options
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  -h, --help       Show this message and exit.
-  --prefix PREFIX  Expected tag prefix (default: 'v'). Include the '{group}' token to render each group's name when --group lists multiple groups (e.g. '{group}-v').
-  --strict         Fail if the expected tag for the current version is missing.
-  --group GROUP    Version group to read when multiple groups are configured. Pass a comma-separated list (e.g. 'a,b,c') to check several groups in one invocation; --prefix must then include the '{group}' token.
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Examples
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  $ rrt tag create
-  $ rrt tag create --push
-  $ rrt tag create --prefix '' --message 'Release 1.2.3'
-  $ rrt tag create --group backend,sdk --prefix '{group}-v'
-  $ rrt tag check
-  $ rrt tag check --strict
-  $ rrt tag check --group backend,sdk --prefix '{group}-v'
 ```

--- a/docs/src/content/docs/commands/version-release.mdx
+++ b/docs/src/content/docs/commands/version-release.mdx
@@ -37,6 +37,13 @@ description: "Generated command reference for the Version & Release command grou
   - [`rrt release check`](#rrt-release-check)
   - [`rrt release notes`](#rrt-release-notes)
   - [`rrt release repair`](#rrt-release-repair)
+- [`rrt sync`](#rrt-sync)
+  - [Configuration](#configuration)
+  - [Supported providers](#supported-providers)
+  - [Basic usage](#basic-usage)
+  - [Mirror-orchestration mode](#mirror-orchestration-mode)
+  - [CI mirror loop](#ci-mirror-loop)
+  - [Hook](#hook)
 - [`rrt tag`](#rrt-tag)
   - [Overview](#overview-2)
   - [Responsibilities](#responsibilities-1)
@@ -46,13 +53,6 @@ description: "Generated command reference for the Version & Release command grou
   - [Caveats](#caveats)
   - [`rrt tag create`](#rrt-tag-create)
   - [`rrt tag check`](#rrt-tag-check)
-- [`rrt sync`](#rrt-sync)
-  - [Configuration](#configuration)
-  - [Supported providers](#supported-providers)
-  - [Basic usage](#basic-usage)
-  - [Mirror-orchestration mode](#mirror-orchestration-mode)
-  - [CI mirror loop](#ci-mirror-loop)
-  - [Hook](#hook)
 - [`rrt workspace`](#rrt-workspace)
   - [Overview](#overview-3)
   - [When to use this](#when-to-use-this)
@@ -727,6 +727,132 @@ Examples
   $ rrt release repair --from main --hotfix
 ```
 
+## `rrt sync`
+
+### Configuration
+
+`rrt sync` reads upstream version information using the `[tool.rrt.upstream]`
+block in your project config:
+
+```toml
+[tool.rrt.upstream]
+package = "my-package"
+provider = "pypi"
+commit_message = "Mirror: {version}"
+```
+
+`package` is the registry name of the upstream package. `provider` selects the
+registry to query.  `commit_message` is a Python format string; `{version}` is
+replaced with the new version string and used as the git commit message when
+``--commit`` is given.
+
+### Supported providers
+
+| Provider | `provider` value | Notes |
+|---|---|---|
+| PyPI | `pypi` | Python package index; queries `/pypi/<package>/json` |
+| npm | `npm` | Node package registry; queries `/package/<package>` |
+| NuGet | `nuget` | .NET package registry; queries the NuGet API |
+| crates.io | `crates` | Rust crate registry; requires a `User-Agent` header — handled internally |
+| Packagist | `packagist` | PHP package registry; `package` must be in `vendor/name` form |
+
+### Basic usage
+
+```bash
+# List newer versions one per line (default)
+rrt sync
+
+# Emit a JSON array of newer version strings
+rrt sync --json
+
+# Target a specific version group
+rrt sync --group backend
+```
+
+### Mirror-orchestration mode
+
+```bash
+# Apply every newer version to version targets (no git side-effects)
+rrt sync --bump
+
+# Apply + commit each version with the default message "Mirror: <version>"
+rrt sync --bump --commit
+
+# Apply + commit + annotated tag per version
+rrt sync --bump --commit --tag
+
+# Preview the plan without touching anything
+rrt sync --bump --commit --tag --dry-run
+
+# Custom commit message template
+rrt sync --bump --commit --commit-message "chore: mirror {version}"
+```
+
+### CI mirror loop
+
+Use `rrt sync` output to drive a CI bump loop that tracks upstream releases:
+
+```bash
+for v in $(rrt sync); do
+    rrt bump "$v" --no-changelog --force
+done
+```
+
+Or let `rrt sync --bump --commit --tag` handle the full loop in a single call.
+
+### Hook
+
+`rrt-sync` is published as a manual-stage pre-commit hook. Add it to your
+`.pre-commit-config.yaml` to run it on demand before a release:
+
+```yaml
+repos:
+  - repo: https://github.com/Anselmoo/repo-release-tools
+    rev: v1.10.0
+    hooks:
+      - id: rrt-sync
+```
+
+```bash
+pre-commit run rrt-sync --hook-stage manual
+```
+
+```text
+Usage:  rrt sync [OPTIONS]
+
+Fetch all released versions of the configured upstream package and print those that are strictly newer than the current project version.  With --bump, apply each newer version in ascending order, optionally committing and tagging each one.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Arguments
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Options
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  -h, --help             Show this message and exit.
+  --group GROUP          Version group name (default: first/default group).
+  --json                 Emit a JSON array of newer version strings instead of one-per-line output.
+  --dry-run              Preview without side effects.
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Mirror orchestration
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  --bump                 Apply each newer version to version_targets + pin_targets in ascending order.  Without this flag the command lists newer versions only.
+  --commit               After each version's apply, stage changed files and create a git commit.
+  --tag                  After each version's apply (and optional commit), create an annotated git tag.
+  --commit-message TMPL  Override the commit message template.  Use {version} as a placeholder (e.g. 'chore: mirror {version}').  Defaults to group.upstream_commit_message ('Mirror: {version}').
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+Examples
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  $ rrt sync
+  $ rrt sync --json
+  $ rrt sync --group backend
+  $ rrt sync --bump
+  $ rrt sync --bump --commit --tag
+  $ rrt sync --bump --commit --commit-message 'chore: mirror {version}' --dry-run
+```
+
 ## `rrt tag`
 
 Create and validate release tags for the current repository.
@@ -868,132 +994,6 @@ Examples
   $ rrt tag check
   $ rrt tag check --strict
   $ rrt tag check --group backend,sdk --prefix '{group}-v'
-```
-
-## `rrt sync`
-
-### Configuration
-
-`rrt sync` reads upstream version information using the `[tool.rrt.upstream]`
-block in your project config:
-
-```toml
-[tool.rrt.upstream]
-package = "my-package"
-provider = "pypi"
-commit_message = "Mirror: {version}"
-```
-
-`package` is the registry name of the upstream package. `provider` selects the
-registry to query.  `commit_message` is a Python format string; `{version}` is
-replaced with the new version string and used as the git commit message when
-``--commit`` is given.
-
-### Supported providers
-
-| Provider | `provider` value | Notes |
-|---|---|---|
-| PyPI | `pypi` | Python package index; queries `/pypi/<package>/json` |
-| npm | `npm` | Node package registry; queries `/package/<package>` |
-| NuGet | `nuget` | .NET package registry; queries the NuGet API |
-| crates.io | `crates` | Rust crate registry; requires a `User-Agent` header — handled internally |
-| Packagist | `packagist` | PHP package registry; `package` must be in `vendor/name` form |
-
-### Basic usage
-
-```bash
-# List newer versions one per line (default)
-rrt sync
-
-# Emit a JSON array of newer version strings
-rrt sync --json
-
-# Target a specific version group
-rrt sync --group backend
-```
-
-### Mirror-orchestration mode
-
-```bash
-# Apply every newer version to version targets (no git side-effects)
-rrt sync --bump
-
-# Apply + commit each version with the default message "Mirror: <version>"
-rrt sync --bump --commit
-
-# Apply + commit + annotated tag per version
-rrt sync --bump --commit --tag
-
-# Preview the plan without touching anything
-rrt sync --bump --commit --tag --dry-run
-
-# Custom commit message template
-rrt sync --bump --commit --commit-message "chore: mirror {version}"
-```
-
-### CI mirror loop
-
-Use `rrt sync` output to drive a CI bump loop that tracks upstream releases:
-
-```bash
-for v in $(rrt sync); do
-    rrt bump "$v" --no-changelog --force
-done
-```
-
-Or let `rrt sync --bump --commit --tag` handle the full loop in a single call.
-
-### Hook
-
-`rrt-sync` is published as a manual-stage pre-commit hook. Add it to your
-`.pre-commit-config.yaml` to run it on demand before a release:
-
-```yaml
-repos:
-  - repo: https://github.com/Anselmoo/repo-release-tools
-    rev: v1.10.0
-    hooks:
-      - id: rrt-sync
-```
-
-```bash
-pre-commit run rrt-sync --hook-stage manual
-```
-
-```text
-Usage:  rrt sync [OPTIONS]
-
-Fetch all released versions of the configured upstream package and print those that are strictly newer than the current project version.  With --bump, apply each newer version in ascending order, optionally committing and tagging each one.
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Arguments
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Options
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  -h, --help             Show this message and exit.
-  --group GROUP          Version group name (default: first/default group).
-  --json                 Emit a JSON array of newer version strings instead of one-per-line output.
-  --dry-run              Preview without side effects.
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Mirror orchestration
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  --bump                 Apply each newer version to version_targets + pin_targets in ascending order.  Without this flag the command lists newer versions only.
-  --commit               After each version's apply, stage changed files and create a git commit.
-  --tag                  After each version's apply (and optional commit), create an annotated git tag.
-  --commit-message TMPL  Override the commit message template.  Use {version} as a placeholder (e.g. 'chore: mirror {version}').  Defaults to group.upstream_commit_message ('Mirror: {version}').
-
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-Examples
-────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  $ rrt sync
-  $ rrt sync --json
-  $ rrt sync --group backend
-  $ rrt sync --bump
-  $ rrt sync --bump --commit --tag
-  $ rrt sync --bump --commit --commit-message 'chore: mirror {version}' --dry-run
 ```
 
 ## `rrt workspace`

--- a/src/repo_release_tools/cli.py
+++ b/src/repo_release_tools/cli.py
@@ -12,36 +12,7 @@ from collections.abc import Callable, Iterable
 from typing import IO, Any, NoReturn, cast
 
 from repo_release_tools.assets.banner import get_cached_banner
-from repo_release_tools.commands import (
-    agents_cmd,
-    artifacts_cmd,
-    branch,
-    bump,
-    changelog_cmd,
-    ci_version,
-    config_cmd,
-    docs_cmd,
-    doctor,
-    drift_cmd,
-    env_cmd,
-    eol_check,
-    fields_cmd,
-    folder,
-    git_cmd,
-    hooks_cmd,
-    init,
-    install_cmd,
-    mcp_cmd,
-    project_cmd,
-    release_cmd,
-    skill,
-    sync_cmd,
-    tag,
-    toc,
-    tree,
-    workspace,
-)
-from repo_release_tools.commands.action_cmd import register as action_register
+from repo_release_tools.commands._registry import CommandCategory, ensure_registered, registry
 from repo_release_tools.ui import (
     IS_LEGACY_TERMINAL,
     Style,
@@ -111,91 +82,41 @@ def _compute_col_width(actions: list[argparse.Action], width: int | None = None)
     return min(2 + max_left + 2, total_width // 2)
 
 
-COMMAND_GROUPS: dict[str, list[str]] = {
-    "Version & Release": ["bump", "changelog", "ci-version", "release", "sync", "workspace", "tag"],
-    "Repository Health": [
-        "doctor",
-        "artifacts",
-        "fields",
-        "config",
-        "env",
-        "eol",
-        "toc",
-        "tree",
-        "docs",
-        "drift",
-        "folder",
-    ],
-    "CI & Automation": ["action"],
-    "Git Workflow": ["branch", "git"],
-    "Setup & Tooling": ["install", "init", "skill", "agents", "hooks"],
+ensure_registered()
+
+COMMAND_GROUPS: dict[str, list[str]] = registry.groups_by_label()
+
+# `git`'s own subcommands (status, commit, undo-safe, ...) aren't top-level
+# CommandSpecs, so they aren't covered by the registry above. They keep their
+# own small, explicit classification here.
+_NESTED_COMMAND_CATEGORIES: dict[str, CommandCategory] = {
+    "status": CommandCategory.READ,
+    "diff": CommandCategory.READ,
+    "log": CommandCategory.READ,
+    "sync-status": CommandCategory.READ,
+    "check-dirty-tree": CommandCategory.READ,
+    "commit": CommandCategory.WRITE,
+    "commit-all": CommandCategory.WRITE,
+    "move": CommandCategory.WRITE,
+    "squash-local": CommandCategory.WRITE,
+    "undo-safe": CommandCategory.DANGER,
+    "rebootstrap": CommandCategory.DANGER,
 }
 
-READ_COMMANDS = {
-    "status",
-    "diff",
-    "log",
-    "doctor",
-    "release",
-    "sync-status",
-    "check-dirty-tree",
-    "config",
-    "env",
-}
 
-WRITE_COMMANDS = {
-    "action",
-    "agents",
-    "branch",
-    "bump",
-    "ci-version",
-    "drift",
-    "git",
-    "hooks",
-    "init",
-    "install",
-    "skill",
-    "commit",
-    "commit-all",
-    "sync",
-    "move",
-    "squash-local",
-}
+def _nested_names(category: CommandCategory) -> set[str]:
+    """Return nested-subcommand names classified under *category*."""
+    return {name for name, cat in _NESTED_COMMAND_CATEGORIES.items() if cat is category}
 
-DANGER_COMMANDS = {
-    "undo-safe",
-    "rebootstrap",
-}
 
-COMMAND_REGISTRARS = (
-    agents_cmd.register,
-    artifacts_cmd.register,
-    branch.register,
-    bump.register,
-    changelog_cmd.register,
-    ci_version.register,
-    action_register,
-    config_cmd.register,
-    doctor.register,
-    drift_cmd.register,
-    env_cmd.register,
-    eol_check.register,
-    fields_cmd.register,
-    folder.register,
-    git_cmd.register,
-    hooks_cmd.register,
-    init.register,
-    install_cmd.register,
-    mcp_cmd.register,
-    project_cmd.register,
-    release_cmd.register,
-    skill.register,
-    sync_cmd.register,
-    tag.register,
-    toc.register,
-    tree.register,
-    docs_cmd.register,
-    workspace.register,
+READ_COMMANDS = registry.names_in_category(CommandCategory.READ) | _nested_names(
+    CommandCategory.READ
+)
+WRITE_COMMANDS = registry.names_in_category(CommandCategory.WRITE) | _nested_names(
+    CommandCategory.WRITE
+)
+DANGER_COMMANDS = registry.names_in_category(CommandCategory.DANGER) | _nested_names(
+    CommandCategory.DANGER
 )
 
 
@@ -203,8 +124,7 @@ def _register_command_parsers(
     subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
 ) -> None:
     """Register all top-level command modules on the root parser."""
-    for register in COMMAND_REGISTRARS:
-        register(subparsers)
+    registry.register_all(subparsers)
 
 
 _ROOT_EXAMPLES = (

--- a/src/repo_release_tools/commands/_registry.py
+++ b/src/repo_release_tools/commands/_registry.py
@@ -41,9 +41,13 @@ class CommandCategory(StrEnum):
 
 
 class CommandGroup(StrEnum):
-    """The five command groups shown in grouped `--help` output.
+    """The command groups shown in grouped `--help` output, in display order.
 
-    Also used to generate the command-group reference doc pages.
+    The first five are also used to generate the command-group reference doc
+    pages (see ``_DOC_PAGE_GROUPS`` below). ``OTHER`` is a CLI-help-only
+    fallback bucket: a command that reaches this far without an explicit
+    group still shows up somewhere in `--help` instead of silently
+    vanishing — the exact failure mode this module exists to prevent.
     """
 
     VERSION_RELEASE = "version-release"
@@ -51,6 +55,7 @@ class CommandGroup(StrEnum):
     CI_AUTOMATION = "ci-automation"
     GIT_WORKFLOW = "git-workflow"
     SETUP_TOOLING = "setup-tooling"
+    OTHER = "other"
 
 
 COMMAND_GROUP_LABELS: dict[CommandGroup, str] = {
@@ -59,7 +64,18 @@ COMMAND_GROUP_LABELS: dict[CommandGroup, str] = {
     CommandGroup.CI_AUTOMATION: "CI & Automation",
     CommandGroup.GIT_WORKFLOW: "Git Workflow",
     CommandGroup.SETUP_TOOLING: "Setup & Tooling",
+    CommandGroup.OTHER: "Other",
 }
+
+# Groups rendered as their own doc page by docs/publisher.py. OTHER never gets a
+# dedicated page — it's a CLI-help-only fallback, not a real documented group.
+_DOC_PAGE_GROUPS: tuple[CommandGroup, ...] = (
+    CommandGroup.VERSION_RELEASE,
+    CommandGroup.REPO_HEALTH,
+    CommandGroup.CI_AUTOMATION,
+    CommandGroup.GIT_WORKFLOW,
+    CommandGroup.SETUP_TOOLING,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -69,7 +85,7 @@ class CommandSpec:
     name: str
     register: RegisterFn
     category: CommandCategory
-    group: CommandGroup | None = None
+    group: CommandGroup = CommandGroup.OTHER
 
 
 @dataclass(slots=True)
@@ -99,26 +115,38 @@ class CommandRegistry:
         """Return the names of every top-level command in *category*."""
         return {spec.name for spec in self._specs.values() if spec.category is category}
 
-    def groups_by_label(self) -> dict[str, list[str]]:
-        """Return ``{group display name: [command names]}`` for grouped help output."""
-        result: dict[str, list[str]] = {}
-        for spec in self._specs.values():
-            if spec.group is None:
-                continue
-            label = COMMAND_GROUP_LABELS[spec.group]
-            result.setdefault(label, []).append(spec.name)
-        return result
-
-    def groups_config(self) -> tuple[tuple[str, str, tuple[str, ...]], ...]:
-        """Return ``((slug, label, (command names, ...)), ...)`` for doc generation."""
+    def _names_by_group(self) -> dict[CommandGroup, list[str]]:
         by_group: dict[CommandGroup, list[str]] = {}
         for spec in self._specs.values():
-            if spec.group is None:
-                continue
             by_group.setdefault(spec.group, []).append(spec.name)
+        return by_group
+
+    def groups_by_label(self) -> dict[str, list[str]]:
+        """Return ``{group display name: [command names]}`` for grouped help output.
+
+        Ordered by :class:`CommandGroup` declaration order (including ``OTHER``,
+        so a command is never silently omitted), each group's commands sorted
+        by name — independent of import/registration order.
+        """
+        by_group = self._names_by_group()
+        return {
+            COMMAND_GROUP_LABELS[group]: sorted(names)
+            for group in CommandGroup
+            if (names := by_group.get(group))
+        }
+
+    def groups_config(self) -> tuple[tuple[str, str, tuple[str, ...]], ...]:
+        """Return ``((slug, label, (command names, ...)), ...)`` for doc generation.
+
+        Ordered by ``_DOC_PAGE_GROUPS`` (``OTHER`` excluded — it never gets a doc
+        page), each group's commands sorted by name — independent of
+        import/registration order.
+        """
+        by_group = self._names_by_group()
         return tuple(
-            (group.value, COMMAND_GROUP_LABELS[group], tuple(names))
-            for group, names in by_group.items()
+            (group.value, COMMAND_GROUP_LABELS[group], tuple(sorted(names)))
+            for group in _DOC_PAGE_GROUPS
+            if (names := by_group.get(group))
         )
 
 
@@ -129,7 +157,7 @@ def register_command(
     *,
     name: str,
     category: CommandCategory,
-    group: CommandGroup | None = None,
+    group: CommandGroup = CommandGroup.OTHER,
 ) -> Callable[[RegisterFn], RegisterFn]:
     """Decorate a command module's ``register()`` function to self-register it."""
 

--- a/src/repo_release_tools/commands/_registry.py
+++ b/src/repo_release_tools/commands/_registry.py
@@ -1,0 +1,179 @@
+"""Self-registering command declaration for `rrt`'s argparse subcommands.
+
+Before this module existed, every subcommand required hand-syncing three to
+five separate places in ``cli.py`` and ``docs/publisher.py``: an import block,
+a tuple of registrar callables, flat name sets used for help-text coloring,
+and a command-group mapping duplicated (in prose only, not code) between the
+two files. Missing the coloring/grouping sets was silent — commands still
+worked, they just rendered with the wrong style or vanished from grouped
+help, exactly what happened to the ``mcp`` and ``project`` commands.
+
+Each command module now declares itself once, at its own ``register()``
+function, via :func:`register_command`. ``cli.py`` and ``docs/publisher.py``
+both read the resulting :data:`registry` instead of maintaining their own
+copies.
+
+``ensure_registered`` still needs an explicit list of command modules to
+import — a decorator only runs once its module has been imported, and
+nothing else does so on `rrt`'s behalf. That single, `noqa`'d import list is
+the one place left that needs a new line when a command module is added.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import argparse
+    from collections.abc import Callable
+
+    RegisterFn = Callable[[argparse._SubParsersAction[argparse.ArgumentParser]], None]
+
+
+class CommandCategory(StrEnum):
+    """Semantic classification of a top-level command, used for help styling."""
+
+    READ = "read"
+    WRITE = "write"
+    DANGER = "danger"
+
+
+class CommandGroup(StrEnum):
+    """The five command groups shown in grouped `--help` output.
+
+    Also used to generate the command-group reference doc pages.
+    """
+
+    VERSION_RELEASE = "version-release"
+    REPO_HEALTH = "repo-health"
+    CI_AUTOMATION = "ci-automation"
+    GIT_WORKFLOW = "git-workflow"
+    SETUP_TOOLING = "setup-tooling"
+
+
+COMMAND_GROUP_LABELS: dict[CommandGroup, str] = {
+    CommandGroup.VERSION_RELEASE: "Version & Release",
+    CommandGroup.REPO_HEALTH: "Repository Health",
+    CommandGroup.CI_AUTOMATION: "CI & Automation",
+    CommandGroup.GIT_WORKFLOW: "Git Workflow",
+    CommandGroup.SETUP_TOOLING: "Setup & Tooling",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class CommandSpec:
+    """A single top-level command's full declaration."""
+
+    name: str
+    register: RegisterFn
+    category: CommandCategory
+    group: CommandGroup | None = None
+
+
+@dataclass(slots=True)
+class CommandRegistry:
+    """Holds every registered :class:`CommandSpec`, in declaration order."""
+
+    _specs: dict[str, CommandSpec] = field(default_factory=dict)
+
+    def add(self, spec: CommandSpec) -> None:
+        """Register *spec*, raising if its name was already registered."""
+        if spec.name in self._specs:
+            raise ValueError(f"command {spec.name!r} already registered")
+        self._specs[spec.name] = spec
+
+    def register_all(self, subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+        """Call every registered command's ``register()`` against *subparsers*."""
+        for spec in self._specs.values():
+            spec.register(subparsers)
+            if spec.name not in subparsers.choices:
+                raise RuntimeError(
+                    f"CommandSpec name {spec.name!r} does not match the parser name "
+                    "its register() function added — decorator and add_parser() "
+                    "have drifted apart."
+                )
+
+    def names_in_category(self, category: CommandCategory) -> set[str]:
+        """Return the names of every top-level command in *category*."""
+        return {spec.name for spec in self._specs.values() if spec.category is category}
+
+    def groups_by_label(self) -> dict[str, list[str]]:
+        """Return ``{group display name: [command names]}`` for grouped help output."""
+        result: dict[str, list[str]] = {}
+        for spec in self._specs.values():
+            if spec.group is None:
+                continue
+            label = COMMAND_GROUP_LABELS[spec.group]
+            result.setdefault(label, []).append(spec.name)
+        return result
+
+    def groups_config(self) -> tuple[tuple[str, str, tuple[str, ...]], ...]:
+        """Return ``((slug, label, (command names, ...)), ...)`` for doc generation."""
+        by_group: dict[CommandGroup, list[str]] = {}
+        for spec in self._specs.values():
+            if spec.group is None:
+                continue
+            by_group.setdefault(spec.group, []).append(spec.name)
+        return tuple(
+            (group.value, COMMAND_GROUP_LABELS[group], tuple(names))
+            for group, names in by_group.items()
+        )
+
+
+registry = CommandRegistry()
+
+
+def register_command(
+    *,
+    name: str,
+    category: CommandCategory,
+    group: CommandGroup | None = None,
+) -> Callable[[RegisterFn], RegisterFn]:
+    """Decorate a command module's ``register()`` function to self-register it."""
+
+    def decorator(fn: RegisterFn) -> RegisterFn:
+        registry.add(CommandSpec(name=name, register=fn, category=category, group=group))
+        return fn
+
+    return decorator
+
+
+def ensure_registered() -> None:
+    """Import every command module so its ``@register_command`` decorator runs.
+
+    Idempotent: Python caches each import in ``sys.modules``, so calling this
+    more than once (cli.py and docs/publisher.py both need to) re-executes no
+    module body and re-registers nothing.
+    """
+    from repo_release_tools.commands import (  # noqa: F401
+        action_cmd,
+        agents_cmd,
+        artifacts_cmd,
+        branch,
+        bump,
+        changelog_cmd,
+        ci_version,
+        config_cmd,
+        docs_cmd,
+        doctor,
+        drift_cmd,
+        env_cmd,
+        eol_check,
+        fields_cmd,
+        folder,
+        git_cmd,
+        hooks_cmd,
+        init,
+        install_cmd,
+        mcp_cmd,
+        project_cmd,
+        release_cmd,
+        skill,
+        sync_cmd,
+        tag,
+        toc,
+        tree,
+        workspace,
+    )

--- a/src/repo_release_tools/commands/action_cmd.py
+++ b/src/repo_release_tools/commands/action_cmd.py
@@ -58,6 +58,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from repo_release_tools import __version__
+from repo_release_tools.commands._registry import CommandCategory, CommandGroup, register_command
 from repo_release_tools.ui import DryRunPrinter, VerbosePrinter, highlight_terminal
 
 WORKFLOW_PATH = Path(".github/workflows/rrt.yml")
@@ -156,6 +157,7 @@ def cmd_init(args: argparse.Namespace) -> int:
     return 0
 
 
+@register_command(name="action", category=CommandCategory.WRITE, group=CommandGroup.CI_AUTOMATION)
 def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
     """Register the action command group."""
     parser = subparsers.add_parser(

--- a/src/repo_release_tools/commands/agents_cmd.py
+++ b/src/repo_release_tools/commands/agents_cmd.py
@@ -49,6 +49,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 
+from repo_release_tools.commands._registry import CommandCategory, CommandGroup, register_command
 from repo_release_tools.integrations.agent_assets import BUNDLED_AGENTS, BundledAgent
 from repo_release_tools.ui import DryRunPrinter, VerbosePrinter
 
@@ -294,6 +295,7 @@ def cmd_install(args: argparse.Namespace) -> int:
     return 0
 
 
+@register_command(name="agents", category=CommandCategory.WRITE, group=CommandGroup.SETUP_TOOLING)
 def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
     """Register the agents command group."""
     parser = subparsers.add_parser(

--- a/src/repo_release_tools/commands/artifacts_cmd.py
+++ b/src/repo_release_tools/commands/artifacts_cmd.py
@@ -51,6 +51,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from repo_release_tools.commands._registry import CommandCategory, CommandGroup, register_command
 from repo_release_tools.config import (
     RrtConfig,
     find_repo_root,
@@ -362,6 +363,7 @@ def _add_artifacts_strict_argument(parser: argparse.ArgumentParser, *, default: 
         )
 
 
+@register_command(name="artifacts", category=CommandCategory.READ, group=CommandGroup.REPO_HEALTH)
 def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
     """Register the artifacts subcommand."""
     parser = subparsers.add_parser(

--- a/src/repo_release_tools/commands/branch.py
+++ b/src/repo_release_tools/commands/branch.py
@@ -78,6 +78,7 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+from repo_release_tools.commands._registry import CommandCategory, CommandGroup, register_command
 from repo_release_tools.ui import GLYPHS, DryRunPrinter, VerbosePrinter
 from repo_release_tools.workflow import git
 
@@ -591,6 +592,7 @@ def cmd_rescue(args: argparse.Namespace) -> int:
     return 0
 
 
+@register_command(name="branch", category=CommandCategory.WRITE, group=CommandGroup.GIT_WORKFLOW)
 def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
     """Register branch subcommands."""
     branch_parser = subparsers.add_parser(

--- a/src/repo_release_tools/commands/bump.py
+++ b/src/repo_release_tools/commands/bump.py
@@ -83,6 +83,7 @@ from repo_release_tools.commands._common import (
     find_duplicate_group_names,
     parse_group_names,
 )
+from repo_release_tools.commands._registry import CommandCategory, CommandGroup, register_command
 from repo_release_tools.commands._version_render import render_version_write_events
 from repo_release_tools.config import (
     RrtConfig,
@@ -872,6 +873,7 @@ _BUMP_EXAMPLES = (
 )
 
 
+@register_command(name="bump", category=CommandCategory.WRITE, group=CommandGroup.VERSION_RELEASE)
 def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
     """Register the bump command."""
     parser = subparsers.add_parser(

--- a/src/repo_release_tools/commands/changelog_cmd.py
+++ b/src/repo_release_tools/commands/changelog_cmd.py
@@ -52,10 +52,14 @@ from __future__ import annotations
 
 import argparse
 
+from repo_release_tools.commands._registry import CommandCategory, CommandGroup, register_command
 from repo_release_tools.commands.changelog_compare import register_subcommand as _register_compare
 from repo_release_tools.commands.changelog_lint import register_subcommand as _register_lint
 
 
+@register_command(
+    name="changelog", category=CommandCategory.READ, group=CommandGroup.VERSION_RELEASE
+)
 def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
     """Register the ``changelog`` command group."""
     parser = subparsers.add_parser(

--- a/src/repo_release_tools/commands/ci_version.py
+++ b/src/repo_release_tools/commands/ci_version.py
@@ -56,6 +56,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from repo_release_tools.commands._common import describe_config_load_error
+from repo_release_tools.commands._registry import CommandCategory, CommandGroup, register_command
 from repo_release_tools.commands._version_render import render_version_write_events
 from repo_release_tools.config import (
     VALID_CI_FORMATS,
@@ -502,6 +503,9 @@ def _add_compute_args(parser: argparse.ArgumentParser) -> None:
     )
 
 
+@register_command(
+    name="ci-version", category=CommandCategory.WRITE, group=CommandGroup.VERSION_RELEASE
+)
 def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
     """Register the ``ci-version`` command and its subcommands."""
     parser = subparsers.add_parser(

--- a/src/repo_release_tools/commands/config_cmd.py
+++ b/src/repo_release_tools/commands/config_cmd.py
@@ -90,6 +90,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from repo_release_tools import config as cfg
+from repo_release_tools.commands._registry import CommandCategory, CommandGroup, register_command
 from repo_release_tools.config.reference import render_reference_toml
 from repo_release_tools.ui import (
     GLYPHS,
@@ -390,6 +391,7 @@ def cmd_config(args: argparse.Namespace) -> int:
     return 0
 
 
+@register_command(name="config", category=CommandCategory.READ, group=CommandGroup.REPO_HEALTH)
 def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
     """Register the config command."""
     parser = subparsers.add_parser(

--- a/src/repo_release_tools/commands/docs_cmd.py
+++ b/src/repo_release_tools/commands/docs_cmd.py
@@ -87,6 +87,7 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+from repo_release_tools.commands._registry import CommandCategory, CommandGroup, register_command
 from repo_release_tools.commands.docs_suggest import cmd_docs_suggest
 from repo_release_tools.config import (
     DocsConfig,
@@ -1319,6 +1320,7 @@ def _add_docs_map_arguments(parser: argparse.ArgumentParser) -> None:
     )
 
 
+@register_command(name="docs", category=CommandCategory.READ, group=CommandGroup.REPO_HEALTH)
 def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
     """Register the docs command."""
     parser = subparsers.add_parser(

--- a/src/repo_release_tools/commands/doctor.py
+++ b/src/repo_release_tools/commands/doctor.py
@@ -82,6 +82,7 @@ from repo_release_tools.changelog import (
     has_unreleased_section,
 )
 from repo_release_tools.commands._common import describe_config_load_error
+from repo_release_tools.commands._registry import CommandCategory, CommandGroup, register_command
 from repo_release_tools.config import (
     RrtConfig,
     find_repo_root,
@@ -459,6 +460,7 @@ def cmd_doctor(args: argparse.Namespace) -> int:
     return 0 if all_ok else 1
 
 
+@register_command(name="doctor", category=CommandCategory.READ, group=CommandGroup.REPO_HEALTH)
 def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
     """Register the doctor command."""
     parser = subparsers.add_parser(

--- a/src/repo_release_tools/commands/drift_cmd.py
+++ b/src/repo_release_tools/commands/drift_cmd.py
@@ -63,6 +63,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from repo_release_tools.commands._registry import CommandCategory, CommandGroup, register_command
 from repo_release_tools.state import (
     DRIFT_LOCK_NAME,
     build_lock,
@@ -179,6 +180,7 @@ def cmd_check(args: argparse.Namespace) -> int:
     return 1
 
 
+@register_command(name="drift", category=CommandCategory.WRITE, group=CommandGroup.REPO_HEALTH)
 def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
     """Register the drift command group."""
     parser = subparsers.add_parser(

--- a/src/repo_release_tools/commands/env_cmd.py
+++ b/src/repo_release_tools/commands/env_cmd.py
@@ -50,6 +50,7 @@ import os
 import sys
 from dataclasses import dataclass
 
+from repo_release_tools.commands._registry import CommandCategory, CommandGroup, register_command
 from repo_release_tools.ui import VerbosePrinter
 
 ENV_EPILOG = "  $ rrt env\n  $ rrt env --json"
@@ -179,6 +180,7 @@ def cmd_env_check(args: argparse.Namespace) -> int:
     return 1
 
 
+@register_command(name="env", category=CommandCategory.READ, group=CommandGroup.REPO_HEALTH)
 def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
     """Register the env command."""
     parser = subparsers.add_parser(

--- a/src/repo_release_tools/commands/eol_check.py
+++ b/src/repo_release_tools/commands/eol_check.py
@@ -76,6 +76,7 @@ from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
 
+from repo_release_tools.commands._registry import CommandCategory, CommandGroup, register_command
 from repo_release_tools.config import (
     EolConfig,
     EolOverride,
@@ -434,6 +435,7 @@ def cmd_eol(args: argparse.Namespace) -> int:
     return 1
 
 
+@register_command(name="eol", category=CommandCategory.READ, group=CommandGroup.REPO_HEALTH)
 def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
     """Register the eol command."""
     parser = subparsers.add_parser(

--- a/src/repo_release_tools/commands/fields_cmd.py
+++ b/src/repo_release_tools/commands/fields_cmd.py
@@ -98,6 +98,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from repo_release_tools.commands._registry import CommandCategory, CommandGroup, register_command
 from repo_release_tools.config import (
     RrtConfig,
     find_repo_root,
@@ -590,6 +591,7 @@ def _add_fields_strict_argument(parser: argparse.ArgumentParser, *, default: boo
         )
 
 
+@register_command(name="fields", category=CommandCategory.READ, group=CommandGroup.REPO_HEALTH)
 def register(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
     """Register the fields subcommand."""
     parser = subparsers.add_parser(

--- a/src/repo_release_tools/commands/folder.py
+++ b/src/repo_release_tools/commands/folder.py
@@ -31,6 +31,7 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+from repo_release_tools.commands._registry import CommandCategory, CommandGroup, register_command
 from repo_release_tools.config import (
     RrtConfig,
     is_missing_tool_rrt_error,
@@ -327,6 +328,7 @@ def _add_folder_check_arguments(parser: argparse.ArgumentParser) -> None:
     )
 
 
+@register_command(name="folder", category=CommandCategory.READ, group=CommandGroup.REPO_HEALTH)
 def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
     """Register the folder command family."""
     parser = subparsers.add_parser(

--- a/src/repo_release_tools/commands/git_cmd.py
+++ b/src/repo_release_tools/commands/git_cmd.py
@@ -90,6 +90,7 @@ from __future__ import annotations
 
 import argparse
 
+from repo_release_tools.commands._registry import CommandCategory, CommandGroup, register_command
 from repo_release_tools.commands.git_backport import register_backport
 from repo_release_tools.commands.git_commit import register_commit
 from repo_release_tools.commands.git_inspect import register_inspect
@@ -106,6 +107,7 @@ GIT_EPILOG = (
 )
 
 
+@register_command(name="git", category=CommandCategory.WRITE, group=CommandGroup.GIT_WORKFLOW)
 def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
     """Register the git command group."""
     parser = subparsers.add_parser(

--- a/src/repo_release_tools/commands/hooks_cmd.py
+++ b/src/repo_release_tools/commands/hooks_cmd.py
@@ -54,6 +54,7 @@ from pathlib import Path
 from sysconfig import get_path
 from typing import Any, cast
 
+from repo_release_tools.commands._registry import CommandCategory, CommandGroup, register_command
 from repo_release_tools.ui import DryRunPrinter, VerbosePrinter
 
 HOOK_TARGET_PATHS = {
@@ -629,6 +630,7 @@ def cmd_install(args: argparse.Namespace) -> int:
     return 0
 
 
+@register_command(name="hooks", category=CommandCategory.WRITE, group=CommandGroup.SETUP_TOOLING)
 def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
     """Register the hooks command group."""
     parser = subparsers.add_parser(

--- a/src/repo_release_tools/commands/init.py
+++ b/src/repo_release_tools/commands/init.py
@@ -70,6 +70,7 @@ import tomllib
 from dataclasses import dataclass
 from pathlib import Path
 
+from repo_release_tools.commands._registry import CommandCategory, CommandGroup, register_command
 from repo_release_tools.config import (
     DEFAULT_INIT_CONFIG,
     find_explicit_config_file,
@@ -357,6 +358,7 @@ def _has_rrt_section(manifest: str, text: str) -> bool:
     return isinstance(tool_rrt, dict)
 
 
+@register_command(name="init", category=CommandCategory.WRITE, group=CommandGroup.SETUP_TOOLING)
 def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
     """Register the init command."""
     parser = subparsers.add_parser(

--- a/src/repo_release_tools/commands/install_cmd.py
+++ b/src/repo_release_tools/commands/install_cmd.py
@@ -67,6 +67,7 @@ from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
 
 from repo_release_tools.commands import agents_cmd, hooks_cmd, skill
+from repo_release_tools.commands._registry import CommandCategory, CommandGroup, register_command
 from repo_release_tools.ui import DryRunPrinter, VerbosePrinter
 
 INSTALL_EXAMPLES = (
@@ -202,6 +203,7 @@ def cmd_install(args: argparse.Namespace) -> int:
     return 0
 
 
+@register_command(name="install", category=CommandCategory.WRITE, group=CommandGroup.SETUP_TOOLING)
 def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
     """Register the unified install command."""
     parser = subparsers.add_parser(

--- a/src/repo_release_tools/commands/mcp_cmd.py
+++ b/src/repo_release_tools/commands/mcp_cmd.py
@@ -26,6 +26,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
+from repo_release_tools.commands._registry import CommandCategory, register_command
 from repo_release_tools.ui import DryRunPrinter
 
 _NAME_RE = re.compile(r"^[a-z][a-z0-9_]*$")
@@ -179,6 +180,7 @@ def _studly_case(name: str) -> str:
     return "".join(part.capitalize() for part in name.split("_"))
 
 
+@register_command(name="mcp", category=CommandCategory.READ)
 def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
     """Register the `mcp` command group on the root parser."""
     parser = subparsers.add_parser(

--- a/src/repo_release_tools/commands/mcp_cmd.py
+++ b/src/repo_release_tools/commands/mcp_cmd.py
@@ -26,7 +26,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
-from repo_release_tools.commands._registry import CommandCategory, register_command
+from repo_release_tools.commands._registry import CommandCategory, CommandGroup, register_command
 from repo_release_tools.ui import DryRunPrinter
 
 _NAME_RE = re.compile(r"^[a-z][a-z0-9_]*$")
@@ -180,7 +180,7 @@ def _studly_case(name: str) -> str:
     return "".join(part.capitalize() for part in name.split("_"))
 
 
-@register_command(name="mcp", category=CommandCategory.READ)
+@register_command(name="mcp", category=CommandCategory.READ, group=CommandGroup.SETUP_TOOLING)
 def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
     """Register the `mcp` command group on the root parser."""
     parser = subparsers.add_parser(

--- a/src/repo_release_tools/commands/project_cmd.py
+++ b/src/repo_release_tools/commands/project_cmd.py
@@ -23,6 +23,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
+from repo_release_tools.commands._registry import CommandCategory, register_command
 from repo_release_tools.config.project_meta import (
     ProjectMetadata,
     load_project_metadata,
@@ -147,6 +148,7 @@ def _render_text(metadata: ProjectMetadata) -> str:
     return "\n".join(lines) + ("\n" if lines else "")
 
 
+@register_command(name="project", category=CommandCategory.READ)
 def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
     """Register the `project` command group on the root parser."""
     parser = subparsers.add_parser(

--- a/src/repo_release_tools/commands/project_cmd.py
+++ b/src/repo_release_tools/commands/project_cmd.py
@@ -23,7 +23,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
-from repo_release_tools.commands._registry import CommandCategory, register_command
+from repo_release_tools.commands._registry import CommandCategory, CommandGroup, register_command
 from repo_release_tools.config.project_meta import (
     ProjectMetadata,
     load_project_metadata,
@@ -148,7 +148,7 @@ def _render_text(metadata: ProjectMetadata) -> str:
     return "\n".join(lines) + ("\n" if lines else "")
 
 
-@register_command(name="project", category=CommandCategory.READ)
+@register_command(name="project", category=CommandCategory.READ, group=CommandGroup.REPO_HEALTH)
 def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
     """Register the `project` command group on the root parser."""
     parser = subparsers.add_parser(

--- a/src/repo_release_tools/commands/release_cmd.py
+++ b/src/repo_release_tools/commands/release_cmd.py
@@ -72,6 +72,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from repo_release_tools.commands._common import describe_config_load_error
+from repo_release_tools.commands._registry import CommandCategory, CommandGroup, register_command
 from repo_release_tools.commands.release_notes import register_subcommand as _register_notes
 from repo_release_tools.commands.release_repair import register_subcommand as _register_repair
 from repo_release_tools.config import (
@@ -368,6 +369,7 @@ def cmd_release_check(args: argparse.Namespace) -> int:
     return 1
 
 
+@register_command(name="release", category=CommandCategory.READ, group=CommandGroup.VERSION_RELEASE)
 def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
     """Register release-oriented commands."""
     parser = subparsers.add_parser(

--- a/src/repo_release_tools/commands/skill.py
+++ b/src/repo_release_tools/commands/skill.py
@@ -64,6 +64,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 
+from repo_release_tools.commands._registry import CommandCategory, CommandGroup, register_command
 from repo_release_tools.integrations.skill_assets import BUNDLED_SKILLS
 from repo_release_tools.ui import DryRunPrinter, VerbosePrinter
 
@@ -249,6 +250,7 @@ def cmd_install(args: argparse.Namespace) -> int:
     return 0
 
 
+@register_command(name="skill", category=CommandCategory.WRITE, group=CommandGroup.SETUP_TOOLING)
 def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
     """Register the skill command group."""
     parser = subparsers.add_parser(

--- a/src/repo_release_tools/commands/sync_cmd.py
+++ b/src/repo_release_tools/commands/sync_cmd.py
@@ -18,6 +18,7 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+from repo_release_tools.commands._registry import CommandCategory, CommandGroup, register_command
 from repo_release_tools.commands.bump import apply_version
 from repo_release_tools.commands.tag import cmd_tag_create
 from repo_release_tools.config import load_or_autodetect_config
@@ -302,6 +303,7 @@ _SYNC_EXAMPLES = (
 )
 
 
+@register_command(name="sync", category=CommandCategory.WRITE, group=CommandGroup.VERSION_RELEASE)
 def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
     """Register the ``rrt sync`` command."""
     parser = subparsers.add_parser(

--- a/src/repo_release_tools/commands/tag.py
+++ b/src/repo_release_tools/commands/tag.py
@@ -71,6 +71,7 @@ from repo_release_tools.commands._common import (
     find_duplicate_group_names,
     parse_group_names,
 )
+from repo_release_tools.commands._registry import CommandCategory, CommandGroup, register_command
 from repo_release_tools.config import (
     VersionGroup,
     find_repo_root,
@@ -523,6 +524,7 @@ _TAG_EPILOG = (
 )
 
 
+@register_command(name="tag", category=CommandCategory.READ, group=CommandGroup.VERSION_RELEASE)
 def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
     """Register the tag command."""
     parser = subparsers.add_parser(

--- a/src/repo_release_tools/commands/toc.py
+++ b/src/repo_release_tools/commands/toc.py
@@ -47,6 +47,7 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+from repo_release_tools.commands._registry import CommandCategory, CommandGroup, register_command
 from repo_release_tools.tools.inject import (
     ANCHOR_END_TOKEN,
     ANCHOR_START_TOKEN,
@@ -166,6 +167,7 @@ def cmd_toc(args: argparse.Namespace) -> int:
     return 0
 
 
+@register_command(name="toc", category=CommandCategory.READ, group=CommandGroup.REPO_HEALTH)
 def register(sub: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
     """Register the ``toc`` subcommand on *sub*."""
     parser: argparse.ArgumentParser = sub.add_parser(

--- a/src/repo_release_tools/commands/tree.py
+++ b/src/repo_release_tools/commands/tree.py
@@ -118,6 +118,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, TypeAlias
 
+from repo_release_tools.commands._registry import CommandCategory, CommandGroup, register_command
 from repo_release_tools.state import (
     build_tree_lock,
     hash_content,
@@ -1180,6 +1181,7 @@ def cmd_tree(args: argparse.Namespace) -> int:
     return 0
 
 
+@register_command(name="tree", category=CommandCategory.READ, group=CommandGroup.REPO_HEALTH)
 def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
     """Register the tree command."""
     parser = subparsers.add_parser(

--- a/src/repo_release_tools/commands/workspace.py
+++ b/src/repo_release_tools/commands/workspace.py
@@ -50,6 +50,7 @@ from repo_release_tools.changelog import (
     promote_unreleased,
 )
 from repo_release_tools.commands._common import describe_config_load_error
+from repo_release_tools.commands._registry import CommandCategory, CommandGroup, register_command
 from repo_release_tools.commands._version_render import render_version_write_events
 from repo_release_tools.config import (
     RrtConfig,
@@ -253,6 +254,9 @@ _WORKSPACE_EPILOG = (
 )
 
 
+@register_command(
+    name="workspace", category=CommandCategory.READ, group=CommandGroup.VERSION_RELEASE
+)
 def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
     """Register the workspace command."""
     parser = subparsers.add_parser(

--- a/src/repo_release_tools/docs/publisher.py
+++ b/src/repo_release_tools/docs/publisher.py
@@ -224,6 +224,8 @@ def _get_command_doc_modules() -> dict[str, object]:
         git_cmd,
         hooks_cmd,
         init,
+        mcp_cmd,
+        project_cmd,
         tag,
         workspace,
     )
@@ -248,6 +250,8 @@ def _get_command_doc_modules() -> dict[str, object]:
         "hooks": hooks_cmd,
         "init": init,
         "install": install_module,
+        "mcp": mcp_cmd,
+        "project": project_cmd,
         "release": release_cmd_module,
         "skill": skill_module,
         "tag": tag,

--- a/src/repo_release_tools/docs/publisher.py
+++ b/src/repo_release_tools/docs/publisher.py
@@ -13,6 +13,14 @@ package CLI surface.
 avoid a circular-import cycle:
   ``cli`` → ``docs_cmd`` → ``docs_publisher`` → ``cli``
 All other package imports are at module level.
+
+``COMMAND_GROUPS_CONFIG`` below is computed eagerly at module-import time from
+:data:`repo_release_tools.commands._registry.registry`, after calling
+``ensure_registered()`` to guarantee every command module has registered
+first. That's only safe because nothing under ``repo_release_tools.commands``
+imports ``docs_publisher`` at *its own* module level (``docs_cmd`` does it
+lazily too, inside a function body) — so this module is never itself
+imported mid-way through ``ensure_registered()``'s sweep. Keep it that way.
 """
 
 from __future__ import annotations
@@ -39,6 +47,7 @@ from repo_release_tools.commands import skill as skill_module
 from repo_release_tools.commands import sync_cmd as sync_cmd_module
 from repo_release_tools.commands import toc as toc_module
 from repo_release_tools.commands import tree as tree_module
+from repo_release_tools.commands._registry import ensure_registered, registry
 from repo_release_tools.config import is_missing_tool_rrt_error
 from repo_release_tools.docs.formats.markdown import heading_level, normalize_markdown_headings
 from repo_release_tools.integrations import action as action_module
@@ -105,34 +114,12 @@ _STARLIGHT_BASE: str = "https://anselmoo.github.io/repo-release-tools"
 # ---------------------------------------------------------------------------
 
 # Maps a URL-safe slug to (group display name, tuple of CLI command names).
-# Command names must match the argparse names used in cli.COMMAND_GROUPS.
-COMMAND_GROUPS_CONFIG: tuple[tuple[str, str, tuple[str, ...]], ...] = (
-    (
-        "version-release",
-        "Version & Release",
-        ("bump", "changelog", "ci-version", "release", "sync", "workspace", "tag"),
-    ),
-    (
-        "repo-health",
-        "Repository Health",
-        (
-            "doctor",
-            "artifacts",
-            "fields",
-            "config",
-            "env",
-            "eol",
-            "toc",
-            "tree",
-            "docs",
-            "drift",
-            "folder",
-        ),
-    ),
-    ("git-workflow", "Git Workflow", ("branch", "git")),
-    ("ci-automation", "CI & Automation", ("action",)),
-    ("setup-tooling", "Setup & Tooling", ("install", "init", "skill", "agents", "hooks")),
-)
+# Sourced from commands/_registry.py's CommandRegistry — every command module
+# declares its own name/category/group once, at its own register() function,
+# via @register_command. ensure_registered() guarantees every module has done
+# so before groups_config() reads the result (see "Import discipline" above).
+ensure_registered()
+COMMAND_GROUPS_CONFIG: tuple[tuple[str, str, tuple[str, ...]], ...] = registry.groups_config()
 
 
 # ---------------------------------------------------------------------------
@@ -221,36 +208,52 @@ def _render_topic_doc(slug: str) -> str:
 
 
 def _get_command_doc_modules() -> dict[str, object]:
-    """Return the per-command module registry (lazily importing cli)."""
-    from repo_release_tools import cli  # noqa: PLC0415  (lazy – avoid circular)
-    from repo_release_tools.commands import action_cmd  # noqa: PLC0415
+    """Return the per-command module registry."""
+    from repo_release_tools.commands import (  # noqa: PLC0415
+        action_cmd,
+        agents_cmd,
+        artifacts_cmd,
+        changelog_cmd,
+        ci_version,
+        config_cmd,
+        docs_cmd,
+        drift_cmd,
+        env_cmd,
+        fields_cmd,
+        folder,
+        git_cmd,
+        hooks_cmd,
+        init,
+        tag,
+        workspace,
+    )
 
     return {
         "action": action_cmd,
-        "agents": cli.agents_cmd,
-        "artifacts": cli.artifacts_cmd,
-        "branch": cli.branch,
-        "bump": cli.bump,
-        "changelog": cli.changelog_cmd,
-        "ci-version": cli.ci_version,
-        "config": cli.config_cmd,
-        "docs": cli.docs_cmd,
-        "doctor": cli.doctor,
-        "drift": cli.drift_cmd,
-        "env": cli.env_cmd,
-        "eol": cli.eol_check,
-        "fields": cli.fields_cmd,
-        "folder": cli.folder,
-        "git": cli.git_cmd,
-        "hooks": cli.hooks_cmd,
-        "init": cli.init,
-        "install": cli.install_cmd,
-        "release": cli.release_cmd,
-        "skill": cli.skill,
-        "tag": cli.tag,
+        "agents": agents_cmd,
+        "artifacts": artifacts_cmd,
+        "branch": branch_module,
+        "bump": bump_module,
+        "changelog": changelog_cmd,
+        "ci-version": ci_version,
+        "config": config_cmd,
+        "docs": docs_cmd,
+        "doctor": doctor_module,
+        "drift": drift_cmd,
+        "env": env_cmd,
+        "eol": eol_check_module,
+        "fields": fields_cmd,
+        "folder": folder,
+        "git": git_cmd,
+        "hooks": hooks_cmd,
+        "init": init,
+        "install": install_module,
+        "release": release_cmd_module,
+        "skill": skill_module,
+        "tag": tag,
         "toc": toc_module,
-        "tree": cli.tree,
-        "workspace": cli.workspace,
+        "tree": tree_module,
+        "workspace": workspace,
     }
 
 

--- a/tests/core/test_command_registry.py
+++ b/tests/core/test_command_registry.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from collections.abc import Callable
+
+import pytest
+
+from repo_release_tools.commands import _registry
+from repo_release_tools.commands._registry import (
+    CommandCategory,
+    CommandGroup,
+    CommandRegistry,
+    CommandSpec,
+    register_command,
+)
+
+
+def _noop_register(name: str) -> Callable[[argparse._SubParsersAction], None]:
+    def register(subparsers: argparse._SubParsersAction) -> None:
+        subparsers.add_parser(name)
+
+    return register
+
+
+def test_add_duplicate_name_raises_value_error() -> None:
+    registry = CommandRegistry()
+    registry.add(
+        CommandSpec(name="foo", register=_noop_register("foo"), category=CommandCategory.READ)
+    )
+
+    with pytest.raises(ValueError, match="foo"):
+        registry.add(
+            CommandSpec(name="foo", register=_noop_register("foo"), category=CommandCategory.WRITE)
+        )
+
+
+def test_register_all_happy_path() -> None:
+    registry = CommandRegistry()
+    registry.add(
+        CommandSpec(name="foo", register=_noop_register("foo"), category=CommandCategory.READ)
+    )
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers()
+
+    registry.register_all(subparsers)
+
+    assert "foo" in subparsers.choices
+
+
+def test_register_all_raises_on_name_mismatch() -> None:
+    """A register() function that adds a differently-named parser than its
+    CommandSpec.name is a drift bug the registry must catch immediately."""
+    registry = CommandRegistry()
+    registry.add(
+        CommandSpec(name="foo", register=_noop_register("not-foo"), category=CommandCategory.READ)
+    )
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers()
+
+    with pytest.raises(RuntimeError, match="foo"):
+        registry.register_all(subparsers)
+
+
+def test_names_in_category() -> None:
+    registry = CommandRegistry()
+    registry.add(CommandSpec(name="r", register=_noop_register("r"), category=CommandCategory.READ))
+    registry.add(
+        CommandSpec(name="w", register=_noop_register("w"), category=CommandCategory.WRITE)
+    )
+    registry.add(
+        CommandSpec(name="d", register=_noop_register("d"), category=CommandCategory.DANGER)
+    )
+
+    assert registry.names_in_category(CommandCategory.READ) == {"r"}
+    assert registry.names_in_category(CommandCategory.WRITE) == {"w"}
+    assert registry.names_in_category(CommandCategory.DANGER) == {"d"}
+
+
+def test_groups_by_label_skips_ungrouped_commands() -> None:
+    registry = CommandRegistry()
+    registry.add(
+        CommandSpec(
+            name="bump",
+            register=_noop_register("bump"),
+            category=CommandCategory.WRITE,
+            group=CommandGroup.VERSION_RELEASE,
+        )
+    )
+    registry.add(
+        CommandSpec(name="mcp", register=_noop_register("mcp"), category=CommandCategory.READ)
+    )
+
+    groups = registry.groups_by_label()
+
+    assert groups == {"Version & Release": ["bump"]}
+
+
+def test_groups_config_matches_group_labels() -> None:
+    registry = CommandRegistry()
+    registry.add(
+        CommandSpec(
+            name="branch",
+            register=_noop_register("branch"),
+            category=CommandCategory.WRITE,
+            group=CommandGroup.GIT_WORKFLOW,
+        )
+    )
+    registry.add(
+        CommandSpec(
+            name="git",
+            register=_noop_register("git"),
+            category=CommandCategory.WRITE,
+            group=CommandGroup.GIT_WORKFLOW,
+        )
+    )
+
+    assert registry.groups_config() == (("git-workflow", "Git Workflow", ("branch", "git")),)
+
+
+def test_register_command_decorator_populates_registry(monkeypatch: pytest.MonkeyPatch) -> None:
+    fresh = CommandRegistry()
+    monkeypatch.setattr(_registry, "registry", fresh)
+
+    @register_command(
+        name="widget", category=CommandCategory.WRITE, group=CommandGroup.SETUP_TOOLING
+    )
+    def register(subparsers: argparse._SubParsersAction) -> None:
+        subparsers.add_parser("widget")
+
+    assert register.__name__ == "register"
+    assert fresh.names_in_category(CommandCategory.WRITE) == {"widget"}
+    assert fresh.groups_by_label() == {"Setup & Tooling": ["widget"]}
+
+
+def test_register_command_rejects_duplicate_on_real_registry() -> None:
+    """The real, fully-populated registry already has 'bump'; decorating a second
+    register() with the same name must fail loudly at decoration time."""
+    with pytest.raises(ValueError, match="bump"):
+
+        @register_command(name="bump", category=CommandCategory.WRITE)
+        def register(subparsers: argparse._SubParsersAction) -> None:
+            subparsers.add_parser("bump")
+
+
+def test_ensure_registered_is_idempotent() -> None:
+    _registry.ensure_registered()
+    before = dict(_registry.registry._specs)
+    _registry.ensure_registered()
+    after = dict(_registry.registry._specs)
+
+    assert before is not after
+    assert before.keys() == after.keys()
+
+
+def test_real_registry_has_all_28_top_level_commands() -> None:
+    _registry.ensure_registered()
+    names = set(_registry.registry._specs)
+
+    assert len(names) == 28
+    assert {"mcp", "project"} <= names  # ungrouped commands stay registered
+
+
+def test_docs_publisher_import_without_cli_first_populates_all_groups() -> None:
+    """docs.publisher must fully populate COMMAND_GROUPS_CONFIG even when it is
+    the first repo_release_tools module imported in the process (i.e. before
+    cli.py has ever run ensure_registered() itself) — a regression guard for
+    the partial-registry bug class documented in docs/publisher.py's "Import
+    discipline" docstring section."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from repo_release_tools.docs import publisher\n"
+            "names = {n for _, _, cmds in publisher.COMMAND_GROUPS_CONFIG for n in cmds}\n"
+            "assert len(names) == 26, sorted(names)\n",
+        ],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/tests/core/test_command_registry.py
+++ b/tests/core/test_command_registry.py
@@ -78,7 +78,9 @@ def test_names_in_category() -> None:
     assert registry.names_in_category(CommandCategory.DANGER) == {"d"}
 
 
-def test_groups_by_label_skips_ungrouped_commands() -> None:
+def test_groups_by_label_falls_back_to_other_for_unassigned_group() -> None:
+    """A CommandSpec with no explicit group must still show up somewhere in
+    grouped help output — under "Other" — rather than vanishing silently."""
     registry = CommandRegistry()
     registry.add(
         CommandSpec(
@@ -94,19 +96,46 @@ def test_groups_by_label_skips_ungrouped_commands() -> None:
 
     groups = registry.groups_by_label()
 
-    assert groups == {"Version & Release": ["bump"]}
+    assert groups == {"Version & Release": ["bump"], "Other": ["mcp"]}
+
+
+def test_groups_by_label_orders_groups_by_declaration_and_names_alphabetically() -> None:
+    """Group and within-group order must come from CommandGroup's declaration order
+    and name sorting — not from registration/import order."""
+    registry = CommandRegistry()
+    registry.add(
+        CommandSpec(
+            name="skill",
+            register=_noop_register("skill"),
+            category=CommandCategory.WRITE,
+            group=CommandGroup.SETUP_TOOLING,
+        )
+    )
+    registry.add(
+        CommandSpec(
+            name="workspace",
+            register=_noop_register("workspace"),
+            category=CommandCategory.READ,
+            group=CommandGroup.VERSION_RELEASE,
+        )
+    )
+    registry.add(
+        CommandSpec(
+            name="bump",
+            register=_noop_register("bump"),
+            category=CommandCategory.WRITE,
+            group=CommandGroup.VERSION_RELEASE,
+        )
+    )
+
+    assert list(registry.groups_by_label().items()) == [
+        ("Version & Release", ["bump", "workspace"]),
+        ("Setup & Tooling", ["skill"]),
+    ]
 
 
 def test_groups_config_matches_group_labels() -> None:
     registry = CommandRegistry()
-    registry.add(
-        CommandSpec(
-            name="branch",
-            register=_noop_register("branch"),
-            category=CommandCategory.WRITE,
-            group=CommandGroup.GIT_WORKFLOW,
-        )
-    )
     registry.add(
         CommandSpec(
             name="git",
@@ -115,8 +144,26 @@ def test_groups_config_matches_group_labels() -> None:
             group=CommandGroup.GIT_WORKFLOW,
         )
     )
+    registry.add(
+        CommandSpec(
+            name="branch",
+            register=_noop_register("branch"),
+            category=CommandCategory.WRITE,
+            group=CommandGroup.GIT_WORKFLOW,
+        )
+    )
 
     assert registry.groups_config() == (("git-workflow", "Git Workflow", ("branch", "git")),)
+
+
+def test_groups_config_excludes_other() -> None:
+    """OTHER is a CLI-help-only fallback; it must never produce a doc page."""
+    registry = CommandRegistry()
+    registry.add(
+        CommandSpec(name="mcp", register=_noop_register("mcp"), category=CommandCategory.READ)
+    )
+
+    assert registry.groups_config() == ()
 
 
 def test_register_command_decorator_populates_registry(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -136,7 +183,14 @@ def test_register_command_decorator_populates_registry(monkeypatch: pytest.Monke
 
 def test_register_command_rejects_duplicate_on_real_registry() -> None:
     """The real, fully-populated registry already has 'bump'; decorating a second
-    register() with the same name must fail loudly at decoration time."""
+    register() with the same name must fail loudly at decoration time.
+
+    Explicitly calls ensure_registered() first rather than relying on it having
+    already run as a side effect of some other test/conftest import — otherwise
+    this test only passes by incidental import ordering.
+    """
+    _registry.ensure_registered()
+
     with pytest.raises(ValueError, match="bump"):
 
         @register_command(name="bump", category=CommandCategory.WRITE)
@@ -145,13 +199,19 @@ def test_register_command_rejects_duplicate_on_real_registry() -> None:
 
 
 def test_ensure_registered_is_idempotent() -> None:
+    """A second call must reuse the same registry and CommandSpec objects, not
+    re-run any module's decorator (which would raise ValueError on the resulting
+    duplicate registration)."""
     _registry.ensure_registered()
-    before = dict(_registry.registry._specs)
-    _registry.ensure_registered()
-    after = dict(_registry.registry._specs)
+    registry_before = _registry.registry
+    specs_before = dict(_registry.registry._specs)
 
-    assert before is not after
-    assert before.keys() == after.keys()
+    _registry.ensure_registered()
+
+    assert _registry.registry is registry_before
+    assert _registry.registry._specs.keys() == specs_before.keys()
+    for name, spec in specs_before.items():
+        assert _registry.registry._specs[name] is spec
 
 
 def test_real_registry_has_all_28_top_level_commands() -> None:
@@ -159,7 +219,19 @@ def test_real_registry_has_all_28_top_level_commands() -> None:
     names = set(_registry.registry._specs)
 
     assert len(names) == 28
-    assert {"mcp", "project"} <= names  # ungrouped commands stay registered
+    assert {"mcp", "project"} <= names
+
+
+def test_every_registered_command_is_visible_in_groups_by_label() -> None:
+    """Regression guard: a command must always show up somewhere in grouped
+    `--help` output, even if a future command forgets to declare a group."""
+    _registry.ensure_registered()
+    all_names = set(_registry.registry._specs)
+    visible_names = {
+        name for names in _registry.registry.groups_by_label().values() for name in names
+    }
+
+    assert all_names <= visible_names
 
 
 def test_docs_publisher_import_without_cli_first_populates_all_groups() -> None:
@@ -174,7 +246,7 @@ def test_docs_publisher_import_without_cli_first_populates_all_groups() -> None:
             "-c",
             "from repo_release_tools.docs import publisher\n"
             "names = {n for _, _, cmds in publisher.COMMAND_GROUPS_CONFIG for n in cmds}\n"
-            "assert len(names) == 26, sorted(names)\n",
+            "assert len(names) == 28, sorted(names)\n",
         ],
         capture_output=True,
         check=False,


### PR DESCRIPTION
## Summary
- Every `rrt` subcommand required hand-syncing 3-5 places across `cli.py` and `docs/publisher.py`: an import block, the `COMMAND_REGISTRARS` tuple, the `READ_COMMANDS`/`WRITE_COMMANDS`/`DANGER_COMMANDS` help-styling sets, the `COMMAND_GROUPS` help grouping (already silently drifted — `mcp`/`project` were missing), and a hand-duplicated `COMMAND_GROUPS_CONFIG` used for doc generation.
- Each of the 28 command modules now self-registers a `CommandSpec` (name, category, group) via `@register_command` on its own existing `register()` function, in a new `commands/_registry.py`. `cli.py` and `docs/publisher.py` both read the resulting registry instead of maintaining their own copies.
- Bonus: registering a duplicate command name now raises `ValueError` at import time, and a name/`add_parser()` mismatch raises `RuntimeError` at registration time, instead of silently drifting.

Closes #206.

## Test plan
- [x] `uv run pytest -q -m "not runtime"` — 3311 passed, 100% coverage
- [x] `uv run ty check` — clean
- [x] `uvx pre-commit run --all-files` — clean
- [x] `rrt --help` / `rrt mcp --help` / `rrt project --help` manually verified — grouped epilog and command styling unchanged, `mcp`/`project` now correctly rendered
- [x] `uv run poe docs-generate` — regenerated the 5 command-group reference pages; diff is limited to command ordering within groups (documented cosmetic side effect of switching the single ordering source from two independently hand-curated lists to one registry-derived order)

🤖 Generated with [Claude Code](https://claude.com/claude-code)