### PR TITLE
chore: Update CLAUDE PR template for clarity

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/agent.md
+++ b/.github/PULL_REQUEST_TEMPLATE/agent.md
@@ -37,7 +37,7 @@ AGENT: fill the three fields above first — every other section below depends o
 
 ## Traceability
 
-- Related issue/task: <!-- AGENT: search the branch name and commit subjects for `#<number>`; if none is found, write N/A — do not invent one -->
+- Related issue/task: <!-- AGENT: search the branch name and commit subjects for `#<number>`; if none is found, write N/A — do not invent one. If this PR fixes that issue, use a GitHub closing keyword (e.g. `Fixes #123`) so it auto-closes on merge. -->
 - Modules touched: <!-- AGENT: paste the file list from `git diff --stat "$BASE"...HEAD` verbatim -->
 
 ## Breaking changes

--- a/.github/PULL_REQUEST_TEMPLATE/claude-agent.md
+++ b/.github/PULL_REQUEST_TEMPLATE/claude-agent.md
@@ -34,7 +34,7 @@ CLAUDE: fill the three fields above first — every other section below depends 
 
 ## Traceability
 
-- Related issue/task: <!-- CLAUDE: search the branch name and commit subjects for `#<number>`; N/A if none — don't invent one -->
+- Related issue/task: <!-- CLAUDE: search the branch name and commit subjects for `#<number>`; N/A if none — don't invent one. If this PR fixes that issue, use a GitHub closing keyword (e.g. `Fixes #123`) so it auto-closes on merge. -->
 - Modules touched: <!-- CLAUDE: paste the file list from `git diff --stat "$BASE"...HEAD` verbatim -->
 
 ## Breaking changes
@@ -51,14 +51,13 @@ CLAUDE: fill the three fields above first — every other section below depends 
      (.claude/hooks/coverage_non_regression.py) allows a small margin during iteration so it
      doesn't false-block on stale/partial state — that leniency is NOT proof of anything.
      `git push` (check_push_coverage.py) and CI always re-verify fresh at a hard 100%. Verify
-     against that number, not against the Stop hook having stayed quiet. If possible, mention the fixed issue(s) via GitHub notation (e.g. Fixes #123). -->
+     against that number, not against the Stop hook having stayed quiet. -->
 
 - [ ] `uv run pytest -q -m "not runtime"` passes with no `Missing:` lines (`--cov-fail-under=100` in `pyproject.toml`)
 - [ ] Changelog: per `SECTION_MAP`, `feat/fix/refactor/perf/docs` need a `[Unreleased]` bullet; `chore/ci/build/test/deps` are exempt — confirm with `git diff "$BASE"...HEAD -- CHANGELOG.md`, or N/A
 - [ ] `rrt-hooks check-branch-name --branch "$(git branch --show-current)"` exits 0, and `rrt-hooks check-commit-subject --subject "<subject>"` exits 0 for each commit subject above
 - [ ] Every mutating `rrt` command run for this change was previewed with `--dry-run` first — list them, or N/A
 - [ ] `rrt docs map --check` exits 0 — or N/A if no `[tool.rrt.docs.map]`-managed directory was touched
-- [ ] Fixes:
 
 ## Follow-ups (out of scope, not fixed here)
 

--- a/.github/PULL_REQUEST_TEMPLATE/claude-agent.md
+++ b/.github/PULL_REQUEST_TEMPLATE/claude-agent.md
@@ -51,13 +51,15 @@ CLAUDE: fill the three fields above first — every other section below depends 
      (.claude/hooks/coverage_non_regression.py) allows a small margin during iteration so it
      doesn't false-block on stale/partial state — that leniency is NOT proof of anything.
      `git push` (check_push_coverage.py) and CI always re-verify fresh at a hard 100%. Verify
-     against that number, not against the Stop hook having stayed quiet. -->
+     against that number, not against the Stop hook having stayed quiet. If possible, mentioned
+     the fixed issue or issues via GitHub notation -->
 
 - [ ] `uv run pytest -q -m "not runtime"` passes with no `Missing:` lines (`--cov-fail-under=100` in `pyproject.toml`)
 - [ ] Changelog: per `SECTION_MAP`, `feat/fix/refactor/perf/docs` need a `[Unreleased]` bullet; `chore/ci/build/test/deps` are exempt — confirm with `git diff "$BASE"...HEAD -- CHANGELOG.md`, or N/A
 - [ ] `rrt-hooks check-branch-name --branch "$(git branch --show-current)"` exits 0, and `rrt-hooks check-commit-subject --subject "<subject>"` exits 0 for each commit subject above
 - [ ] Every mutating `rrt` command run for this change was previewed with `--dry-run` first — list them, or N/A
 - [ ] `rrt docs map --check` exits 0 — or N/A if no `[tool.rrt.docs.map]`-managed directory was touched
+- [ ] Fixes:
 
 ## Follow-ups (out of scope, not fixed here)
 

--- a/.github/PULL_REQUEST_TEMPLATE/claude-agent.md
+++ b/.github/PULL_REQUEST_TEMPLATE/claude-agent.md
@@ -51,8 +51,7 @@ CLAUDE: fill the three fields above first — every other section below depends 
      (.claude/hooks/coverage_non_regression.py) allows a small margin during iteration so it
      doesn't false-block on stale/partial state — that leniency is NOT proof of anything.
      `git push` (check_push_coverage.py) and CI always re-verify fresh at a hard 100%. Verify
-     against that number, not against the Stop hook having stayed quiet. If possible, mentioned
-     the fixed issue or issues via GitHub notation -->
+     against that number, not against the Stop hook having stayed quiet. If possible, mention the fixed issue(s) via GitHub notation (e.g. Fixes #123). -->
 
 - [ ] `uv run pytest -q -m "not runtime"` passes with no `Missing:` lines (`--cov-fail-under=100` in `pyproject.toml`)
 - [ ] Changelog: per `SECTION_MAP`, `feat/fix/refactor/perf/docs` need a `[Unreleased]` bullet; `chore/ci/build/test/deps` are exempt — confirm with `git diff "$BASE"...HEAD -- CHANGELOG.md`, or N/A

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 
 <!-- What changed, and why. -->
 
-Related issue/task: <!-- #123, or N/A -->
+Related issue/task: <!-- #123, or N/A. If this PR fixes that issue, use a closing keyword (e.g. "Fixes #123") so it auto-closes on merge. -->
 
 ## Checklist
 


### PR DESCRIPTION
Clarified instructions regarding issue mentions and updated checklist item.

## Summary

<!-- What changed, and why. -->

## Checklist

- [ ] Tests pass (`uv run pytest -q -m "not runtime"`) and coverage stayed at 100%
- [ ] Changelog `[Unreleased]` entry added — or N/A (chore/ci/build/test/deps-only change)
- [ ] Branch and commit(s) follow this repo's `<type>/<kebab-slug>` + Conventional Commits convention

<!-- Agent-authored PR? Pick one of these via ?template=<file> on this PR's URL, or the
     "Choose a template" link above the description box:
       claude-agent.md — Claude Code
       agent.md        — Copilot, Codex, Gemini, or any other agent -->
